### PR TITLE
pass type not instance to `is_time_variant_term`

### DIFF
--- a/src/static_injector_models/electric_loads.jl
+++ b/src/static_injector_models/electric_loads.jl
@@ -236,7 +236,7 @@ is_time_variant_term(
     ::OptimizationContainer,
     ::PSY.LoadCost,
     ::OnVariable,
-    ::PSY.ControllableLoad,
+    ::Type{<:PSY.ControllableLoad},
     ::AbstractLoadFormulation,
     ::Int,
 ) = false
@@ -245,7 +245,7 @@ is_time_variant_term(
     ::OptimizationContainer,
     cost::PSY.MarketBidCost,
     ::OnVariable,
-    ::PSY.ControllableLoad,
+    ::Type{<:PSY.ControllableLoad},
     ::PowerLoadInterruption,
     ::Int,
 ) =

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -2291,7 +2291,7 @@ function add_proportional_cost!(
         for t in get_time_steps(container)
             cost_term = proportional_cost(container, op_cost_data, U(), d, V(), t)
             add_as_time_variant =
-                is_time_variant_term(container, op_cost_data, U(), d, V(), t)
+                is_time_variant_term(container, op_cost_data, U(), T, V(), t)
             iszero(cost_term) && continue
             cost_term *= multiplier
             exp = if d isa PSY.HydroPumpTurbine && PSY.get_must_run(d)

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -2323,7 +2323,7 @@ is_time_variant_term(
     ::OptimizationContainer,
     cost::PSY.MarketBidCost,
     ::OnVariable,
-    ::PSY.HydroGen,
+    ::Type{<:PSY.HydroGen},
     ::AbstractHydroUnitCommitment,
     t::Int,
 ) =

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -94,7 +94,7 @@ initial_condition_variable(::InitialTimeDurationOff, d::PSY.ThermalGen, ::Abstra
 function proportional_cost(container::OptimizationContainer, cost::PSY.ThermalGenerationCost, S::OnVariable, T::PSY.ThermalGen, U::AbstractThermalFormulation, t::Int)
     return onvar_cost(container, cost, S, T, U, t) + PSY.get_constant_term(PSY.get_vom_cost(PSY.get_variable(cost))) + PSY.get_fixed(cost)
 end
-is_time_variant_term(::OptimizationContainer, ::PSY.ThermalGenerationCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation, t::Int) = false
+is_time_variant_term(::OptimizationContainer, ::PSY.ThermalGenerationCost, ::OnVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation, t::Int) = false
 
 function proportional_cost(container::OptimizationContainer, cost::PSY.MarketBidCost, ::OnVariable, comp::T, ::AbstractThermalFormulation, t::Int) where {T <: PSY.ThermalGen}
     if is_time_variant(PSY.get_incremental_initial_input(cost))
@@ -108,7 +108,7 @@ function proportional_cost(container::OptimizationContainer, cost::PSY.MarketBid
         return PSY.get_initial_input(PSY.get_incremental_offer_curves(PSY.get_operation_cost(comp)))
     end
 end
-is_time_variant_term(::OptimizationContainer, cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation, t::Int) =
+is_time_variant_term(::OptimizationContainer, cost::PSY.MarketBidCost, ::OnVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation, t::Int) =
     is_time_variant(PSY.get_incremental_initial_input(cost))
 
 proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{RateofChangeConstraintSlackUp, RateofChangeConstraintSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST


### PR DESCRIPTION
At some point IOM's `is_time_variant_term` was changed to take component types ([here](https://github.com/NREL-Sienna/InfrastructureOptimizationModels.jl/blob/main/src/common_models/interfaces.jl#L138)). Update POM accordingly.