### PR TITLE
Update POM to IOM type-dispatch API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,9 +26,6 @@ PowerFlows = "94fada2c-0ca5-4b90-a1fb-4bc5b59ccfc7"
 [extensions]
 PowerFlowsExt = "PowerFlows"
 
-[sources]
-InfrastructureSystems = {url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl", rev = "IS4"}
-
 [compat]
 Dates = "1"
 DocStringExtensions = "~0.8, ~0.9"

--- a/src/ac_transmission_models/AC_branches.jl
+++ b/src/ac_transmission_models/AC_branches.jl
@@ -72,10 +72,11 @@ function add_variables!(
     ::Type{T},
     network_model::NetworkModel{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractBranchFormulation,
+    ::Type{F},
 ) where {
     T <: AbstractACActivePowerFlow,
-    U <: PSY.ACTransmission}
+    U <: PSY.ACTransmission,
+    F <: AbstractBranchFormulation}
     time_steps = get_time_steps(container)
     net_reduction_data = network_model.network_reduction
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
@@ -102,8 +103,8 @@ function add_variables!(
         if has_entry
             @assert !isempty(tracker_container) name arc reduction
         end
-        ub = get_variable_upper_bound(T, reduction_entry, typeof(formulation))
-        lb = get_variable_lower_bound(T, reduction_entry, typeof(formulation))
+        ub = get_variable_upper_bound(T, reduction_entry, F)
+        lb = get_variable_lower_bound(T, reduction_entry, F)
         for t in time_steps
             if !has_entry
                 tracker_container[t] = JuMP.@variable(
@@ -124,7 +125,7 @@ function add_variables!(
     ::Type{T},
     network_model::NetworkModel{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::StaticBranchUnbounded,
+    ::Type{StaticBranchUnbounded},
 ) where {
     T <: AbstractACActivePowerFlow,
     U <: PSY.ACTransmission}
@@ -178,7 +179,7 @@ function add_variables!(
     ::Type{S},
     network_model::NetworkModel{CopperPlatePowerModel},
     devices::IS.FlattenIteratorWrapper{T},
-    formulation::U,
+    ::Type{U},
 ) where {
     S <: AbstractACActivePowerFlow,
     T <: PSY.ACTransmission,

--- a/src/ac_transmission_models/AC_branches.jl
+++ b/src/ac_transmission_models/AC_branches.jl
@@ -18,36 +18,36 @@
 # for the branch flows either in AC or DC.
 
 #! format: off
-get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
-get_variable_binary(::PhaseShifterAngle, ::Type{PSY.PhaseShiftingTransformer}, ::AbstractBranchFormulation,) = false
+get_variable_binary(::Type{FlowActivePowerVariable}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_binary(::Type{PhaseShifterAngle}, ::Type{PSY.PhaseShiftingTransformer}, ::Type{<:AbstractBranchFormulation}) = false
 
-get_parameter_multiplier(::FixValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::LowerBoundValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::UpperBoundValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
+get_parameter_multiplier(::Type{FixValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{LowerBoundValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{UpperBoundValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
 
 # Per-device reactance multiplier (1/get_x(d)) computed inline at add_to_expression! call sites.
-get_variable_multiplier(::PhaseShifterAngle, ::Type{<:PSY.PhaseShiftingTransformer}, ::PhaseAngleControl) = 1.0
+get_variable_multiplier(::Type{PhaseShifterAngle}, ::Type{<:PSY.PhaseShiftingTransformer}, ::Type{PhaseAngleControl}) = 1.0
 
-get_multiplier_value(::AbstractDynamicBranchRatingTimeSeriesParameter, d::PSY.ACTransmission, ::StaticBranch) = PSY.get_rating(d)
-get_multiplier_value(::AbstractDynamicBranchRatingTimeSeriesParameter, d::PNM.BranchesParallel, ::StaticBranch) = PNM.get_equivalent_rating(d)
+get_multiplier_value(::Type{<:AbstractDynamicBranchRatingTimeSeriesParameter}, d::PSY.ACTransmission, ::Type{StaticBranch}) = PSY.get_rating(d)
+get_multiplier_value(::Type{<:AbstractDynamicBranchRatingTimeSeriesParameter}, d::PNM.BranchesParallel, ::Type{StaticBranch}) = PNM.get_equivalent_rating(d)
 
 
 get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, U}) where {T <: PSY.ACTransmission, U <: AbstractBranchFormulation} = DeviceModel(T, U)
 
 #### Properties of slack variables
-get_variable_binary(::FlowActivePowerSlackUpperBound, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
-get_variable_binary(::FlowActivePowerSlackLowerBound, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
+get_variable_binary(::Type{FlowActivePowerSlackUpperBound}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_binary(::Type{FlowActivePowerSlackLowerBound}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
 # These two methods are defined to avoid ambiguities
-get_variable_upper_bound(::FlowActivePowerSlackUpperBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerSlackUpperBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 0.0
-get_variable_upper_bound(::FlowActivePowerSlackLowerBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerSlackLowerBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 0.0
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.BranchesSeries, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.BranchesSeries, ::AbstractBranchFormulation) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.BranchesParallel, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.BranchesParallel, ::AbstractBranchFormulation) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.ThreeWindingTransformerWinding, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.ThreeWindingTransformerWinding, ::AbstractBranchFormulation) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerSlackUpperBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerSlackUpperBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 0.0
+get_variable_upper_bound(::Type{FlowActivePowerSlackLowerBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerSlackLowerBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 0.0
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesSeries, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesSeries, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesParallel, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesParallel, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.ThreeWindingTransformerWinding, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.ThreeWindingTransformerWinding, ::Type{<:AbstractBranchFormulation}) = nothing
 
 #! format: on
 function get_default_time_series_names(
@@ -84,7 +84,7 @@ function add_variables!(
 
     variable_container = add_variable_container!(
         container,
-        T(),
+        T,
         U,
         branch_names,
         time_steps,
@@ -102,8 +102,8 @@ function add_variables!(
         if has_entry
             @assert !isempty(tracker_container) name arc reduction
         end
-        ub = get_variable_upper_bound(T(), reduction_entry, formulation)
-        lb = get_variable_lower_bound(T(), reduction_entry, formulation)
+        ub = get_variable_upper_bound(T, reduction_entry, typeof(formulation))
+        lb = get_variable_lower_bound(T, reduction_entry, typeof(formulation))
         for t in time_steps
             if !has_entry
                 tracker_container[t] = JuMP.@variable(
@@ -193,7 +193,7 @@ function _get_flow_variable_vector(
     ::NetworkModel{<:AbstractDCPModel},
     ::Type{B},
 ) where {B <: PSY.ACTransmission}
-    return [get_variable(container, FlowActivePowerVariable(), B)]
+    return [get_variable(container, FlowActivePowerVariable, B)]
 end
 
 function _get_flow_variable_vector(
@@ -202,8 +202,8 @@ function _get_flow_variable_vector(
     ::Type{B},
 ) where {B <: PSY.ACTransmission}
     return [
-        get_variable(container, FlowActivePowerFromToVariable(), B),
-        get_variable(container, FlowActivePowerToFromVariable(), B),
+        get_variable(container, FlowActivePowerFromToVariable, B),
+        get_variable(container, FlowActivePowerToFromVariable, B),
     ]
 end
 
@@ -375,8 +375,8 @@ function _add_flow_rate_constraint!(
     reduction_entry = branch_maps_by_type[arc]
     time_steps = get_time_steps(container)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)[name, :]
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)[name, :]
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)[name, :]
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)[name, :]
     end
     limits = get_min_max_limits(reduction_entry, FlowRateConstraint, StaticBranch)
     for t in time_steps
@@ -422,7 +422,7 @@ function add_constraints!(
     con_lb =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
@@ -431,19 +431,19 @@ function add_constraints!(
     con_ub =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
             meta = "ub",
         )
 
-    array = get_variable(container, FlowActivePowerVariable(), T)
+    array = get_variable(container, FlowActivePowerVariable, T)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraint][T]
@@ -487,7 +487,7 @@ function add_constraints!(
     con_lb =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
@@ -496,19 +496,19 @@ function add_constraints!(
     con_ub =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
             meta = "ub",
         )
 
-    array = get_expression(container, PTDFBranchFlow(), T)
+    array = get_expression(container, PTDFBranchFlow, T)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraint][T]
@@ -541,11 +541,11 @@ function _add_flow_rate_constraint_with_parameters!(
 ) where {T <: PSY.ACTransmission}
     time_steps = get_time_steps(container)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)[name, :]
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)[name, :]
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)[name, :]
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)[name, :]
     end
     param_container =
-        get_parameter(container, DynamicBranchRatingTimeSeriesParameter(), T)
+        get_parameter(container, DynamicBranchRatingTimeSeriesParameter, T)
     param = get_parameter_column_refs(param_container, name)
     mult = get_multiplier_array(param_container)[name, :]
 
@@ -593,7 +593,7 @@ function add_flow_rate_constraint_with_parameters!(
     con_lb =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
@@ -602,14 +602,14 @@ function add_flow_rate_constraint_with_parameters!(
     con_ub =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
             meta = "ub",
         )
 
-    var_array = get_expression(container, PTDFBranchFlow(), T)
+    var_array = get_expression(container, PTDFBranchFlow, T)
 
     ts_name = get_time_series_names(device_model)[DynamicBranchRatingTimeSeriesParameter]
     ts_type = get_default_time_series_type(container)
@@ -670,20 +670,20 @@ function add_constraints!(
         cons_type,
     )
     time_steps = get_time_steps(container)
-    var1 = get_variable(container, FlowActivePowerFromToVariable(), B)
-    var2 = get_variable(container, FlowReactivePowerFromToVariable(), B)
+    var1 = get_variable(container, FlowActivePowerFromToVariable, B)
+    var2 = get_variable(container, FlowReactivePowerFromToVariable, B)
     add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         B,
         device_names,
         time_steps,
     )
-    constraint = get_constraint(container, cons_type(), B)
+    constraint = get_constraint(container, cons_type, B)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), B)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, B)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraintFromTo][B]
@@ -722,19 +722,19 @@ function add_constraints!(
         devices,
         cons_type,
     )
-    var1 = get_variable(container, FlowActivePowerToFromVariable(), B)
-    var2 = get_variable(container, FlowReactivePowerToFromVariable(), B)
+    var1 = get_variable(container, FlowActivePowerToFromVariable, B)
+    var2 = get_variable(container, FlowReactivePowerToFromVariable, B)
     add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         B,
         device_names,
         time_steps,
     )
-    constraint = get_constraint(container, cons_type(), B)
+    constraint = get_constraint(container, cons_type, B)
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), B)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, B)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraintToFrom][B]
@@ -862,14 +862,11 @@ function add_expressions!(
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
     # Needs to be a vector to use multi-threading
     name_to_arc_map = collect(PNM.get_name_to_arc_map(net_reduction_data, B))
-    nodal_balance_expressions = get_expression(
-        container,
-        ActivePowerBalance(),
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance,
         PSY.ACBus,
     )
 
-    branch_flow_expr = add_expression_container!(container,
-        PTDFBranchFlow(),
+    branch_flow_expr = add_expression_container!(container, PTDFBranchFlow,
         B,
         branch_names,
         time_steps,
@@ -925,8 +922,8 @@ function add_constraints!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.ACTransmission}
     time_steps = get_time_steps(container)
-    branch_flow_expr = get_expression(container, PTDFBranchFlow(), T)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
+    branch_flow_expr = get_expression(container, PTDFBranchFlow, T)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
     net_reduction_data = network_model.network_reduction
     reduced_branch_tracker = get_reduced_branch_tracker(network_model)
     branches = get_branch_argument_constraint_axis(
@@ -935,9 +932,7 @@ function add_constraints!(
         devices,
         cons_type,
     )
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         branches,
         time_steps,
@@ -946,8 +941,8 @@ function add_constraints!(
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
 
     for name in branches
@@ -988,16 +983,14 @@ function add_constraints!(
     ptdf = get_PTDF_matrix(network_model)
     branches = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         branches,
         time_steps,
     )
-    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), PSY.ACBus)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
-    angle_variables = get_variable(container, PhaseShifterAngle(), T)
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance, PSY.ACBus)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
+    angle_variables = get_variable(container, PhaseShifterAngle, T)
     jump_model = get_jump_model(container)
     for br in devices
         arc = PNM.get_arc_tuple(br)
@@ -1169,13 +1162,11 @@ function add_constraints!(
     ::NetworkModel{DCPPowerModel},
 ) where {T <: PSY.PhaseShiftingTransformer}
     time_steps = get_time_steps(container)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
-    ps_angle_variables = get_variable(container, PhaseShifterAngle(), T)
-    bus_angle_variables = get_variable(container, VoltageAngle(), PSY.ACBus)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
+    ps_angle_variables = get_variable(container, PhaseShifterAngle, T)
+    bus_angle_variables = get_variable(container, VoltageAngle, PSY.ACBus)
     jump_model = get_jump_model(container)
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         axes(flow_variables)[1],
         time_steps,
@@ -1209,7 +1200,7 @@ function add_to_objective_function!(
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ACTransmission}
     if get_use_slacks(device_model)
-        variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
+        variable_up = get_variable(container, FlowActivePowerSlackUpperBound, T)
         # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)
@@ -1230,8 +1221,8 @@ function add_to_objective_function!(
     ::Type{<:AbstractActivePowerModel},
 ) where {T <: PSY.ACTransmission}
     if get_use_slacks(device_model)
-        variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        variable_dn = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        variable_up = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        variable_dn = get_variable(container, FlowActivePowerSlackLowerBound, T)
         # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)

--- a/src/ac_transmission_models/branch_constructor.jl
+++ b/src/ac_transmission_models/branch_constructor.jl
@@ -90,13 +90,13 @@ function construct_device!(
             container,
             FlowActivePowerSlackUpperBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
     add_feedforward_arguments!(container, device_model, devices)
@@ -136,14 +136,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
 
@@ -292,7 +292,7 @@ function construct_device!(
         FlowActivePowerVariable,
         network_model,
         devices,
-        StaticBranchBounds(),
+        StaticBranchBounds,
     )
 
     if get_use_slacks(device_model)
@@ -301,14 +301,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
 
@@ -391,7 +391,7 @@ function construct_device!(
             container,
             FlowActivePowerSlackUpperBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
     add_feedforward_arguments!(container, device_model, devices)
@@ -501,7 +501,7 @@ function construct_device!(
             FlowActivePowerVariable,
             network_model,
             devices,
-            HVDCTwoTerminalLossless(),
+            HVDCTwoTerminalLossless,
         )
         add_to_expression!(
             container,
@@ -572,7 +572,7 @@ function construct_device!(
     network_model::NetworkModel{CopperPlatePowerModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -675,7 +675,7 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -737,7 +737,7 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalLossless())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalLossless)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -779,16 +779,16 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch())
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch)
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -857,16 +857,16 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
-    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
+    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -930,13 +930,13 @@ function construct_device!(
         container,
         HVDCActivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalPiecewiseLoss(),
+        HVDCTwoTerminalPiecewiseLoss,
     )
     add_variables!(
         container,
         HVDCActivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalPiecewiseLoss(),
+        HVDCTwoTerminalPiecewiseLoss,
     )
     _add_sparse_pwl_loss_variables!(container, devices, device_model)
     add_to_expression!(
@@ -1010,15 +1010,15 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1100,103 +1100,103 @@ function construct_device!(
         container,
         HVDCActivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCActivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCReactivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCReactivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierDelayAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterExtinctionAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierPowerFactorAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterPowerFactorAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierOverlapAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterOverlapAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierDCVoltageVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterDCVoltageVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierACCurrentVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterACCurrentVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         DCLineCurrentFlowVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierTapSettingVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterTapSettingVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
 
     # Expressions
@@ -1335,8 +1335,8 @@ function construct_device!(
     network_model::NetworkModel{DCPPowerModel},
 )
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl())
-    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl())
+    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl)
+    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1357,8 +1357,8 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 )
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl())
-    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl())
+    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl)
+    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1458,14 +1458,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            T(),
+            T,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            T(),
+            T,
         )
     end
     if any(has_ts) && !all(has_ts)
@@ -1478,7 +1478,7 @@ function construct_device!(
         FlowActivePowerVariable,
         network_model,
         devices,
-        T(),
+        T,
     )
     add_to_expression!(
         container,

--- a/src/area_interchange.jl
+++ b/src/area_interchange.jl
@@ -1,10 +1,10 @@
 #! format: off
-get_multiplier_value(::FromToFlowLimitParameter, d::PSY.AreaInterchange, ::AbstractBranchFormulation) = -1.0 * PSY.get_from_to_flow_limit(d)
-get_multiplier_value(::ToFromFlowLimitParameter, d::PSY.AreaInterchange, ::AbstractBranchFormulation) = PSY.get_to_from_flow_limit(d)
+get_multiplier_value(::Type{FromToFlowLimitParameter}, d::PSY.AreaInterchange, ::Type{<:AbstractBranchFormulation}) = -1.0 * PSY.get_from_to_flow_limit(d)
+get_multiplier_value(::Type{ToFromFlowLimitParameter}, d::PSY.AreaInterchange, ::Type{<:AbstractBranchFormulation}) = PSY.get_to_from_flow_limit(d)
 
-get_parameter_multiplier(::FixValueParameter, ::PSY.AreaInterchange, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::LowerBoundValueParameter, ::PSY.AreaInterchange, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::UpperBoundValueParameter, ::PSY.AreaInterchange, ::AbstractBranchFormulation) = 1.0
+get_parameter_multiplier(::Type{FixValueParameter}, ::PSY.AreaInterchange, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{LowerBoundValueParameter}, ::PSY.AreaInterchange, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{UpperBoundValueParameter}, ::PSY.AreaInterchange, ::Type{<:AbstractBranchFormulation}) = 1.0
 
 get_initial_conditions_device_model(
     ::OperationModel,
@@ -39,9 +39,7 @@ function add_variables!(
 ) where {T <: AbstractPowerModel}
     time_steps = get_time_steps(container)
 
-    variable = add_variable_container!(
-        container,
-        FlowActivePowerVariable(),
+    variable = add_variable_container!(container, FlowActivePowerVariable,
         PSY.AreaInterchange,
         PSY.get_name.(devices),
         time_steps,
@@ -83,25 +81,21 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     device_names = PSY.get_name.(devices)
 
-    con_ub = add_constraints_container!(
-        container,
-        FlowLimitConstraint(),
+    con_ub = add_constraints_container!(container, FlowLimitConstraint,
         PSY.AreaInterchange,
         device_names,
         time_steps;
         meta = "ub",
     )
 
-    con_lb = add_constraints_container!(
-        container,
-        FlowLimitConstraint(),
+    con_lb = add_constraints_container!(container, FlowLimitConstraint,
         PSY.AreaInterchange,
         device_names,
         time_steps;
         meta = "lb",
     )
 
-    var_array = get_variable(container, FlowActivePowerVariable(), PSY.AreaInterchange)
+    var_array = get_variable(container, FlowActivePowerVariable, PSY.AreaInterchange)
     if !all(PSY.has_time_series.(devices))
         for device in devices
             ci_name = PSY.get_name(device)
@@ -122,19 +116,17 @@ function add_constraints!(
         end
     else
         param_container_from_to =
-            get_parameter(container, FromToFlowLimitParameter(), PSY.AreaInterchange)
-        param_multiplier_from_to = get_parameter_multiplier_array(
-            container,
-            FromToFlowLimitParameter(),
-            PSY.AreaInterchange,
-        )
+            get_parameter(container, FromToFlowLimitParameter, PSY.AreaInterchange)
+        param_multiplier_from_to =
+            get_parameter_multiplier_array(container, FromToFlowLimitParameter,
+                PSY.AreaInterchange,
+            )
         param_container_to_from =
-            get_parameter(container, ToFromFlowLimitParameter(), PSY.AreaInterchange)
-        param_multiplier_to_from = get_parameter_multiplier_array(
-            container,
-            ToFromFlowLimitParameter(),
-            PSY.AreaInterchange,
-        )
+            get_parameter(container, ToFromFlowLimitParameter, PSY.AreaInterchange)
+        param_multiplier_to_from =
+            get_parameter_multiplier_array(container, ToFromFlowLimitParameter,
+                PSY.AreaInterchange,
+            )
         jump_model = get_jump_model(container)
         for device in devices
             name = PSY.get_name(device)
@@ -173,25 +165,21 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     device_names = PSY.get_name.(devices)
 
-    con_ub = add_constraints_container!(
-        container,
-        LineFlowBoundConstraint(),
+    con_ub = add_constraints_container!(container, LineFlowBoundConstraint,
         PSY.AreaInterchange,
         device_names,
         time_steps;
         meta = "ub",
     )
 
-    con_lb = add_constraints_container!(
-        container,
-        LineFlowBoundConstraint(),
+    con_lb = add_constraints_container!(container, LineFlowBoundConstraint,
         PSY.AreaInterchange,
         device_names,
         time_steps;
         meta = "lb",
     )
 
-    area_ex_var = get_variable(container, FlowActivePowerVariable(), PSY.AreaInterchange)
+    area_ex_var = get_variable(container, FlowActivePowerVariable, PSY.AreaInterchange)
     jm = get_jump_model(container)
     for area_interchange in devices
         inter_change_name = PSY.get_name(area_interchange)
@@ -220,7 +208,7 @@ function add_constraints!(
             sum_of_flows = JuMP.AffExpr()
             for (mult, inter_area_branches) in direction_branch_map
                 for (type, names) in inter_area_branches
-                    flow_expr = get_expression(container, PTDFBranchFlow(), type)
+                    flow_expr = get_expression(container, PTDFBranchFlow, type)
                     for name in names
                         JuMP.add_to_expression!(sum_of_flows, flow_expr[name, t], mult)
                     end

--- a/src/area_interchange.jl
+++ b/src/area_interchange.jl
@@ -35,7 +35,7 @@ function add_variables!(
     ::Type{FlowActivePowerVariable},
     model::NetworkModel{T},
     devices::IS.FlattenIteratorWrapper{PSY.AreaInterchange},
-    formulation::AbstractBranchFormulation,
+    ::Type{<:AbstractBranchFormulation},
 ) where {T <: AbstractPowerModel}
     time_steps = get_time_steps(container)
 
@@ -60,7 +60,7 @@ function add_variables!(
     ::Type{FlowActivePowerVariable},
     model::NetworkModel{CopperPlatePowerModel},
     devices::IS.FlattenIteratorWrapper{PSY.AreaInterchange},
-    formulation::AbstractBranchFormulation,
+    ::Type{<:AbstractBranchFormulation},
 )
     @warn(
         "CopperPlatePowerModel ignores AreaInterchanges. Instead use AreaBalancePowerModel."

--- a/src/common_models/add_expressions.jl
+++ b/src/common_models/add_expressions.jl
@@ -40,7 +40,7 @@ function add_expressions!(
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    add_expression_container!(container, T(), D, names, time_steps)
+    add_expression_container!(container, T, D, names, time_steps)
     return
 end
 
@@ -74,9 +74,7 @@ function add_expressions!(
 
     if !isempty(names)
         expr_type = found_quad_fuel_functions ? JuMP.QuadExpr : GAE
-        add_expression_container!(
-            container,
-            T(),
+        add_expression_container!(container, T,
             D,
             names,
             time_steps;
@@ -102,9 +100,7 @@ function add_expressions!(
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)
     @assert length(devices) == 1
-    add_expression_container!(
-        container,
-        T(),
+    add_expression_container!(container, T,
         D,
         PSY.get_name.(devices),
         time_steps;

--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -511,7 +511,7 @@ function _add_parameters!(
 
     IOM.set_subsystem!(IOM.get_attributes(parameter_container), IOM.get_subsystem(model))
     jump_model = get_jump_model(container)
-    ts_vector = IOM.get_time_series(container, service, T(), name)
+    ts_vector = IOM.get_time_series(container, service, T, name)
     multiplier = get_multiplier_value(T, service, V)
     for t in time_steps
         IOM.set_multiplier!(parameter_container, multiplier, name, t)

--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -104,7 +104,7 @@ function _check_dynamic_branch_rating_ts(
         end
     end
 
-    multiplier = get_multiplier_value(T(), device, W())
+    multiplier = get_multiplier_value(T, device, W)
     if !all(x -> x >= rating, multiplier * ts)
         @warn "There are values of Parameter $T associated with $(typeof(device)) '$(PSY.get_name(device))' lower than the device static rating $(rating)."
     end
@@ -164,7 +164,7 @@ function _add_time_series_parameters!(
         calc_additional_axes(container, param, devices_with_time_series, model)
     param_container = add_param_container!(
         container,
-        param,
+        T,
         D,
         ts_type,
         ts_name,
@@ -187,7 +187,7 @@ function _add_time_series_parameters!(
     end
 
     for device in devices_with_time_series
-        multiplier = get_multiplier_value(T(), device, W())
+        multiplier = get_multiplier_value(T, device, W)
         device_name = PSY.get_name(device)
         for step in time_steps
             IOM.set_multiplier!(param_container, multiplier, device_name, step)
@@ -233,7 +233,7 @@ function _add_time_series_parameters!(
     additional_axes = ()
     param_container = add_param_container!(
         container,
-        param,
+        T,
         D,
         ts_type,
         ts_name,
@@ -273,7 +273,7 @@ function _add_time_series_parameters!(
                 _unwrap_for_param.(Ref(param_instance), raw_ts_vals, Ref(additional_axes))
             @assert all(_size_wrapper.(ts_vals) .== Ref(length.(additional_axes)))
         end
-        multiplier = get_multiplier_value(T(), reduction_entry, W())
+        multiplier = get_multiplier_value(T, reduction_entry, W)
         jump_model = get_jump_model(container)
         param_array = get_parameter_array(param_container)
         for t in time_steps
@@ -442,7 +442,7 @@ function _add_parameters!(
     additional_axes = calc_additional_axes(container, param, active_devices, model)
     param_container = add_param_container!(
         container,
-        param,
+        T,
         D,
         _param_to_vars(T(), W()),
         SOSStatusVariable.NO_VARIABLE,
@@ -469,7 +469,7 @@ function _add_parameters!(
             )
             IOM.set_multiplier!(
                 param_container,
-                get_multiplier_value(T(), device, W()),
+                get_multiplier_value(T, device, W),
                 device_name,
                 step,
             )
@@ -498,9 +498,7 @@ function _add_parameters!(
     ts_uuid = string(IS.get_time_series_uuid(ts_type, service, ts_name))
     @debug "adding" T U _group = IOM.LOG_GROUP_OPTIMIZATION_CONTAINER
     additional_axes = calc_additional_axes(container, T(), [service], model)
-    parameter_container = add_param_container!(
-        container,
-        T(),
+    parameter_container = add_param_container!(container, T,
         U,
         ts_type,
         ts_name,
@@ -514,7 +512,7 @@ function _add_parameters!(
     IOM.set_subsystem!(IOM.get_attributes(parameter_container), IOM.get_subsystem(model))
     jump_model = get_jump_model(container)
     ts_vector = IOM.get_time_series(container, service, T(), name)
-    multiplier = get_multiplier_value(T(), service, V())
+    multiplier = get_multiplier_value(T, service, V)
     for t in time_steps
         IOM.set_multiplier!(parameter_container, multiplier, name, t)
         IOM.set_parameter!(parameter_container, jump_model, ts_vector[t], ts_uuid, t)
@@ -542,19 +540,19 @@ function _add_parameters!(
     @debug "adding" T D U _group = IOM.LOG_GROUP_OPTIMIZATION_CONTAINER
     names = [PSY.get_name(device) for device in devices]
     time_steps = get_time_steps(container)
-    parameter_container = add_param_container!(container, T(), D, key, names, time_steps)
+    parameter_container = add_param_container!(container, T, D, key, names, time_steps)
     jump_model = get_jump_model(container)
     for d in devices
         name = PSY.get_name(d)
-        if get_variable_warm_start_value(U(), d, W()) === nothing
+        if get_variable_warm_start_value(U, d, W) === nothing
             inital_parameter_value = 0.0
         else
-            inital_parameter_value = get_variable_warm_start_value(U(), d, W())
+            inital_parameter_value = get_variable_warm_start_value(U, d, W)
         end
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), d, W()),
+                get_parameter_multiplier(T, d, W),
                 name,
                 t,
             )
@@ -589,22 +587,22 @@ function _add_parameters!(
     @debug "adding" T D U _group = IOM.LOG_GROUP_OPTIMIZATION_CONTAINER
     names = [PSY.get_name(device) for device in devices if !PSY.get_must_run(device)]
     time_steps = get_time_steps(container)
-    parameter_container = add_param_container!(container, T(), D, key, names, time_steps)
+    parameter_container = add_param_container!(container, T, D, key, names, time_steps)
     jump_model = get_jump_model(container)
     for d in devices
         if PSY.get_must_run(d)
             continue
         end
         name = PSY.get_name(d)
-        if get_variable_warm_start_value(U(), d, W()) === nothing
+        if get_variable_warm_start_value(U, d, W) === nothing
             inital_parameter_value = 0.0
         else
-            inital_parameter_value = get_variable_warm_start_value(U(), d, W())
+            inital_parameter_value = get_variable_warm_start_value(U, d, W)
         end
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), d, W()),
+                get_parameter_multiplier(T, d, W),
                 name,
                 t,
             )
@@ -640,19 +638,19 @@ function _add_parameters!(
     names = [PSY.get_name(device) for device in devices]
     time_steps = get_time_steps(container)
     parameter_container =
-        add_param_container!(container, T(), D, key, names, time_steps; meta = "$U")
+        add_param_container!(container, T, D, key, names, time_steps; meta = "$U")
     jump_model = get_jump_model(container)
     for d in devices
         name = PSY.get_name(d)
-        if get_variable_warm_start_value(U(), d, W()) === nothing
+        if get_variable_warm_start_value(U, d, W) === nothing
             inital_parameter_value = 0.0
         else
-            inital_parameter_value = get_variable_warm_start_value(U(), d, W())
+            inital_parameter_value = get_variable_warm_start_value(U, d, W)
         end
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), d, W()),
+                get_parameter_multiplier(T, d, W),
                 name,
                 t,
             )
@@ -687,9 +685,7 @@ function _add_parameters!(
     @debug "adding" T D U _group = IOM.LOG_GROUP_OPTIMIZATION_CONTAINER
     names = [PSY.get_name(device) for device in devices]
     time_steps = get_time_steps(container)
-    parameter_container = add_param_container!(
-        container,
-        T(),
+    parameter_container = add_param_container!(container, T,
         D,
         key,
         names,
@@ -702,14 +698,14 @@ function _add_parameters!(
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), d, W()),
+                get_parameter_multiplier(T, d, W),
                 name,
                 t,
             )
             IOM.set_parameter!(
                 parameter_container,
                 jump_model,
-                get_initial_parameter_value(T(), d, W()),
+                get_initial_parameter_value(T, d, W),
                 name,
                 t,
             )
@@ -739,9 +735,7 @@ function _add_parameters!(
     !isempty(IOM.get_feedforwards(model)) && return
     names = [PSY.get_name(device) for device in devices]
     time_steps = get_time_steps(container)
-    parameter_container = add_param_container!(
-        container,
-        T(),
+    parameter_container = add_param_container!(container, T,
         D,
         VariableKey(OnVariable, D),
         names,
@@ -754,14 +748,14 @@ function _add_parameters!(
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), d, W()),
+                get_parameter_multiplier(T, d, W),
                 name,
                 t,
             )
             IOM.set_parameter!(
                 parameter_container,
                 jump_model,
-                get_initial_parameter_value(T(), d, W()),
+                get_initial_parameter_value(T, d, W),
                 name,
                 t,
             )
@@ -791,9 +785,7 @@ function _add_parameters!(
     contributing_devices = IOM.get_contributing_devices(model)
     names = [PSY.get_name(device) for device in contributing_devices]
     time_steps = get_time_steps(container)
-    parameter_container = add_param_container!(
-        container,
-        T(),
+    parameter_container = add_param_container!(container, T,
         S,
         key,
         names,
@@ -806,14 +798,14 @@ function _add_parameters!(
         for t in time_steps
             IOM.set_multiplier!(
                 parameter_container,
-                get_parameter_multiplier(T(), S, W()),
+                get_parameter_multiplier(T, S, W),
                 name,
                 t,
             )
             IOM.set_parameter!(
                 parameter_container,
                 jump_model,
-                get_initial_parameter_value(T(), S, W()),
+                get_initial_parameter_value(T, S, W),
                 name,
                 t,
             )

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -31,7 +31,7 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
@@ -39,7 +39,7 @@ function add_to_expression!(
         bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(
-            get_expression(container, T(), PSY.ACBus)[bus_no, t],
+            get_expression(container, T, PSY.ACBus)[bus_no, t],
             get_parameter_column_refs(param_container, name)[t],
             multiplier[name, t],
         )
@@ -64,7 +64,7 @@ function add_to_expression!(
     W <: AbstractLoadFormulation,
     X <: PM.AbstractPowerModel,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
     network_reduction = get_network_reduction(network_model)
     ts_name = get_time_series_names(model)[U]
@@ -83,10 +83,10 @@ function add_to_expression!(
                 mult = multiplier[name, t]
             else
                 param_value = 1.0
-                mult = get_multiplier_value(U(), d, W())
+                mult = get_multiplier_value(U, d, W)
             end
             add_proportional_to_jump_expression!(
-                get_expression(container, T(), PSY.ACBus)[bus_no, t],
+                get_expression(container, T, PSY.ACBus)[bus_no, t],
                 param_value,
                 mult,
             )
@@ -118,7 +118,7 @@ function add_to_expression!(
         bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         for t in time_steps
             add_proportional_to_jump_expression!(
-                get_expression(container, T(), PSY.ACBus)[bus_no, t],
+                get_expression(container, T, PSY.ACBus)[bus_no, t],
                 PSY.get_active_power(d),
                 -1.0,
             )
@@ -150,7 +150,7 @@ function add_to_expression!(
         area_name = PSY.get_name(PSY.get_area(bus))
         for t in time_steps
             add_proportional_to_jump_expression!(
-                get_expression(container, T(), PSY.Area)[area_name, t],
+                get_expression(container, T, PSY.Area)[area_name, t],
                 PSY.get_active_power(d),
                 -1.0,
             )
@@ -182,7 +182,7 @@ function add_to_expression!(
         bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         for t in time_steps
             add_proportional_to_jump_expression!(
-                get_expression(container, T(), PSY.ACBus)[bus_no, t],
+                get_expression(container, T, PSY.ACBus)[bus_no, t],
                 PSY.get_reactive_power(d),
                 -1.0,
             )
@@ -204,7 +204,7 @@ function add_to_expression!(
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
@@ -212,7 +212,7 @@ function add_to_expression!(
         area_name = PSY.get_name(PSY.get_area(bus))
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(
-            get_expression(container, T(), PSY.Area)[area_name, t],
+            get_expression(container, T, PSY.Area)[area_name, t],
             get_parameter_column_refs(param_container, name)[t],
             multiplier[name, t],
         )
@@ -233,7 +233,7 @@ function add_to_expression!(
     V <: PSY.ElectricLoad,
     W <: AbstractLoadFormulation,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
     ts_name = get_time_series_names(model)[U]
     ts_type = get_default_time_series_type(container)
@@ -252,10 +252,10 @@ function add_to_expression!(
                 mult = multiplier[name, t]
             else
                 param_value = 1.0
-                mult = get_multiplier_value(U(), d, W())
+                mult = get_multiplier_value(U, d, W)
             end
             add_proportional_to_jump_expression!(
-                get_expression(container, T(), PSY.Area)[area_name, t],
+                get_expression(container, T, PSY.Area)[area_name, t],
                 param_value,
                 mult,
             )
@@ -278,15 +278,15 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    parameter = get_parameter_array(container, U(), V)
+    parameter = get_parameter_array(container, U, V)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
         bus_no = PNM.get_mapped_bus_number(network_reduction, PSY.get_bus(d))
         name = PSY.get_name(d)
-        mult = get_expression_multiplier(U(), T(), d, W())
+        mult = get_expression_multiplier(U, T, d, W)
         add_proportional_to_jump_expression!(
-            get_expression(container, T(), PSY.ACBus)[bus_no, t],
+            get_expression(container, T, PSY.ACBus)[bus_no, t],
             parameter[name, t],
             mult,
         )
@@ -311,8 +311,8 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -322,7 +322,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -342,8 +342,8 @@ function add_to_expression!(
     V <: PSY.StaticInjection,
     W <: AbstractDeviceFormulation,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.Area)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.Area)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
         name = PSY.get_name(d)
@@ -352,7 +352,7 @@ function add_to_expression!(
         add_proportional_to_jump_expression!(
             expression[area_name, t],
             variable[name, t],
-            get_variable_multiplier(U(), V, W()),
+            get_variable_multiplier(U, V, W),
         )
     end
     return
@@ -375,8 +375,8 @@ function add_to_expression!(
     W <: HVDCTwoTerminalDispatch,
     X <: Union{PTDFPowerModel, CopperPlatePowerModel, SecurityConstrainedPTDFPowerModel},
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -389,7 +389,7 @@ function add_to_expression!(
                 add_proportional_to_jump_expression!(
                     expression[ref_bus_from, t],
                     variable[name, t],
-                    get_variable_multiplier(U(), V, W()),
+                    get_variable_multiplier(U, V, W),
                 )
             end
         end
@@ -413,8 +413,8 @@ function add_to_expression!(
     X <:
     Union{AreaPTDFPowerModel, AreaBalancePowerModel, SecurityConstrainedAreaPTDFPowerModel},
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.Area)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.Area)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -424,7 +424,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[area_name, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -447,9 +447,9 @@ function add_to_expression!(
     V <: PSY.TwoTerminalHVDC,
     W <: AbstractTwoTerminalDCLineFormulation,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), PSY.System)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, PSY.System)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -493,9 +493,9 @@ function add_to_expression!(
     W <: AbstractTwoTerminalDCLineFormulation,
     X <: AbstractPTDFModel,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), _system_expression_type(X))
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, _system_expression_type(X))
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -540,9 +540,9 @@ function add_to_expression!(
     W <: HVDCTwoTerminalPiecewiseLoss,
     X <: AbstractPTDFModel,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), _system_expression_type(X))
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, _system_expression_type(X))
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -587,8 +587,8 @@ function add_to_expression!(
     W <: HVDCTwoTerminalLCC,                        # formulation
     X <: ACPPowerModel,                             # network model
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -624,8 +624,8 @@ function add_to_expression!(
     W <: HVDCTwoTerminalLCC,
     X <: ACPPowerModel,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -661,8 +661,8 @@ function add_to_expression!(
     W <: HVDCTwoTerminalLCC,                        # formulation
     X <: ACPPowerModel,                             # network model
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -698,8 +698,8 @@ function add_to_expression!(
     W <: HVDCTwoTerminalLCC,
     X <: ACPPowerModel,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -735,9 +735,9 @@ function add_to_expression!(
     W <: HVDCTwoTerminalPiecewiseLoss,
     X <: AbstractPTDFModel,
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), _system_expression_type(X))
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, _system_expression_type(X))
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -783,8 +783,8 @@ function add_to_expression!(
     X <: CopperPlatePowerModel,
 }
     if has_subnetworks(network_model)
-        var = get_variable(container, U(), V)
-        sys_expr = get_expression(container, T(), PSY.System)
+        var = get_variable(container, U, V)
+        sys_expr = get_expression(container, T, PSY.System)
         time_steps = get_time_steps(container)
         for d in devices
             name = PSY.get_name(d)
@@ -823,8 +823,8 @@ function add_to_expression!(
     X <: CopperPlatePowerModel,
 }
     if has_subnetworks(network_model)
-        var = get_variable(container, U(), V)
-        sys_expr = get_expression(container, T(), PSY.System)
+        var = get_variable(container, U, V)
+        sys_expr = get_expression(container, T, PSY.System)
         time_steps = get_time_steps(container)
         for d in devices
             name = PSY.get_name(d)
@@ -862,8 +862,8 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -874,7 +874,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -898,8 +898,8 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -910,7 +910,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -929,8 +929,8 @@ function add_to_expression!(
     U <: FlowActivePowerToFromVariable,
     V <: PSY.TwoTerminalHVDC,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     radial_network_reduction = get_radial_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -941,7 +941,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -976,12 +976,12 @@ function add_to_expression!(
             get_name.(generators),
             time_steps)
 
-    #variable_generator_outages = get_variable(container, U(), V)
-    variable_generator = get_variable(container, U(), V)
-    variable_generator_change = get_variable(container, D(), V)
+    #variable_generator_outages = get_variable(container, U, V)
+    variable_generator = get_variable(container, U, V)
+    variable_generator_change = get_variable(container, D, V)
 
     for generator in generators
-        variable_generator = get_variable(container, U(), typeof(generator))
+        variable_generator = get_variable(container, U, typeof(generator))
         generator_name = get_name(generator)
 
         for generator_outage in generator_outages
@@ -1033,10 +1033,10 @@ function add_to_expression!(
 
     lodf = get_LODF_matrix(network_model)
 
-    variable_branches_outages = get_variable(container, U(), V)
+    variable_branches_outages = get_variable(container, U, V)
 
     for branch in branches
-        variable_branches = get_variable(container, U(), typeof(branch))
+        variable_branches = get_variable(container, U, typeof(branch))
         branch_name = get_name(branch)
 
         for branch_outage in branches_outages
@@ -1127,8 +1127,8 @@ function _add_to_expression!(
     W <: AbstractCompactUnitCommitment,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1141,13 +1141,13 @@ function _add_to_expression!(
             if PSY.get_must_run(d)
                 add_proportional_to_jump_expression!(
                     expression[bus_no, t],
-                    p_min * get_variable_multiplier(U(), V, W()),
+                    p_min * get_variable_multiplier(U, V, W),
                 )
             else
                 add_proportional_to_jump_expression!(
                     expression[bus_no, t],
                     variable[name, t],
-                    p_min * get_variable_multiplier(U(), V, W()),
+                    p_min * get_variable_multiplier(U, V, W),
                 )
             end
         end
@@ -1168,8 +1168,8 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: Union{AbstractCompactUnitCommitment, ThermalCompactDispatch},
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -1181,13 +1181,13 @@ function add_to_expression!(
             if PSY.get_must_run(d)
                 add_proportional_to_jump_expression!(
                     expression[area_name, t],
-                    p_min * get_variable_multiplier(U(), V, W()),
+                    p_min * get_variable_multiplier(U, V, W),
                 )
             else
                 add_proportional_to_jump_expression!(
                     expression[area_name, t],
                     variable[name, t],
-                    p_min * get_variable_multiplier(U(), V, W()),
+                    p_min * get_variable_multiplier(U, V, W),
                 )
             end
         end
@@ -1211,9 +1211,9 @@ function add_to_expression!(
     V <: PSY.StaticInjection,
     W <: AbstractDeviceFormulation,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
-    expression = get_expression(container, T(), PSY.System)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         device_bus = PSY.get_bus(d)
@@ -1245,9 +1245,9 @@ function add_to_expression!(
     V <: PSY.ElectricLoad,
     W <: AbstractLoadFormulation,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
-    expression = get_expression(container, T(), PSY.System)
+    expression = get_expression(container, T, PSY.System)
     ts_name = get_time_series_names(device_model)[U]
     ts_type = get_default_time_series_type(container)
     time_steps = get_time_steps(container)
@@ -1265,7 +1265,7 @@ function add_to_expression!(
                 mult = multiplier[name, t]
             else
                 param_value = 1.0
-                mult = get_multiplier_value(U(), d, W())
+                mult = get_multiplier_value(U, d, W)
             end
             add_proportional_to_jump_expression!(
                 expression[ref_bus, t],
@@ -1293,7 +1293,7 @@ function add_to_expression!(
     V <: PSY.MotorLoad,
     W <: StaticPowerLoad,
 }
-    expression = get_expression(container, T(), PSY.System)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         device_bus = PSY.get_bus(d)
@@ -1322,15 +1322,15 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: AbstractDeviceFormulation,
 }
-    parameter = get_parameter_array(container, U(), V)
-    expression = get_expression(container, T(), PSY.System)
+    parameter = get_parameter_array(container, U, V)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
         ref_bus = get_reference_bus(network_model, device_bus)
         for t in time_steps
-            mult = get_expression_multiplier(U(), T(), d, W())
+            mult = get_expression_multiplier(U, T, d, W)
             add_proportional_to_jump_expression!(
                 expression[ref_bus, t],
                 parameter[name, t],
@@ -1357,8 +1357,8 @@ function add_to_expression!(
     V <: PSY.StaticInjection,
     W <: AbstractDeviceFormulation,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         device_bus = PSY.get_bus(d)
@@ -1368,7 +1368,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[ref_bus, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -1388,8 +1388,8 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: AbstractCompactUnitCommitment,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.System)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -1401,7 +1401,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[ref_bus, t],
                 variable[name, t],
-                p_min * get_variable_multiplier(U(), V, W()),
+                p_min * get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -1425,10 +1425,10 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPTDFModel,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
-    sys_expr = get_expression(container, T(), _system_expression_type(X))
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    sys_expr = get_expression(container, T, _system_expression_type(X))
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1470,10 +1470,10 @@ function add_to_expression!(
     W <: AbstractLoadFormulation,
     X <: AbstractPTDFModel,
 }
-    param_container = get_parameter(container, U(), V)
+    param_container = get_parameter(container, U, V)
     multiplier = get_multiplier_array(param_container)
-    sys_expr = get_expression(container, T(), _system_expression_type(X))
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    sys_expr = get_expression(container, T, _system_expression_type(X))
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     ts_name = get_time_series_names(device_model)[U]
     ts_type = get_default_time_series_type(container)
@@ -1494,7 +1494,7 @@ function add_to_expression!(
                 mult = multiplier[name, t]
             else
                 param = 1.0
-                mult = get_multiplier_value(U(), d, W())
+                mult = get_multiplier_value(U, d, W)
             end
             add_proportional_to_jump_expression!(sys_expr[ref_index, t], param, mult)
             add_proportional_to_jump_expression!(nodal_expr[bus_no, t], param, mult)
@@ -1517,16 +1517,16 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPTDFModel,
 }
-    parameter = get_parameter_array(container, U(), V)
-    sys_expr = get_expression(container, T(), PSY.System)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    parameter = get_parameter_array(container, U, V)
+    sys_expr = get_expression(container, T, PSY.System)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
         bus_no_ = PSY.get_number(PSY.get_bus(d))
         bus_no = PNM.get_mapped_bus_number(network_reduction, bus_no_)
-        mult = get_expression_multiplier(U(), T(), d, W())
+        mult = get_expression_multiplier(U, T, d, W)
         device_bus = PSY.get_bus(d)
         ref_index = _ref_index(network_model, device_bus)
         for t in time_steps
@@ -1562,9 +1562,9 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: PTDFPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    sys_expr = get_expression(container, T(), PSY.System)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    sys_expr = get_expression(container, T, PSY.System)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1576,12 +1576,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 sys_expr[ref_index, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 nodal_expr[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -1605,8 +1605,8 @@ function add_to_expression!(
     W <: StaticPowerLoad,
     X <: AbstractPTDFModel,
 }
-    sys_expr = get_expression(container, T(), PSY.System)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    sys_expr = get_expression(container, T, PSY.System)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1644,9 +1644,9 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AreaPTDFPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    area_expr = get_expression(container, T(), PSY.Area)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    area_expr = get_expression(container, T, PSY.Area)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1658,12 +1658,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 area_expr[area_name, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 nodal_expr[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -1687,9 +1687,9 @@ function add_to_expression!(
     W <: AbstractCompactUnitCommitment,
     X <: PTDFPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    sys_expr = get_expression(container, T(), _system_expression_type(PTDFPowerModel))
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    sys_expr = get_expression(container, T, _system_expression_type(PTDFPowerModel))
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1702,12 +1702,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 sys_expr[ref_index, t],
                 variable[name, t],
-                p_min * get_variable_multiplier(U(), V, W()),
+                p_min * get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 nodal_expr[bus_no, t],
                 variable[name, t],
-                p_min * get_variable_multiplier(U(), V, W()),
+                p_min * get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -1731,8 +1731,8 @@ function add_to_expression!(
     W <: AbstractBranchFormulation,
     X <: AbstractActivePowerModel,
 }
-    var = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1768,8 +1768,8 @@ function add_to_expression!(
     W <: AbstractBranchFormulation,
     U <: Union{AreaBalancePowerModel, AreaPTDFPowerModel},
 }
-    flow_variable = get_variable(container, FlowActivePowerVariable(), PSY.AreaInterchange)
-    expression = get_expression(container, ActivePowerBalance(), PSY.Area)
+    flow_variable = get_variable(container, FlowActivePowerVariable, PSY.AreaInterchange)
+    expression = get_expression(container, ActivePowerBalance, PSY.Area)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -1823,9 +1823,9 @@ function add_to_expression!(
     W <: AbstractBranchFormulation,
     X <: Union{PTDFPowerModel, SecurityConstrainedPTDFPowerModel},
 }
-    var = get_variable(container, U(), V)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), PSY.System)
+    var = get_variable(container, U, V)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, PSY.System)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1889,8 +1889,8 @@ function add_to_expression!(
         end
     end
     if !isempty(inter_network_branches)
-        var = get_variable(container, U(), V)
-        sys_expr = get_expression(container, T(), PSY.System)
+        var = get_variable(container, U, V)
+        sys_expr = get_expression(container, T, PSY.System)
         time_steps = get_time_steps(container)
         for d in devices
             name = PSY.get_name(d)
@@ -1928,8 +1928,8 @@ function add_to_expression!(
     ::DeviceModel{PSY.PhaseShiftingTransformer, V},
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: ActivePowerBalance, U <: PhaseShifterAngle, V <: PhaseAngleControl}
-    var = get_variable(container, U(), PSY.PhaseShiftingTransformer)
-    expression = get_expression(container, T(), PSY.ACBus)
+    var = get_variable(container, U, PSY.PhaseShiftingTransformer)
+    expression = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     time_steps = get_time_steps(container)
     for d in devices
@@ -1944,12 +1944,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 expression[bus_no_from, t],
                 flow_variable,
-                -x_mult * get_variable_multiplier(U(), PSY.PhaseShiftingTransformer, V()),
+                -x_mult * get_variable_multiplier(U, PSY.PhaseShiftingTransformer, V),
             )
             add_proportional_to_jump_expression!(
                 expression[bus_no_to, t],
                 flow_variable,
-                x_mult * get_variable_multiplier(U(), PSY.PhaseShiftingTransformer, V()),
+                x_mult * get_variable_multiplier(U, PSY.PhaseShiftingTransformer, V),
             )
         end
     end
@@ -1970,11 +1970,11 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
+    variable = get_variable(container, U, V)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
         name = PSY.get_name(d)
@@ -1997,11 +1997,11 @@ function add_to_expression!(
     W <: AbstractReservesFormulation,
 }
     service_name = get_service_name(model)
-    variable = get_variable(container, U(), X, service_name)
+    variable = get_variable(container, U, X, service_name)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
         name = PSY.get_name(d)
@@ -2021,15 +2021,15 @@ function add_to_expression!(
     U <: Union{ConstantMaxInterfaceFlow, VariableMaxInterfaceFlow},
     S <: PSY.TransmissionInterface,
 }
-    expression = get_expression(container, InterfaceTotalFlow(), PSY.TransmissionInterface)
+    expression = get_expression(container, InterfaceTotalFlow, PSY.TransmissionInterface)
     service_name = PSY.get_name(service)
-    variable = get_variable(container, T(), PSY.TransmissionInterface, service_name)
+    variable = get_variable(container, T, PSY.TransmissionInterface, service_name)
     time_steps = get_time_steps(container)
     for t in time_steps
         add_proportional_to_jump_expression!(
             expression[service_name, t],
             variable[t],
-            get_variable_multiplier(T(), S, U()),
+            get_variable_multiplier(T, S, U),
         )
     end
     return
@@ -2105,12 +2105,12 @@ function add_to_expression!(
     network_model::NetworkModel{<:AbstractActivePowerModel},
 ) where {V <: Union{ConstantMaxInterfaceFlow, VariableMaxInterfaceFlow}}
     net_reduction_data = get_network_reduction(network_model)
-    expression = get_expression(container, InterfaceTotalFlow(), PSY.TransmissionInterface)
+    expression = get_expression(container, InterfaceTotalFlow, PSY.TransmissionInterface)
     service_name = get_service_name(model)
     direction_map = PSY.get_direction_mapping(service)
     contributing_devices_map = get_contributing_devices_map(model)
     for (br_type, contributing_devices) in contributing_devices_map
-        variable = get_variable(container, FlowActivePowerVariable(), br_type)
+        variable = get_variable(container, FlowActivePowerVariable, br_type)
         _handle_nodal_or_zonal_interfaces(
             br_type,
             net_reduction_data,
@@ -2142,7 +2142,7 @@ function add_to_expression!(
     network_model::NetworkModel{AreaPTDFPowerModel},
 ) where {V <: Union{ConstantMaxInterfaceFlow, VariableMaxInterfaceFlow}}
     net_reduction_data = get_network_reduction(network_model)
-    expression = get_expression(container, InterfaceTotalFlow(), PSY.TransmissionInterface)
+    expression = get_expression(container, InterfaceTotalFlow, PSY.TransmissionInterface)
     service_name = get_service_name(model)
     direction_map = PSY.get_direction_mapping(service)
     contributing_devices_map = get_contributing_devices_map(model)
@@ -2150,7 +2150,7 @@ function add_to_expression!(
     if !_is_interchanges_interfaces(contributing_devices_map)
         return
     end
-    variable = get_variable(container, FlowActivePowerVariable(), PSY.AreaInterchange)
+    variable = get_variable(container, FlowActivePowerVariable, PSY.AreaInterchange)
     _handle_nodal_or_zonal_interfaces(
         PSY.AreaInterchange,
         net_reduction_data,
@@ -2171,7 +2171,7 @@ function add_to_expression!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {V <: Union{ConstantMaxInterfaceFlow, VariableMaxInterfaceFlow}}
     net_reduction_data = get_network_reduction(network_model)
-    expression = get_expression(container, InterfaceTotalFlow(), PSY.TransmissionInterface)
+    expression = get_expression(container, InterfaceTotalFlow, PSY.TransmissionInterface)
     service_name = get_service_name(model)
     direction_map = PSY.get_direction_mapping(service)
     contributing_devices_map = get_contributing_devices_map(model)
@@ -2181,7 +2181,7 @@ function add_to_expression!(
     end
 
     for (br_type, contributing_devices) in contributing_devices_map
-        flow_expression = get_expression(container, PTDFBranchFlow(), br_type)
+        flow_expression = get_expression(container, PTDFBranchFlow, br_type)
         all_branch_maps_by_type = net_reduction_data.all_branch_maps_by_type
         for (name, (arc, reduction)) in PNM.get_name_to_arc_map(net_reduction_data, br_type)
             reduction_entry = all_branch_maps_by_type[reduction][br_type][arc]
@@ -2341,11 +2341,11 @@ function add_to_expression!(
     W <: AbstractReservesFormulation,
 }
     service_name = get_service_name(model)
-    variable = get_variable(container, U(), X, service_name)
+    variable = get_variable(container, U, X, service_name)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
     for d in devices, t in time_steps
         name = PSY.get_name(d)
@@ -2366,15 +2366,15 @@ function add_to_expression!(
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
 }
-    parameter_array = get_parameter_array(container, U(), V)
+    parameter_array = get_parameter_array(container, U, V)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
-        mult = get_expression_multiplier(U(), T(), d, W())
+        mult = get_expression_multiplier(U, T, d, W)
         for t in time_steps
             add_proportional_to_jump_expression!(
                 expression[name, t],
@@ -2399,18 +2399,18 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: AbstractThermalDispatchFormulation,
 }
-    parameter_array = get_parameter_array(container, U(), V)
+    parameter_array = get_parameter_array(container, U, V)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
     for d in devices
         if PSY.get_must_run(d)
             continue
         end
         name = PSY.get_name(d)
-        mult = get_expression_multiplier(U(), T(), d, W())
+        mult = get_expression_multiplier(U, T, d, W)
         for t in time_steps
             add_proportional_to_jump_expression!(
                 expression[name, t],
@@ -2432,7 +2432,7 @@ function add_to_expression!(
     for (device_type, devices) in contributing_devices_map
         device_model = get(devices_template, Symbol(device_type), nothing)
         device_model === nothing && continue
-        expression_type = get_expression_type_for_reserve(U(), device_type, V)
+        expression_type = get_expression_type_for_reserve(U, device_type, V)
         add_to_expression!(container, expression_type, U, devices, model)
     end
     return
@@ -2449,15 +2449,15 @@ function add_to_expression!(
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
     W <: Union{CopperPlatePowerModel, PTDFPowerModel, SecurityConstrainedPTDFPowerModel},
 }
-    variable = get_variable(container, U(), PSY.System)
-    expression = get_expression(container, T(), _system_expression_type(W))
+    variable = get_variable(container, U, PSY.System)
+    expression = get_expression(container, T, _system_expression_type(W))
     reference_buses = get_reference_buses(network_model)
     time_steps = get_time_steps(container)
     for t in time_steps, n in reference_buses
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.System, W),
+            get_variable_multiplier(U, PSY.System, W),
         )
     end
     return
@@ -2476,16 +2476,16 @@ function add_to_expression!(
     V <: Union{AreaPTDFPowerModel, SecurityConstrainedAreaPTDFPowerModel},
 }
     variable =
-        get_variable(container, U(), _system_expression_type(AreaPTDFPowerModel))
+        get_variable(container, U, _system_expression_type(AreaPTDFPowerModel))
     expression =
-        get_expression(container, T(), _system_expression_type(AreaPTDFPowerModel))
+        get_expression(container, T, _system_expression_type(AreaPTDFPowerModel))
     areas = get_available_components(network_model, PSY.Area, sys)
     time_steps = get_time_steps(container)
     for t in time_steps, n in PSY.get_name.(areas)
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.Area, AreaPTDFPowerModel),
+            get_variable_multiplier(U, PSY.Area, AreaPTDFPowerModel),
         )
     end
     return
@@ -2501,15 +2501,15 @@ function add_to_expression!(
     T <: ActivePowerBalance,
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
 }
-    variable = get_variable(container, U(), PSY.Area)
-    expression = get_expression(container, T(), PSY.Area)
+    variable = get_variable(container, U, PSY.Area)
+    expression = get_expression(container, T, PSY.Area)
     @assert_op length(axes(variable, 1)) == length(axes(expression, 1))
     time_steps = get_time_steps(container)
     for t in time_steps, n in axes(expression, 1)
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.Area, AreaBalancePowerModel),
+            get_variable_multiplier(U, PSY.Area, AreaBalancePowerModel),
         )
     end
     return
@@ -2526,8 +2526,8 @@ function add_to_expression!(
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
     W <: AbstractActivePowerModel,
 }
-    variable = get_variable(container, U(), PSY.ACBus)
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, PSY.ACBus)
+    expression = get_expression(container, T, PSY.ACBus)
     @assert_op length(axes(variable, 1)) == length(axes(expression, 1))
     # We uses axis here to avoid double addition of the slacks to the aggregated buses
     time_steps = get_time_steps(container)
@@ -2535,7 +2535,7 @@ function add_to_expression!(
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.ACBus, W),
+            get_variable_multiplier(U, PSY.ACBus, W),
         )
     end
     return
@@ -2552,15 +2552,15 @@ function add_to_expression!(
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
     W <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), PSY.ACBus, "P")
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, PSY.ACBus, "P")
+    expression = get_expression(container, T, PSY.ACBus)
     # We uses axis here to avoid double addition of the slacks to the aggregated buses
     time_steps = get_time_steps(container)
     for t in time_steps, n in axes(expression, 1)
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.ACBus, W),
+            get_variable_multiplier(U, PSY.ACBus, W),
         )
     end
     return
@@ -2577,15 +2577,15 @@ function add_to_expression!(
     U <: Union{SystemBalanceSlackUp, SystemBalanceSlackDown},
     W <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), PSY.ACBus, "Q")
-    expression = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, PSY.ACBus, "Q")
+    expression = get_expression(container, T, PSY.ACBus)
     # We uses axis here to avoid double addition of the slacks to the aggregated buses
     time_steps = get_time_steps(container)
     for t in time_steps, n in axes(expression, 1)
         add_proportional_to_jump_expression!(
             expression[n, t],
             variable[n, t],
-            get_variable_multiplier(U(), PSY.ACBus, W),
+            get_variable_multiplier(U, PSY.ACBus, W),
         )
     end
     return
@@ -2599,7 +2599,7 @@ function add_cost_to_expression!(
     time_period::Int,
 ) where {S <: CostExpressions, T <: PSY.ReserveDemandCurve}
     if has_container_key(container, S, T, PSY.get_name(component))
-        device_cost_expression = get_expression(container, S(), T, PSY.get_name(component))
+        device_cost_expression = get_expression(container, S, T, PSY.get_name(component))
         component_name = PSY.get_name(component)
         JuMP.add_to_expression!(
             device_cost_expression[component_name, time_period],
@@ -2621,7 +2621,7 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: AbstractDeviceFormulation,
 }
-    variable = get_variable(container, U(), V)
+    variable = get_variable(container, U, V)
     time_steps = get_time_steps(container)
     base_power = get_model_base_power(container)
     resolution = get_resolution(container)
@@ -2632,7 +2632,7 @@ function add_to_expression!(
         if !(var_cost isa PSY.FuelCurve)
             continue
         end
-        expression = get_expression(container, T(), V)
+        expression = get_expression(container, T, V)
         name = PSY.get_name(d)
         device_base_power = PSY.get_base_power(d)
         value_curve = PSY.get_value_curve(var_cost)
@@ -2695,7 +2695,7 @@ function add_to_expression!(
     V <: PSY.ThermalGen,
     W <: AbstractDeviceFormulation,
 }
-    variable = get_variable(container, U(), V)
+    variable = get_variable(container, U, V)
     time_steps = get_time_steps(container)
     base_power = get_model_base_power(container)
     resolution = get_resolution(container)
@@ -2706,7 +2706,7 @@ function add_to_expression!(
         if !(var_cost isa PSY.FuelCurve)
             continue
         end
-        expression = get_expression(container, T(), V)
+        expression = get_expression(container, T, V)
         name = PSY.get_name(d)
         device_base_power = PSY.get_base_power(d)
         value_curve = PSY.get_value_curve(var_cost)
@@ -2770,9 +2770,9 @@ function add_to_expression!(
     V <: PSY.Source,
     W <: AbstractSourceFormulation,
 }
-    expression = get_expression(container, T(), V)
-    variable = get_variable(container, U(), V)
-    mult = get_variable_multiplier(U(), V, W())
+    expression = get_expression(container, T, V)
+    variable = get_variable(container, U, V)
+    mult = get_variable_multiplier(U, V, W)
     time_steps = get_time_steps(container)
     for d in devices
         name = PSY.get_name(d)
@@ -2803,10 +2803,10 @@ function add_to_expression!(
     names = PSY.get_name.(areas)
     time_steps = get_time_steps(container)
     if !has_container_key(container, T, V)
-        expression = add_expression_container!(container, T(), V, names, time_steps)
+        expression = add_expression_container!(container, T, V, names, time_steps)
     end
-    expression = get_expression(container, T(), V)
-    variable = get_variable(container, U(), V)
+    expression = get_expression(container, T, V)
+    variable = get_variable(container, U, V)
     for n in names, t in time_steps
         add_proportional_to_jump_expression!(expression[n, t], variable[n, t], 1.0)
     end
@@ -2828,10 +2828,10 @@ function add_to_expression!(
     names = PSY.get_name.(services)
     time_steps = get_time_steps(container)
     if !has_container_key(container, T, V)
-        expression = add_expression_container!(container, T(), PSY.AGC, names, time_steps)
+        expression = add_expression_container!(container, T, PSY.AGC, names, time_steps)
     end
-    expression = get_expression(container, T(), PSY.AGC)
-    variable = get_variable(container, U(), PSY.AGC)
+    expression = get_expression(container, T, PSY.AGC)
+    variable = get_variable(container, U, PSY.AGC)
     for s in services, t in time_steps
         name = PSY.get_name(s)
         # Per-device bias multiplier for AGC frequency deviation
@@ -2839,7 +2839,7 @@ function add_to_expression!(
         add_proportional_to_jump_expression!(
             expression[name, t],
             variable[t],
-            bias_mult * get_variable_multiplier(U(), V, W()),
+            bias_mult * get_variable_multiplier(U, V, W),
         )
     end
     return
@@ -2855,7 +2855,7 @@ function add_to_expression!(
     time_period::Int,
 ) where {S <: Union{CostExpressions, FuelConsumptionExpression}, T <: PSY.Component}
     if has_container_key(container, S, T)
-        device_cost_expression = get_expression(container, S(), T)
+        device_cost_expression = get_expression(container, S, T)
         component_name = PSY.get_name(component)
         JuMP.add_to_expression!(
             device_cost_expression[component_name, time_period],
@@ -2874,7 +2874,7 @@ function add_to_expression!(
 ) where {S <: CostExpressions, T <: PSY.ReserveDemandCurve}
     if has_container_key(container, S, T, PSY.get_name(component))
         device_cost_expression =
-            get_expression(container, S(), T, PSY.get_name(component))
+            get_expression(container, S, T, PSY.get_name(component))
         component_name = PSY.get_name(component)
         JuMP.add_to_expression!(
             device_cost_expression[component_name, time_period],

--- a/src/common_models/make_system_expressions.jl
+++ b/src/common_models/make_system_expressions.jl
@@ -273,8 +273,6 @@ function initialize_system_expressions!(
     return
 end
 
-# NOTE: Commented out because it references TransportHVDCNetworkModel concrete type
-# This should be defined in PowerSimulations if needed for specific network models
 function initialize_hvdc_system!(
     container::OptimizationContainer,
     network_model::NetworkModel{T},
@@ -289,8 +287,6 @@ function initialize_hvdc_system!(
     return
 end
 
-# NOTE: Commented out because it references VoltageDispatchHVDCNetworkModel concrete type
-# This should be defined in PowerSimulations if needed for specific network models
 function initialize_hvdc_system!(
     container::OptimizationContainer,
     network_model::NetworkModel{T},
@@ -302,6 +298,6 @@ function initialize_hvdc_system!(
     dc_bus_numbers = sort(PSY.get_number.(dc_buses))
     container.expressions[ExpressionKey(DCCurrentBalance, PSY.DCBus)] =
         make_container_array(dc_bus_numbers, get_time_steps(container))
-    add_variables!(container, DCVoltage, dc_buses, dc_model)
+    add_variables!(container, DCVoltage, dc_buses, U)
     return
 end

--- a/src/common_models/market_bid_overrides.jl
+++ b/src/common_models/market_bid_overrides.jl
@@ -22,7 +22,7 @@ _has_market_bid_cost(device::PSY.ControllableLoad) =
 #################################################################################
 
 _consider_parameter(
-    ::StartupCostParameter,
+    ::Type{StartupCostParameter},
     container::OptimizationContainer,
     ::DeviceModel{T, D},
 ) where {T, D <: AbstractCompactUnitCommitment} =
@@ -34,7 +34,7 @@ _consider_parameter(
 
 # ThermalMultiStart: accept NTuple{3, Float64} and StartUpStages without warning
 function validate_occ_component(
-    ::StartupCostParameter,
+    ::Type{StartupCostParameter},
     device::PSY.ThermalMultiStart,
 )
     startup = PSY.get_start_up(PSY.get_operation_cost(device))
@@ -49,7 +49,7 @@ end
 # Renewable / Storage: warn on nonzero startup, shutdown, and no-load costs
 
 function validate_occ_component(
-    ::StartupCostParameter,
+    ::Type{StartupCostParameter},
     device::Union{PSY.RenewableDispatch, PSY.Storage},
 )
     startup = PSY.get_start_up(PSY.get_operation_cost(device))
@@ -61,7 +61,7 @@ function validate_occ_component(
 end
 
 function validate_occ_component(
-    ::ShutdownCostParameter,
+    ::Type{ShutdownCostParameter},
     device::Union{PSY.RenewableDispatch, PSY.Storage},
 )
     shutdown = PSY.get_shut_down(PSY.get_operation_cost(device))
@@ -73,7 +73,7 @@ function validate_occ_component(
 end
 
 function validate_occ_component(
-    ::IncrementalCostAtMinParameter,
+    ::Type{IncrementalCostAtMinParameter},
     device::Union{PSY.RenewableDispatch, PSY.Storage},
 )
     no_load_cost = PSY.get_no_load_cost(PSY.get_operation_cost(device))
@@ -87,7 +87,7 @@ function validate_occ_component(
 end
 
 function validate_occ_component(
-    ::DecrementalCostAtMinParameter,
+    ::Type{DecrementalCostAtMinParameter},
     device::PSY.Storage,
 )
     no_load_cost = PSY.get_no_load_cost(PSY.get_operation_cost(device))
@@ -107,38 +107,38 @@ end
 
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.Source},
-    ::ActivePowerOutVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{ActivePowerOutVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.Source},
-    ::ActivePowerInVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{ActivePowerInVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.RenewableDispatch},
-    ::ActivePowerVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{ActivePowerVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.Generator},
-    ::ActivePowerVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{ActivePowerVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = true
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.ControllableLoad},
-    ::ActivePowerVariable,
-    ::PowerLoadInterruption,
+    ::Type{ActivePowerVariable},
+    ::Type{PowerLoadInterruption},
 ) = true
 _include_min_gen_power_in_constraint(
     ::Type{<:PSY.ControllableLoad},
-    ::ActivePowerVariable,
-    ::PowerLoadDispatch,
+    ::Type{ActivePowerVariable},
+    ::Type{PowerLoadDispatch},
 ) = false
 _include_min_gen_power_in_constraint(
     ::Type,
-    ::PowerAboveMinimumVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{PowerAboveMinimumVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 
 #################################################################################
@@ -149,18 +149,18 @@ _include_min_gen_power_in_constraint(
 
 _include_constant_min_gen_power_in_constraint(
     ::Type{<:PSY.ControllableLoad},
-    ::ActivePowerVariable,
-    ::PowerLoadDispatch,
+    ::Type{ActivePowerVariable},
+    ::Type{PowerLoadDispatch},
 ) = true
 _include_constant_min_gen_power_in_constraint(
     ::Type{<:PSY.ControllableLoad},
-    ::ActivePowerVariable,
-    ::PowerLoadInterruption,
+    ::Type{ActivePowerVariable},
+    ::Type{PowerLoadInterruption},
 ) = false
 _include_constant_min_gen_power_in_constraint(
     ::Type{<:PSY.RenewableGen},
-    ::ActivePowerVariable,
-    ::AbstractRenewableDispatchFormulation,
+    ::Type{ActivePowerVariable},
+    ::Type{<:AbstractRenewableDispatchFormulation},
 ) = true
 
 #################################################################################
@@ -169,10 +169,10 @@ _include_constant_min_gen_power_in_constraint(
 
 function add_variable_cost_to_objective!(
     container::OptimizationContainer,
-    ::ActivePowerOutVariable,
+    ::Type{ActivePowerOutVariable},
     component::PSY.Source,
     cost_function::PSY.ImportExportCost,
-    ::ImportExportSourceModel,
+    ::Type{ImportExportSourceModel},
 )
     isnothing(get_output_offer_curves(cost_function)) && return
     add_pwl_term_delta!(
@@ -180,18 +180,18 @@ function add_variable_cost_to_objective!(
         container,
         component,
         cost_function,
-        ActivePowerOutVariable(),
-        ImportExportSourceModel(),
+        ActivePowerOutVariable,
+        ImportExportSourceModel,
     )
     return
 end
 
 function add_variable_cost_to_objective!(
     container::OptimizationContainer,
-    ::ActivePowerInVariable,
+    ::Type{ActivePowerInVariable},
     component::PSY.Source,
     cost_function::PSY.ImportExportCost,
-    ::ImportExportSourceModel,
+    ::Type{ImportExportSourceModel},
 )
     isnothing(get_input_offer_curves(cost_function)) && return
     add_pwl_term_delta!(
@@ -199,8 +199,8 @@ function add_variable_cost_to_objective!(
         container,
         component,
         cost_function,
-        ActivePowerInVariable(),
-        ImportExportSourceModel(),
+        ActivePowerInVariable,
+        ImportExportSourceModel,
     )
     return
 end
@@ -211,10 +211,10 @@ end
 
 function add_variable_cost_to_objective!(
     container::OptimizationContainer,
-    ::T,
+    ::Type{T},
     component::PSY.Component,
     cost_function::PSY.OfferCurveCost,
-    ::U,
+    ::Type{U},
 ) where {T <: VariableType, U <: AbstractControllablePowerLoadFormulation}
     component_name = PSY.get_name(component)
     @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
@@ -226,13 +226,14 @@ function add_variable_cost_to_objective!(
         container,
         component,
         cost_function,
-        T(),
-        U(),
+        T,
+        U,
     )
     return
 end
 
-_vom_offer_direction(::AbstractControllablePowerLoadFormulation) = DecrementalOffer()
+_vom_offer_direction(::Type{<:AbstractControllablePowerLoadFormulation}) =
+    DecrementalOffer()
 
 #################################################################################
 # Section 7: Service-specific PWL (ReserveDemandCurve, StepwiseCostReserve)
@@ -244,16 +245,16 @@ PWL block offer constraints for ORDC (ReserveDemandCurve).
 function add_pwl_constraint_delta!(
     container::OptimizationContainer,
     component::T,
-    ::U,
+    ::Type{U},
     break_points::Vector{Float64},
     pwl_vars::Vector{JuMP.VariableRef},
     period::Int,
 ) where {T <: PSY.ReserveDemandCurve, U <: ServiceRequirementVariable}
     name = PSY.get_name(component)
-    variables = get_variable(container, U(), T, name)
+    variables = get_variable(container, U, T, name)
     const_container = lazy_container_addition!(
         container,
-        PiecewiseLinearBlockIncrementalOfferConstraint(),
+        PiecewiseLinearBlockIncrementalOfferConstraint,
         T,
         axes(variables)...;
         meta = name,
@@ -277,10 +278,10 @@ function add_pwl_term_delta!(
     container::OptimizationContainer,
     component::T,
     cost_data::PSY.CostCurve{PSY.PiecewiseIncrementalCurve},
-    ::U,
-    ::V,
+    ::Type{U},
+    ::Type{V},
 ) where {T <: PSY.Component, U <: VariableType, V <: AbstractServiceFormulation}
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     resolution = get_resolution(container)
     dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
     base_power = get_model_base_power(container)
@@ -309,7 +310,7 @@ function add_pwl_term_delta!(
             length(slopes);
             upper_bound = Inf,
         )
-        add_pwl_constraint_delta!(container, component, U(), break_points, pwl_vars, t)
+        add_pwl_constraint_delta!(container, component, U, break_points, pwl_vars, t)
         pwl_cost_expressions[t] =
             get_pwl_cost_expression_delta(pwl_vars, slopes, multiplier * dt)
     end

--- a/src/common_models/reserve_range_constraints.jl
+++ b/src/common_models/reserve_range_constraints.jl
@@ -30,7 +30,7 @@ function add_reserve_range_constraints!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    array = get_variable(container, U(), V)
+    array = get_variable(container, U, V)
     add_reserve_bound_range_constraints!(
         container, T, LowerBound(), array, devices, model, true)
     add_reserve_bound_range_constraints!(
@@ -52,7 +52,7 @@ function add_reserve_range_constraints!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    array = get_expression(container, U(), W)
+    array = get_expression(container, U, W)
     add_reserve_bound_range_constraints!(
         container, T, get_bound_direction(U()), array, devices, model, true)
     return
@@ -92,7 +92,7 @@ function add_reserve_range_constraints!(
     X <: AbstractDeviceFormulation,
     Y <: AbstractPowerModel,
 }
-    array = get_variable(container, U(), W)
+    array = get_variable(container, U, W)
     add_reserve_bound_range_constraints!(
         container, T, LowerBound(), array, devices, model, false)
     add_reserve_bound_range_constraints!(
@@ -134,7 +134,7 @@ function add_reserve_range_constraints!(
     X <: AbstractDeviceFormulation,
     Y <: AbstractPowerModel,
 }
-    array = get_expression(container, U(), W)
+    array = get_expression(container, U, W)
     add_reserve_bound_range_constraints!(
         container, T, get_bound_direction(U()), array, devices, model, false)
     return

--- a/src/core/default_interface_methods.jl
+++ b/src/core/default_interface_methods.jl
@@ -3,11 +3,11 @@ get_variable_key(variabletype, d) = error("Not Implemented")
 
 #! format: off
 # FIXME: do we need these? We define a default method in IOM too.
-get_multiplier_value(::StartupCostParameter, ::PSY.Device, ::AbstractDeviceFormulation) = 1.0
-get_multiplier_value(::ShutdownCostParameter, ::PSY.Device, ::AbstractDeviceFormulation) = 1.0
-get_multiplier_value(::AbstractCostAtMinParameter, ::PSY.Device, ::AbstractDeviceFormulation) = 1.0
-get_multiplier_value(::AbstractPiecewiseLinearSlopeParameter, ::PSY.Device, ::AbstractDeviceFormulation) = 1.0
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, ::PSY.Device, ::AbstractDeviceFormulation) = 1.0
+get_multiplier_value(::Type{StartupCostParameter}, ::PSY.Device, ::Type{<:AbstractDeviceFormulation}) = 1.0
+get_multiplier_value(::Type{ShutdownCostParameter}, ::PSY.Device, ::Type{<:AbstractDeviceFormulation}) = 1.0
+get_multiplier_value(::Type{<:AbstractCostAtMinParameter}, ::PSY.Device, ::Type{<:AbstractDeviceFormulation}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearSlopeParameter}, ::PSY.Device, ::Type{<:AbstractDeviceFormulation}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.Device, ::Type{<:AbstractDeviceFormulation}) = 1.0
 #! format: on
 
 get_expression_type_for_reserve(_, y::Type{<:PSY.Component}, z) =

--- a/src/core/interfaces.jl
+++ b/src/core/interfaces.jl
@@ -86,19 +86,19 @@ Get the multiplier for a variable type when adding to an expression.
 Default implementation returns 1.0.
 """
 get_variable_multiplier(
-    ::IS.Optimization.VariableType,
+    ::Type{<:IS.Optimization.VariableType},
     ::Type{<:IS.InfrastructureSystemsComponent},
-    ::IOM.AbstractDeviceFormulation,
+    ::Type{<:IOM.AbstractDeviceFormulation},
 ) = 1.0
 
 """
 Get the multiplier for an expression type based on parameter type.
 """
 function get_expression_multiplier(
-    ::P,
+    ::Type{P},
     ::Type{T},
     ::D,
-    ::F,
+    ::Type{F},
 ) where {
     P <: IS.Optimization.ParameterType,
     T <: IS.Optimization.ExpressionType,
@@ -115,9 +115,9 @@ end
 Get multiplier value for a time series parameter.
 """
 function get_multiplier_value(
-    ::T,
+    ::Type{T},
     ::U,
-    ::F,
+    ::Type{F},
 ) where {
     T <: IOM.TimeSeriesParameter,
     U <: IS.InfrastructureSystemsComponent,
@@ -130,9 +130,9 @@ end
 Get the multiplier value for a parameter type.
 """
 function get_multiplier_value(
-    ::P,
+    ::Type{P},
     ::D,
-    ::F,
+    ::Type{F},
 ) where {
     P <: IS.Optimization.ParameterType,
     D <: IS.InfrastructureSystemsComponent,

--- a/src/energy_storage_models/storage_constructor.jl
+++ b/src/energy_storage_models/storage_constructor.jl
@@ -5,8 +5,8 @@ function _add_ancillary_services!(
     model::DeviceModel{T, U},
     network_model::NetworkModel{V},
 ) where {T <: PSY.Storage, U <: StorageDispatchWithReserves, V <: AbstractPowerModel}
-    add_variables!(container, AncillaryServiceVariableDischarge, devices, U())
-    add_variables!(container, AncillaryServiceVariableCharge, devices, U())
+    add_variables!(container, AncillaryServiceVariableDischarge, devices, U)
+    add_variables!(container, AncillaryServiceVariableCharge, devices, U)
     time_steps = get_time_steps(container)
     for exp in [
         ReserveAssignmentBalanceUpDischarge,
@@ -118,23 +118,23 @@ function _active_power_variables_and_expressions(
     model::DeviceModel{T, U},
     network_model::NetworkModel,
 ) where {T <: PSY.Storage, U <: StorageDispatchWithReserves}
-    add_variables!(container, ActivePowerInVariable, devices, U())
-    add_variables!(container, ActivePowerOutVariable, devices, U())
-    add_variables!(container, EnergyVariable, devices, U())
-    add_variables!(container, StorageEnergyOutput, devices, U())
+    add_variables!(container, ActivePowerInVariable, devices, U)
+    add_variables!(container, ActivePowerOutVariable, devices, U)
+    add_variables!(container, EnergyVariable, devices, U)
+    add_variables!(container, StorageEnergyOutput, devices, U)
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, U())
+        add_variables!(container, ReservationVariable, devices, U)
     end
 
     if get_attribute(model, "energy_target")
-        add_variables!(container, StorageEnergyShortageVariable, devices, U())
-        add_variables!(container, StorageEnergySurplusVariable, devices, U())
+        add_variables!(container, StorageEnergyShortageVariable, devices, U)
+        add_variables!(container, StorageEnergySurplusVariable, devices, U)
     end
 
     if get_attribute(model, "cycling_limits")
-        add_variables!(container, StorageChargeCyclingSlackVariable, devices, U())
-        add_variables!(container, StorageDischargeCyclingSlackVariable, devices, U())
+        add_variables!(container, StorageChargeCyclingSlackVariable, devices, U)
+        add_variables!(container, StorageDischargeCyclingSlackVariable, devices, U)
     end
 
     initial_conditions!(container, devices, U())
@@ -238,11 +238,11 @@ function construct_device!(
 ) where {St <: PSY.Storage, D <: StorageDispatchWithReserves, S <: AbstractPowerModel}
     devices = get_available_components(model, sys)
     _active_power_variables_and_expressions(container, devices, model, network_model)
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ReactivePowerVariable, devices, D)
 
     if get_attribute(model, "regularization")
-        add_variables!(container, StorageRegularizationVariableCharge, devices, D())
-        add_variables!(container, StorageRegularizationVariableDischarge, devices, D())
+        add_variables!(container, StorageRegularizationVariableCharge, devices, D)
+        add_variables!(container, StorageRegularizationVariableDischarge, devices, D)
     end
 
     add_to_expression!(
@@ -342,8 +342,8 @@ function construct_device!(
     _active_power_variables_and_expressions(container, devices, model, network_model)
 
     if get_attribute(model, "regularization")
-        add_variables!(container, StorageRegularizationVariableCharge, devices, D())
-        add_variables!(container, StorageRegularizationVariableDischarge, devices, D())
+        add_variables!(container, StorageRegularizationVariableCharge, devices, D)
+        add_variables!(container, StorageRegularizationVariableDischarge, devices, D)
     end
 
     if has_service_model(model)

--- a/src/energy_storage_models/storage_constructor.jl
+++ b/src/energy_storage_models/storage_constructor.jl
@@ -20,7 +20,7 @@ function _add_ancillary_services!(
     ]
         lazy_container_addition!(
             container,
-            exp(),
+            exp,
             T,
             PSY.get_name.(devices),
             time_steps,
@@ -54,9 +54,7 @@ function _add_ancillary_services!(
         union!(services, PSY.get_services(d))
     end
     for s in services
-        lazy_container_addition!(
-            container,
-            TotalReserveOffering(),
+        lazy_container_addition!(container, TotalReserveOffering,
             T,
             PSY.get_name.(devices),
             time_steps;

--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -410,7 +410,7 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    ::F,
+    ::Type{F},
 ) where {
     T <: Union{AncillaryServiceVariableDischarge, AncillaryServiceVariableCharge},
     U <: PSY.Storage,
@@ -448,7 +448,7 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractStorageFormulation,
+    ::Type{<:AbstractStorageFormulation},
 ) where {
     T <: Union{StorageEnergyShortageVariable, StorageEnergySurplusVariable},
     U <: PSY.Storage,
@@ -477,7 +477,7 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractStorageFormulation,
+    ::Type{<:AbstractStorageFormulation},
 ) where {
     T <: Union{StorageChargeCyclingSlackVariable, StorageDischargeCyclingSlackVariable},
     U <: PSY.Storage,

--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -1,96 +1,96 @@
 #! format: off
 requires_initialization(::AbstractStorageFormulation) = false
 
-get_variable_multiplier(::VariableType, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = NaN
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = NaN
 ########################### ActivePowerInVariable, Storage #################################
-get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_lower_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerInVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_input_active_power_limits(d).max
-get_variable_multiplier(::ActivePowerInVariable, d::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = -1.0
+get_variable_binary(::Type{ActivePowerInVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerInVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerInVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_input_active_power_limits(d).max
+get_variable_multiplier(::Type{ActivePowerInVariable}, d::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = -1.0
 
 ########################### ActivePowerOutVariable, Storage #################################
-get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_output_active_power_limits(d).max
-get_variable_multiplier(::ActivePowerOutVariable, d::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = 1.0
+get_variable_binary(::Type{ActivePowerOutVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerOutVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerOutVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_output_active_power_limits(d).max
+get_variable_multiplier(::Type{ActivePowerOutVariable}, d::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = 1.0
 
 ########################### ReactivePowerVariable, Storage #################################
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_reactive_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_reactive_power_limits(d).max
-get_variable_multiplier(::ReactivePowerVariable, d::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = 1.0
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_reactive_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_reactive_power_limits(d).max
+get_variable_multiplier(::Type{ReactivePowerVariable}, d::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = 1.0
 
 ############## EnergyVariable, Storage ####################
-get_variable_binary(::EnergyVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_upper_bound(::EnergyVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_storage_level_limits(d).max * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
-get_variable_lower_bound(::EnergyVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_storage_level_limits(d).min * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
-get_variable_warm_start_value(::EnergyVariable, d::PSY.Storage, ::AbstractStorageFormulation) = PSY.get_initial_storage_capacity_level(d) * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
+get_variable_binary(::Type{EnergyVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_upper_bound(::Type{EnergyVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_storage_level_limits(d).max * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
+get_variable_lower_bound(::Type{EnergyVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_storage_level_limits(d).min * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
+get_variable_warm_start_value(::Type{EnergyVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = PSY.get_initial_storage_capacity_level(d) * PSY.get_storage_capacity(d) * PSY.get_conversion_factor(d)
 
 ############## ReservationVariable, Storage ####################
-get_variable_binary(::ReservationVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = true
+get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = true
 
 ############## Ancillary Services Variables ####################
-get_variable_binary(::AncillaryServiceVariableDischarge, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_binary(::AncillaryServiceVariableCharge, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_binary(::Type{AncillaryServiceVariableDischarge}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_binary(::Type{AncillaryServiceVariableCharge}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
 
-function get_variable_upper_bound(::AncillaryServiceVariableCharge, r::PSY.Reserve, d::PSY.Storage, ::AbstractStorageFormulation)
+function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_input_active_power_limits(d).max
 end
 
-function get_variable_upper_bound(::AncillaryServiceVariableDischarge, r::PSY.Reserve, d::PSY.Storage, ::AbstractStorageFormulation)
+function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_output_active_power_limits(d).max
 end
 
-function get_variable_upper_bound(::AncillaryServiceVariableCharge, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::AbstractStorageFormulation)
+function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_input_active_power_limits(d).max
 end
 
-function get_variable_upper_bound(::AncillaryServiceVariableDischarge, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::AbstractStorageFormulation)
+function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_output_active_power_limits(d).max
 end
 
-function get_variable_upper_bound(::ActivePowerReserveVariable, r::PSY.Reserve, d::PSY.Storage, ::AbstractReservesFormulation)
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d).max + PSY.get_input_active_power_limits(d).max)
 end
-function get_variable_upper_bound(::ActivePowerReserveVariable, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::AbstractReservesFormulation)
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d).max + PSY.get_input_active_power_limits(d).max)
 end
 
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.Storage}, ::Type{<:PSY.Reserve}) = TotalReserveOffering
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Storage}, ::Type{<:PSY.Reserve}) = TotalReserveOffering
 
 ############### Energy Targets Variables #############
-get_variable_binary(::StorageEnergyShortageVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_binary(::StorageEnergySurplusVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_binary(::Type{StorageEnergyShortageVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_binary(::Type{StorageEnergySurplusVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
 
 ############### Cycling Limits Variables #############
-get_variable_binary(::StorageChargeCyclingSlackVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_binary(::StorageDischargeCyclingSlackVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
+get_variable_binary(::Type{StorageChargeCyclingSlackVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_binary(::Type{StorageDischargeCyclingSlackVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
 
 ########################Objective Function##################################################
-objective_function_multiplier(::VariableType, ::AbstractStorageFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::StorageEnergySurplusVariable, ::AbstractStorageFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::StorageEnergyShortageVariable, ::AbstractStorageFormulation)=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{<:VariableType}, ::Type{<:AbstractStorageFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{StorageEnergySurplusVariable}, ::Type{<:AbstractStorageFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{StorageEnergyShortageVariable}, ::Type{<:AbstractStorageFormulation})=OBJECTIVE_FUNCTION_POSITIVE
 
-proportional_cost(cost::PSY.StorageCost, ::StorageEnergySurplusVariable, ::PSY.EnergyReservoirStorage, ::AbstractStorageFormulation)=PSY.get_energy_surplus_cost(cost)
-proportional_cost(cost::PSY.StorageCost, ::StorageEnergyShortageVariable, ::PSY.EnergyReservoirStorage, ::AbstractStorageFormulation)=PSY.get_energy_shortage_cost(cost)
-proportional_cost(::PSY.StorageCost, ::StorageChargeCyclingSlackVariable, ::PSY.EnergyReservoirStorage, ::AbstractStorageFormulation)=CYCLE_VIOLATION_COST
-proportional_cost(::PSY.StorageCost, ::StorageDischargeCyclingSlackVariable, ::PSY.EnergyReservoirStorage, ::AbstractStorageFormulation)=CYCLE_VIOLATION_COST
+proportional_cost(cost::PSY.StorageCost, ::Type{StorageEnergySurplusVariable}, ::PSY.EnergyReservoirStorage, ::Type{<:AbstractStorageFormulation})=PSY.get_energy_surplus_cost(cost)
+proportional_cost(cost::PSY.StorageCost, ::Type{StorageEnergyShortageVariable}, ::PSY.EnergyReservoirStorage, ::Type{<:AbstractStorageFormulation})=PSY.get_energy_shortage_cost(cost)
+proportional_cost(::PSY.StorageCost, ::Type{StorageChargeCyclingSlackVariable}, ::PSY.EnergyReservoirStorage, ::Type{<:AbstractStorageFormulation})=CYCLE_VIOLATION_COST
+proportional_cost(::PSY.StorageCost, ::Type{StorageDischargeCyclingSlackVariable}, ::PSY.EnergyReservoirStorage, ::Type{<:AbstractStorageFormulation})=CYCLE_VIOLATION_COST
 
 
-IOM.variable_cost(cost::PSY.StorageCost, ::ActivePowerOutVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation)=PSY.get_discharge_variable_cost(cost)
-IOM.variable_cost(cost::PSY.StorageCost, ::ActivePowerInVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation)=PSY.get_charge_variable_cost(cost)
+IOM.variable_cost(cost::PSY.StorageCost, ::Type{ActivePowerOutVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation})=PSY.get_discharge_variable_cost(cost)
+IOM.variable_cost(cost::PSY.StorageCost, ::Type{ActivePowerInVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation})=PSY.get_charge_variable_cost(cost)
 
 ######################## Parameters ##################################################
 
-get_parameter_multiplier(::EnergyTargetParameter, ::PSY.Storage, ::AbstractStorageFormulation) = 1.0
-get_parameter_multiplier(::EnergyLimitParameter, ::PSY.Storage, ::AbstractStorageFormulation) = 1.0
-get_parameter_multiplier(::LowerBoundValueParameter, ::PSY.Storage, ::AbstractStorageFormulation) = 1.0
-get_parameter_multiplier(::UpperBoundValueParameter, ::PSY.Storage, ::AbstractStorageFormulation) = 1.0
+get_parameter_multiplier(::Type{EnergyTargetParameter}, ::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 1.0
+get_parameter_multiplier(::Type{EnergyLimitParameter}, ::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 1.0
+get_parameter_multiplier(::Type{LowerBoundValueParameter}, ::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 1.0
+get_parameter_multiplier(::Type{UpperBoundValueParameter}, ::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 1.0
 
 ############## ReservationVariable, Storage ####################
-get_variable_binary(::StorageRegularizationVariable, ::Type{<:PSY.Storage}, ::AbstractStorageFormulation) = false
-get_variable_upper_bound(::StorageRegularizationVariable, d::PSY.Storage, ::AbstractStorageFormulation) = max(PSY.get_input_active_power_limits(d).max, PSY.get_output_active_power_limits(d).max)
-get_variable_lower_bound(::StorageRegularizationVariable, d::PSY.Storage, ::AbstractStorageFormulation) = 0.0
+get_variable_binary(::Type{<:StorageRegularizationVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
+get_variable_upper_bound(::Type{<:StorageRegularizationVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = max(PSY.get_input_active_power_limits(d).max, PSY.get_output_active_power_limits(d).max)
+get_variable_lower_bound(::Type{<:StorageRegularizationVariable}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation}) = 0.0
 
 #! format: on
 
@@ -107,9 +107,9 @@ _include_min_gen_power_in_constraint(
 
 function IOM.variable_cost(
     ::PSY.StorageCost,
-    ::StorageRegularizationVariable,
+    ::Type{<:StorageRegularizationVariable},
     ::Type{<:PSY.Storage},
-    ::AbstractStorageFormulation,
+    ::Type{<:AbstractStorageFormulation},
 )
     return PSY.CostCurve(PSY.LinearCurve(STORAGE_REG_COST), PSY.UnitSystem.SYSTEM_BASE)
 end
@@ -238,12 +238,12 @@ function add_reserve_range_constraint_with_deployment!(
 }
     time_steps = get_time_steps(container)
     names = [PSY.get_name(x) for x in devices]
-    powerout_var = get_variable(container, U(), V)
-    ss_var = get_variable(container, ReservationVariable(), V)
-    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge(), V)
-    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge(), V)
+    powerout_var = get_variable(container, U, V)
+    ss_var = get_variable(container, ReservationVariable, V)
+    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge, V)
+    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge, V)
 
-    constraint = add_constraints_container!(container, T(), V, names, time_steps)
+    constraint = add_constraints_container!(container, T, V, names, time_steps)
 
     for d in devices, t in time_steps
         ci_name = PSY.get_name(d)
@@ -272,12 +272,12 @@ function add_reserve_range_constraint_with_deployment!(
     time_steps = get_time_steps(container)
     names = [PSY.get_name(x) for x in devices]
 
-    powerin_var = get_variable(container, U(), V)
-    ss_var = get_variable(container, ReservationVariable(), V)
-    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge(), V)
-    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge(), V)
+    powerin_var = get_variable(container, U, V)
+    ss_var = get_variable(container, ReservationVariable, V)
+    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge, V)
+    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge, V)
 
-    constraint = add_constraints_container!(container, T(), V, names, time_steps)
+    constraint = add_constraints_container!(container, T, V, names, time_steps)
 
     for d in devices, t in time_steps
         ci_name = PSY.get_name(d)
@@ -305,11 +305,11 @@ function add_reserve_range_constraint_with_deployment_no_reservation!(
 }
     time_steps = get_time_steps(container)
     names = [PSY.get_name(x) for x in devices]
-    powerout_var = get_variable(container, U(), V)
-    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge(), V)
-    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge(), V)
+    powerout_var = get_variable(container, U, V)
+    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge, V)
+    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge, V)
 
-    constraint = add_constraints_container!(container, T(), V, names, time_steps)
+    constraint = add_constraints_container!(container, T, V, names, time_steps)
 
     for d in devices, t in time_steps
         ci_name = PSY.get_name(d)
@@ -338,11 +338,11 @@ function add_reserve_range_constraint_with_deployment_no_reservation!(
     time_steps = get_time_steps(container)
     names = [PSY.get_name(x) for x in devices]
 
-    powerin_var = get_variable(container, U(), V)
-    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge(), V)
-    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge(), V)
+    powerin_var = get_variable(container, U, V)
+    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge, V)
+    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge, V)
 
-    constraint = add_constraints_container!(container, T(), V, names, time_steps)
+    constraint = add_constraints_container!(container, T, V, names, time_steps)
 
     for d in devices, t in time_steps
         ci_name = PSY.get_name(d)
@@ -410,10 +410,11 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractStorageFormulation,
+    ::F,
 ) where {
     T <: Union{AncillaryServiceVariableDischarge, AncillaryServiceVariableCharge},
     U <: PSY.Storage,
+    F <: AbstractStorageFormulation,
 }
     @assert !isempty(devices)
     time_steps = get_time_steps(container)
@@ -422,9 +423,7 @@ function add_variables!(
         union!(services, PSY.get_services(d))
     end
     for service in services
-        variable = add_variable_container!(
-            container,
-            T(),
+        variable = add_variable_container!(container, T,
             U,
             PSY.get_name.(devices),
             time_steps;
@@ -438,7 +437,7 @@ function add_variables!(
                 base_name = "$(T)_$(PSY.get_name(service))_{$(PSY.get_name(d)), $(t)}",
                 lower_bound = 0.0,
                 upper_bound =
-                    get_variable_upper_bound(T(), service, d, formulation)
+                    get_variable_upper_bound(T, service, d, F)
             )
         end
     end
@@ -457,9 +456,7 @@ function add_variables!(
     @assert !isempty(devices)
     time_steps = get_time_steps(container)
     last_time_range = time_steps[end]:time_steps[end]
-    variable = add_variable_container!(
-        container,
-        T(),
+    variable = add_variable_container!(container, T,
         U,
         PSY.get_name.(devices),
         last_time_range,
@@ -488,9 +485,7 @@ function add_variables!(
     @assert !isempty(devices)
     time_steps = get_time_steps(container)
     last_time_range = time_steps[end]:time_steps[end]
-    variable = add_variable_container!(
-        container,
-        T(),
+    variable = add_variable_container!(container, T,
         U,
         PSY.get_name.(devices),
         last_time_range,
@@ -511,7 +506,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveAssignmentBalanceDownCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 0.0
 
@@ -519,7 +514,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveAssignmentBalanceDownCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 1.0
 
@@ -527,7 +522,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveAssignmentBalanceUpCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 1.0
 
@@ -535,7 +530,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveAssignmentBalanceUpCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 0.0
 
@@ -543,7 +538,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveAssignmentBalanceDownDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 0.0
 
@@ -551,7 +546,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveAssignmentBalanceDownDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 1.0
 
@@ -559,7 +554,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveAssignmentBalanceUpDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 1.0
 
@@ -567,7 +562,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveAssignmentBalanceUpDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 0.0
 
@@ -576,7 +571,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveDeploymentBalanceDownCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 0.0
 
@@ -584,7 +579,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveDeploymentBalanceDownCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 1.0
 
@@ -592,7 +587,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveDeploymentBalanceUpCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 1.0
 
@@ -600,7 +595,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableCharge},
     ::Type{ReserveDeploymentBalanceUpCharge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 0.0
 
@@ -608,7 +603,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveDeploymentBalanceDownDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 0.0
 
@@ -616,7 +611,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveDeploymentBalanceDownDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 1.0
 
@@ -624,7 +619,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveDeploymentBalanceUpDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveUp},
 ) = 1.0
 
@@ -632,7 +627,7 @@ get_variable_multiplier(
     ::Type{AncillaryServiceVariableDischarge},
     ::Type{ReserveDeploymentBalanceUpDischarge},
     d::PSY.Storage,
-    ::StorageDispatchWithReserves,
+    ::Type{StorageDispatchWithReserves},
     ::PSY.Reserve{PSY.ReserveDown},
 ) = 0.0
 
@@ -663,9 +658,9 @@ function add_to_expression!(
     V <: PSY.Storage,
     W <: AbstractDeviceFormulation,
 }
-    variable = get_variable(container, U(), V)
-    area_expr = get_expression(container, T(), PSY.Area)
-    nodal_expr = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    area_expr = get_expression(container, T, PSY.Area)
+    nodal_expr = get_expression(container, T, PSY.ACBus)
     network_reduction = get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
@@ -676,12 +671,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 area_expr[area_name, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 nodal_expr[bus_no, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -700,14 +695,14 @@ function add_to_expression!(
     V <: PSY.Storage,
     W <: StorageDispatchWithReserves,
 }
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices
         name = PSY.get_name(d)
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            variable = get_variable(container, U(), V, "$(typeof(s))_$s_name")
-            mult = get_variable_multiplier(U, T, d, W(), s) * get_fraction(T, s)
+            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
+            mult = get_variable_multiplier(U, T, d, W, s) * get_fraction(T, s)
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
                     expression[name, t],
@@ -732,14 +727,14 @@ function add_to_expression!(
     V <: PSY.Storage,
     W <: StorageDispatchWithReserves,
 }
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices
         name = PSY.get_name(d)
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            variable = get_variable(container, U(), V, "$(typeof(s))_$s_name")
-            mult = get_variable_multiplier(U, T, d, W(), s) * get_fraction(T, s)
+            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
+            mult = get_variable_multiplier(U, T, d, W, s) * get_fraction(T, s)
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
                     expression[name, t],
@@ -769,8 +764,8 @@ function add_to_expression!(
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            expression = get_expression(container, T(), V, "$(typeof(s))_$(s_name)")
-            variable = get_variable(container, U(), V, "$(typeof(s))_$s_name")
+            expression = get_expression(container, T, V, "$(typeof(s))_$(s_name)")
+            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
                     expression[name, t],
@@ -799,8 +794,8 @@ function add_to_expression!(
     for d in devices
         name = PSY.get_name(d)
         s_name = get_service_name(service_model)
-        expression = get_expression(container, T(), UV, "$(V)_$(s_name)")
-        variable = get_variable(container, U(), V, s_name)
+        expression = get_expression(container, T, UV, "$(V)_$(s_name)")
+        variable = get_variable(container, U, V, s_name)
         for t in get_time_steps(container)
             add_proportional_to_jump_expression!(
                 expression[name, t],
@@ -840,19 +835,17 @@ function add_energybalance_with_reserves!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
     initial_conditions = get_initial_condition(container, InitialEnergyLevel(), V)
-    energy_var = get_variable(container, EnergyVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
 
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
 
-    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge(), V)
-    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge(), V)
-    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge(), V)
-    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge(), V)
+    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge, V)
+    r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge, V)
+    r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge, V)
+    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge, V)
 
-    constraint = add_constraints_container!(
-        container,
-        EnergyBalanceConstraint(),
+    constraint = add_constraints_container!(container, EnergyBalanceConstraint,
         V,
         names,
         time_steps,
@@ -908,14 +901,12 @@ function add_energybalance_without_reserves!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
     initial_conditions = get_initial_condition(container, InitialEnergyLevel(), V)
-    energy_var = get_variable(container, EnergyVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
 
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
 
-    constraint = add_constraints_container!(
-        container,
-        EnergyBalanceConstraint(),
+    constraint = add_constraints_container!(container, EnergyBalanceConstraint,
         V,
         names,
         time_steps,
@@ -962,22 +953,18 @@ function add_constraints!(
 ) where {V <: PSY.Storage, X <: AbstractPowerModel}
     names = String[PSY.get_name(x) for x in devices]
     time_steps = get_time_steps(container)
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
-    r_up_ds = get_expression(container, ReserveAssignmentBalanceUpDischarge(), V)
-    r_dn_ds = get_expression(container, ReserveAssignmentBalanceDownDischarge(), V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
+    r_up_ds = get_expression(container, ReserveAssignmentBalanceUpDischarge, V)
+    r_dn_ds = get_expression(container, ReserveAssignmentBalanceDownDischarge, V)
 
-    constraint_ds_ub = add_constraints_container!(
-        container,
-        ReserveDischargeConstraint(),
+    constraint_ds_ub = add_constraints_container!(container, ReserveDischargeConstraint,
         V,
         names,
         time_steps;
         meta = "ub",
     )
 
-    constraint_ds_lb = add_constraints_container!(
-        container,
-        ReserveDischargeConstraint(),
+    constraint_ds_lb = add_constraints_container!(container, ReserveDischargeConstraint,
         V,
         names,
         time_steps;
@@ -1009,22 +996,18 @@ function add_constraints!(
 ) where {V <: PSY.Storage, X <: AbstractPowerModel}
     names = String[PSY.get_name(x) for x in devices]
     time_steps = get_time_steps(container)
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
-    r_up_ch = get_expression(container, ReserveAssignmentBalanceUpCharge(), V)
-    r_dn_ch = get_expression(container, ReserveAssignmentBalanceDownCharge(), V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
+    r_up_ch = get_expression(container, ReserveAssignmentBalanceUpCharge, V)
+    r_dn_ch = get_expression(container, ReserveAssignmentBalanceDownCharge, V)
 
-    constraint_ch_ub = add_constraints_container!(
-        container,
-        ReserveChargeConstraint(),
+    constraint_ch_ub = add_constraints_container!(container, ReserveChargeConstraint,
         V,
         names,
         time_steps;
         meta = "ub",
     )
 
-    constraint_ch_lb = add_constraints_container!(
-        container,
-        ReserveChargeConstraint(),
+    constraint_ch_lb = add_constraints_container!(container, ReserveChargeConstraint,
         V,
         names,
         time_steps;
@@ -1068,7 +1051,7 @@ function add_constraints!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
     initial_conditions = get_initial_condition(container, InitialEnergyLevel(), V)
-    energy_var = get_variable(container, EnergyVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
 
     services_set = Set()
     for ic in initial_conditions
@@ -1079,18 +1062,14 @@ function add_constraints!(
     for service in services_set
         service_name = PSY.get_name(service)
         if typeof(service) <: PSY.Reserve{PSY.ReserveUp}
-            add_constraints_container!(
-                container,
-                T(),
+            add_constraints_container!(container, T,
                 V,
                 names,
                 time_steps;
                 meta = "$(typeof(service))_$(service_name)_discharge",
             )
         elseif typeof(service) <: PSY.Reserve{PSY.ReserveDown}
-            add_constraints_container!(
-                container,
-                T(),
+            add_constraints_container!(container, T,
                 V,
                 names,
                 time_steps;
@@ -1118,15 +1097,12 @@ function add_constraints!(
             sustained_param_discharge = inv_efficiency * fraction_of_hour * num_periods
             sustained_param_charge = eff_in * fraction_of_hour * num_periods
             service_name = PSY.get_name(service)
-            reserve_var_discharge = get_variable(
-                container,
-                AncillaryServiceVariableDischarge(),
-                V,
-                "$(typeof(service))_$service_name",
-            )
-            reserve_var_charge = get_variable(
-                container,
-                AncillaryServiceVariableCharge(),
+            reserve_var_discharge =
+                get_variable(container, AncillaryServiceVariableDischarge,
+                    V,
+                    "$(typeof(service))_$service_name",
+                )
+            reserve_var_charge = get_variable(container, AncillaryServiceVariableCharge,
                 V,
                 "$(typeof(service))_$service_name",
             )
@@ -1216,7 +1192,7 @@ function add_constraints!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
     initial_conditions = get_initial_condition(container, InitialEnergyLevel(), V)
-    energy_var = get_variable(container, EnergyVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
 
     services_set = Set()
     for ic in initial_conditions
@@ -1228,18 +1204,14 @@ function add_constraints!(
 
     for serv_type in services_types
         if serv_type <: PSY.Reserve{PSY.ReserveUp}
-            add_constraints_container!(
-                container,
-                T(),
+            add_constraints_container!(container, T,
                 V,
                 names,
                 time_steps;
                 meta = "$(serv_type)_discharge",
             )
         elseif serv_type <: PSY.Reserve{PSY.ReserveDown}
-            add_constraints_container!(
-                container,
-                T(),
+            add_constraints_container!(container, T,
                 V,
                 names,
                 time_steps;
@@ -1269,15 +1241,12 @@ function add_constraints!(
             sustained_param_discharge = inv_efficiency * fraction_of_hour * num_periods
             sustained_param_charge = eff_in * fraction_of_hour * num_periods
             service_name = PSY.get_name(service)
-            reserve_var_discharge = get_variable(
-                container,
-                AncillaryServiceVariableDischarge(),
-                V,
-                "$(typeof(service))_$service_name",
-            )
-            reserve_var_charge = get_variable(
-                container,
-                AncillaryServiceVariableCharge(),
+            reserve_var_discharge =
+                get_variable(container, AncillaryServiceVariableDischarge,
+                    V,
+                    "$(typeof(service))_$service_name",
+                )
+            reserve_var_charge = get_variable(container, AncillaryServiceVariableCharge,
                 V,
                 "$(typeof(service))_$service_name",
             )
@@ -1380,21 +1349,18 @@ function add_constraints!(
 
     for s in services
         s_name = PSY.get_name(s)
-        expression = get_expression(
-            container,
-            TotalReserveOffering(),
+        expression = get_expression(container, TotalReserveOffering,
             V,
             "$(typeof(s))_$(s_name)",
         )
         device_names, time_steps = axes(expression)
-        constraint_container = add_constraints_container!(
-            container,
-            StorageTotalReserveConstraint(),
-            typeof(s),
-            device_names,
-            time_steps;
-            meta = "$(s_name)_$V",
-        )
+        constraint_container =
+            add_constraints_container!(container, StorageTotalReserveConstraint,
+                typeof(s),
+                device_names,
+                time_steps;
+                meta = "$(s_name)_$V",
+            )
         for name in device_names, t in time_steps
             constraint_container[name, t] =
                 JuMP.@constraint(get_jump_model(container), expression[name, t] == 0.0)
@@ -1410,17 +1376,16 @@ function add_constraints!(
     model::DeviceModel{V, StorageDispatchWithReserves},
     network_model::NetworkModel{X},
 ) where {V <: PSY.EnergyReservoirStorage, X <: AbstractPowerModel}
-    energy_var = get_variable(container, EnergyVariable(), V)
-    surplus_var = get_variable(container, StorageEnergySurplusVariable(), V)
-    shortfall_var = get_variable(container, StorageEnergyShortageVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
+    surplus_var = get_variable(container, StorageEnergySurplusVariable, V)
+    shortfall_var = get_variable(container, StorageEnergyShortageVariable, V)
 
     device_names, time_steps = axes(energy_var)
-    constraint_container = add_constraints_container!(
-        container,
-        StateofChargeTargetConstraint(),
-        V,
-        device_names,
-    )
+    constraint_container =
+        add_constraints_container!(container, StateofChargeTargetConstraint,
+            V,
+            device_names,
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1447,10 +1412,10 @@ function add_cycling_charge_without_reserves!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
 
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
-    slack_var = get_variable(container, StorageChargeCyclingSlackVariable(), V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
+    slack_var = get_variable(container, StorageChargeCyclingSlackVariable, V)
 
-    constraint = add_constraints_container!(container, StorageCyclingCharge(), V, names)
+    constraint = add_constraints_container!(container, StorageCyclingCharge, V, names)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1482,11 +1447,11 @@ function add_cycling_charge_with_reserves!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
 
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
-    slack_var = get_variable(container, StorageChargeCyclingSlackVariable(), V)
-    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge(), V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
+    slack_var = get_variable(container, StorageChargeCyclingSlackVariable, V)
+    r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge, V)
 
-    constraint = add_constraints_container!(container, StorageCyclingCharge(), V, names)
+    constraint = add_constraints_container!(container, StorageCyclingCharge, V, names)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1535,11 +1500,11 @@ function add_cycling_discharge_without_reserves!(
     resolution = get_resolution(container)
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
-    slack_var = get_variable(container, StorageDischargeCyclingSlackVariable(), V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
+    slack_var = get_variable(container, StorageDischargeCyclingSlackVariable, V)
 
     constraint =
-        add_constraints_container!(container, StorageCyclingDischarge(), V, names)
+        add_constraints_container!(container, StorageCyclingDischarge, V, names)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1571,12 +1536,12 @@ function add_cycling_discharge_with_reserves!(
     resolution = get_resolution(container)
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
-    slack_var = get_variable(container, StorageDischargeCyclingSlackVariable(), V)
-    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge(), V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
+    slack_var = get_variable(container, StorageDischargeCyclingSlackVariable, V)
+    r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge, V)
 
     constraint =
-        add_constraints_container!(container, StorageCyclingDischarge(), V, names)
+        add_constraints_container!(container, StorageCyclingDischarge, V, names)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1622,32 +1587,30 @@ function add_constraints!(
 ) where {V <: PSY.Storage, X <: AbstractPowerModel}
     names = [PSY.get_name(x) for x in devices]
     time_steps = get_time_steps(container)
-    reg_var = get_variable(container, StorageRegularizationVariableCharge(), V)
-    powerin_var = get_variable(container, ActivePowerInVariable(), V)
+    reg_var = get_variable(container, StorageRegularizationVariableCharge, V)
+    powerin_var = get_variable(container, ActivePowerInVariable, V)
     has_services = has_service_model(model)
 
     if has_services
-        r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge(), V)
-        r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge(), V)
+        r_up_ch = get_expression(container, ReserveDeploymentBalanceUpCharge, V)
+        r_dn_ch = get_expression(container, ReserveDeploymentBalanceDownCharge, V)
     end
 
-    constraint_ub = add_constraints_container!(
-        container,
-        StorageRegularizationConstraintCharge(),
-        V,
-        names,
-        time_steps;
-        meta = "ub",
-    )
+    constraint_ub =
+        add_constraints_container!(container, StorageRegularizationConstraintCharge,
+            V,
+            names,
+            time_steps;
+            meta = "ub",
+        )
 
-    constraint_lb = add_constraints_container!(
-        container,
-        StorageRegularizationConstraintCharge(),
-        V,
-        names,
-        time_steps;
-        meta = "lb",
-    )
+    constraint_lb =
+        add_constraints_container!(container, StorageRegularizationConstraintCharge,
+            V,
+            names,
+            time_steps;
+            meta = "lb",
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1699,31 +1662,29 @@ function add_constraints!(
 ) where {V <: PSY.Storage, X <: AbstractPowerModel}
     names = [PSY.get_name(x) for x in devices]
     time_steps = get_time_steps(container)
-    reg_var = get_variable(container, StorageRegularizationVariableDischarge(), V)
-    powerout_var = get_variable(container, ActivePowerOutVariable(), V)
+    reg_var = get_variable(container, StorageRegularizationVariableDischarge, V)
+    powerout_var = get_variable(container, ActivePowerOutVariable, V)
     has_services = has_service_model(model)
     if has_services
-        r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge(), V)
-        r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge(), V)
+        r_up_ds = get_expression(container, ReserveDeploymentBalanceUpDischarge, V)
+        r_dn_ds = get_expression(container, ReserveDeploymentBalanceDownDischarge, V)
     end
 
-    constraint_ub = add_constraints_container!(
-        container,
-        StorageRegularizationConstraintDischarge(),
-        V,
-        names,
-        time_steps;
-        meta = "ub",
-    )
+    constraint_ub =
+        add_constraints_container!(container, StorageRegularizationConstraintDischarge,
+            V,
+            names,
+            time_steps;
+            meta = "ub",
+        )
 
-    constraint_lb = add_constraints_container!(
-        container,
-        StorageRegularizationConstraintDischarge(),
-        V,
-        names,
-        time_steps;
-        meta = "lb",
-    )
+    constraint_lb =
+        add_constraints_container!(container, StorageRegularizationConstraintDischarge,
+            V,
+            names,
+            time_steps;
+            meta = "lb",
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1772,20 +1733,20 @@ function objective_function!(
     model::DeviceModel{T, U},
     ::Type{V},
 ) where {T <: PSY.Storage, U <: AbstractStorageFormulation, V <: AbstractPowerModel}
-    add_variable_cost!(container, ActivePowerOutVariable(), devices, U())
-    add_variable_cost!(container, ActivePowerInVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerOutVariable, devices, U)
+    add_variable_cost!(container, ActivePowerInVariable, devices, U)
     if get_attribute(model, "regularization")
         add_variable_cost!(
             container,
-            StorageRegularizationVariableCharge(),
+            StorageRegularizationVariableCharge,
             devices,
-            U(),
+            U,
         )
         add_variable_cost!(
             container,
-            StorageRegularizationVariableDischarge(),
+            StorageRegularizationVariableDischarge,
             devices,
-            U(),
+            U,
         )
     end
 
@@ -1799,38 +1760,38 @@ function objective_function!(
     ::Type{V},
 ) where {T <: AbstractStorageFormulation, V <: AbstractPowerModel}
     # TODO problem with time varying MBC.
-    add_variable_cost!(container, ActivePowerOutVariable(), devices, T())
-    add_variable_cost!(container, ActivePowerInVariable(), devices, T())
+    add_variable_cost!(container, ActivePowerOutVariable, devices, T)
+    add_variable_cost!(container, ActivePowerInVariable, devices, T)
     if get_attribute(model, "energy_target")
-        add_proportional_cost!(container, StorageEnergySurplusVariable(), devices, T())
-        add_proportional_cost!(container, StorageEnergyShortageVariable(), devices, T())
+        add_proportional_cost!(container, StorageEnergySurplusVariable, devices, T)
+        add_proportional_cost!(container, StorageEnergyShortageVariable, devices, T)
     end
     if get_attribute(model, "cycling_limits")
         add_proportional_cost!(
             container,
-            StorageChargeCyclingSlackVariable(),
+            StorageChargeCyclingSlackVariable,
             devices,
-            T(),
+            T,
         )
         add_proportional_cost!(
             container,
-            StorageDischargeCyclingSlackVariable(),
+            StorageDischargeCyclingSlackVariable,
             devices,
-            T(),
+            T,
         )
     end
     if get_attribute(model, "regularization")
         add_variable_cost!(
             container,
-            StorageRegularizationVariableCharge(),
+            StorageRegularizationVariableCharge,
             devices,
-            T(),
+            T,
         )
         add_variable_cost!(
             container,
-            StorageRegularizationVariableDischarge(),
+            StorageRegularizationVariableDischarge,
             devices,
-            T(),
+            T,
         )
     end
     return
@@ -1839,19 +1800,20 @@ end
 # no test coverage
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::T,
+    ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractStorageFormulation,
+    ::Type{F},
 ) where {
     T <: Union{StorageChargeCyclingSlackVariable, StorageDischargeCyclingSlackVariable},
     U <: PSY.EnergyReservoirStorage,
+    F <: AbstractStorageFormulation,
 }
     time_steps = get_time_steps(container)
-    variable = get_variable(container, T(), U)
+    variable = get_variable(container, T, U)
     for d in devices
         name = PSY.get_name(d)
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, T(), d, formulation)
+        cost_term = proportional_cost(op_cost_data, T, d, F)
         add_to_objective_invariant_expression!(
             container,
             variable[name, time_steps[end]] * cost_term,
@@ -1861,19 +1823,20 @@ end
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::T,
+    ::Type{T},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractStorageFormulation,
+    ::Type{F},
 ) where {
     T <: Union{StorageEnergyShortageVariable, StorageEnergySurplusVariable},
     U <: PSY.EnergyReservoirStorage,
+    F <: AbstractStorageFormulation,
 }
     time_steps = get_time_steps(container)
-    variable = get_variable(container, T(), U)
+    variable = get_variable(container, T, U)
     for d in devices
         name = PSY.get_name(d)
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, T(), d, formulation)
+        cost_term = proportional_cost(op_cost_data, T, d, F)
         add_to_objective_invariant_expression!(
             container,
             variable[name, time_steps[end]] * cost_term,
@@ -1889,8 +1852,8 @@ function calculate_aux_variable_value!(
     time_steps = get_time_steps(container)
     resolution = get_resolution(container)
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
-    p_variable_output = get_variable(container, ActivePowerOutVariable(), T)
-    aux_variable_container = get_aux_variable(container, StorageEnergyOutput(), T)
+    p_variable_output = get_variable(container, ActivePowerOutVariable, T)
+    aux_variable_container = get_aux_variable(container, StorageEnergyOutput, T)
     device_names = axes(aux_variable_container, 1)
     for name in device_names, t in time_steps
         aux_variable_container[name, t] =

--- a/src/mt_hvdc_models/HVDCsystems.jl
+++ b/src/mt_hvdc_models/HVDCsystems.jl
@@ -1,9 +1,9 @@
 #! format: off
-get_variable_binary(::ActivePowerVariable, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_warm_start_value(::ActivePowerVariable, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_active_power(d)
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_active_power_limits(d).max
-get_variable_multiplier(::VariableType, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = 1.0
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_warm_start_value(::Type{ActivePowerVariable}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_active_power(d)
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_active_power_limits(d).max
+get_variable_multiplier(::Type{<:VariableType}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = 1.0
 
 
 function _get_flow_bounds(d::PSY.TModelHVDCLine)
@@ -41,14 +41,14 @@ function _get_flow_bounds(d::PSY.TModelHVDCLine)
 end
 
 
-get_variable_binary(::FlowActivePowerVariable, ::Type{PSY.TModelHVDCLine}, ::AbstractBranchFormulation) = false
-get_variable_binary(::DCLineCurrent, ::Type{PSY.TModelHVDCLine}, ::AbstractBranchFormulation) = false
-get_variable_warm_start_value(::FlowActivePowerVariable, d::PSY.TModelHVDCLine, ::AbstractBranchFormulation) = PSY.get_active_power_flow(d)
-get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.TModelHVDCLine, ::AbstractBranchFormulation) = _get_flow_bounds(d)[1]
-get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.TModelHVDCLine, ::AbstractBranchFormulation) = _get_flow_bounds(d)[2]
+get_variable_binary(::Type{FlowActivePowerVariable}, ::Type{PSY.TModelHVDCLine}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_binary(::Type{DCLineCurrent}, ::Type{PSY.TModelHVDCLine}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_warm_start_value(::Type{FlowActivePowerVariable}, d::PSY.TModelHVDCLine, ::Type{<:AbstractBranchFormulation}) = PSY.get_active_power_flow(d)
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, d::PSY.TModelHVDCLine, ::Type{<:AbstractBranchFormulation}) = _get_flow_bounds(d)[1]
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, d::PSY.TModelHVDCLine, ::Type{<:AbstractBranchFormulation}) = _get_flow_bounds(d)[2]
 
 # This is an approximation for DC lines since the actual current limit depends on the voltage, that is a variable in the optimization problem
-function get_variable_lower_bound(::DCLineCurrent, d::PSY.TModelHVDCLine, ::AbstractBranchFormulation)
+function get_variable_lower_bound(::Type{DCLineCurrent}, d::PSY.TModelHVDCLine, ::Type{<:AbstractBranchFormulation})
     p_min_flow = _get_flow_bounds(d)[1]
     arc = PSY.get_arc(d)
     bus_from = arc.from
@@ -57,7 +57,7 @@ function get_variable_lower_bound(::DCLineCurrent, d::PSY.TModelHVDCLine, ::Abst
     return p_min_flow / max_v
 end
 # This is an approximation for DC lines since the actual current limit depends on the voltage, that is a variable in the optimization problem
-function get_variable_upper_bound(::DCLineCurrent, d::PSY.TModelHVDCLine, ::AbstractBranchFormulation)
+function get_variable_upper_bound(::Type{DCLineCurrent}, d::PSY.TModelHVDCLine, ::Type{<:AbstractBranchFormulation})
     p_max_flow = _get_flow_bounds(d)[2]
     arc = PSY.get_arc(d)
     bus_from = arc.from
@@ -65,7 +65,7 @@ function get_variable_upper_bound(::DCLineCurrent, d::PSY.TModelHVDCLine, ::Abst
     max_v = max(PSY.get_magnitude(bus_from), PSY.get_magnitude(bus_to))
     return p_max_flow / max_v
 end
-get_variable_multiplier(::VariableType, ::Type{PSY.TModelHVDCLine}, ::AbstractBranchFormulation) = 1.0
+get_variable_multiplier(::Type{<:VariableType}, ::Type{PSY.TModelHVDCLine}, ::Type{<:AbstractBranchFormulation}) = 1.0
 
 requires_initialization(::AbstractConverterFormulation) = false
 requires_initialization(::LosslessLine) = false
@@ -119,52 +119,52 @@ end
 ############################################
 
 ## Binaries ###
-get_variable_binary(::ConverterDCPower, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::ConverterPowerDirection, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = true
-get_variable_binary(::ConverterCurrent, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::ConverterPositiveCurrent, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::ConverterNegativeCurrent, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::ConverterCurrentDirection, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = true
-get_variable_binary(::SquaredConverterCurrent, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::SquaredDCVoltage, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::AuxBilinearConverterVariable, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
-get_variable_binary(::AuxBilinearSquaredConverterVariable, ::Type{PSY.InterconnectingConverter}, ::AbstractConverterFormulation) = false
+get_variable_binary(::Type{ConverterDCPower}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{ConverterPowerDirection}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = true
+get_variable_binary(::Type{ConverterCurrent}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{ConverterPositiveCurrent}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{ConverterNegativeCurrent}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{ConverterCurrentDirection}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = true
+get_variable_binary(::Type{SquaredConverterCurrent}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{SquaredDCVoltage}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{AuxBilinearConverterVariable}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
+get_variable_binary(::Type{AuxBilinearSquaredConverterVariable}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
 function get_variable_binary(
     ::W,
     ::Type{PSY.InterconnectingConverter},
-    ::AbstractConverterFormulation
+    ::Type{<:AbstractConverterFormulation}
 ) where W <: InterpolationVariableType
     return false
 end
 function get_variable_binary(
     ::W,
     ::Type{PSY.InterconnectingConverter},
-    ::AbstractConverterFormulation
+    ::Type{<:AbstractConverterFormulation}
 ) where W <: BinaryInterpolationVariableType
     return true
 end
 
 
 ### Warm Start ###
-get_variable_warm_start_value(::ConverterCurrent, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_dc_current(d)
+get_variable_warm_start_value(::Type{ConverterCurrent}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_dc_current(d)
 
 ### Lower Bounds ###
-get_variable_lower_bound(::ConverterDCPower, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_active_power_limits(d).min
-get_variable_lower_bound(::ConverterCurrent, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = -PSY.get_max_dc_current(d)
-get_variable_lower_bound(::SquaredConverterCurrent, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = 0.0
-get_variable_lower_bound(::SquaredDCVoltage, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_voltage_limits(d.dc_bus).min^2
-get_variable_lower_bound(::InterpolationVariableType, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = 0.0
-get_variable_lower_bound(::ConverterPositiveCurrent, d::PSY.InterconnectingConverter,::AbstractConverterFormulation) = 0.0
-get_variable_lower_bound(::ConverterNegativeCurrent, d::PSY.InterconnectingConverter,::AbstractConverterFormulation) = 0.0
+get_variable_lower_bound(::Type{ConverterDCPower}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_active_power_limits(d).min
+get_variable_lower_bound(::Type{ConverterCurrent}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = -PSY.get_max_dc_current(d)
+get_variable_lower_bound(::Type{SquaredConverterCurrent}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = 0.0
+get_variable_lower_bound(::Type{SquaredDCVoltage}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_voltage_limits(d.dc_bus).min^2
+get_variable_lower_bound(::Type{<:InterpolationVariableType}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = 0.0
+get_variable_lower_bound(::Type{ConverterPositiveCurrent}, d::PSY.InterconnectingConverter,::Type{<:AbstractConverterFormulation}) = 0.0
+get_variable_lower_bound(::Type{ConverterNegativeCurrent}, d::PSY.InterconnectingConverter,::Type{<:AbstractConverterFormulation}) = 0.0
 
 ### Upper Bounds ###
-get_variable_upper_bound(::ConverterDCPower, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_active_power_limits(d).max
-get_variable_upper_bound(::ConverterCurrent, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_max_dc_current(d)
-get_variable_upper_bound(::SquaredConverterCurrent, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_max_dc_current(d)^2
-get_variable_upper_bound(::SquaredDCVoltage, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = PSY.get_voltage_limits(d.dc_bus).max^2
-get_variable_upper_bound(::InterpolationVariableType, d::PSY.InterconnectingConverter, ::AbstractConverterFormulation) = 1.0
-get_variable_upper_bound(::ConverterPositiveCurrent, d::PSY.InterconnectingConverter,::AbstractConverterFormulation) = PSY.get_max_dc_current(d)
-get_variable_upper_bound(::ConverterNegativeCurrent, d::PSY.InterconnectingConverter,::AbstractConverterFormulation) = PSY.get_max_dc_current(d)
+get_variable_upper_bound(::Type{ConverterDCPower}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_active_power_limits(d).max
+get_variable_upper_bound(::Type{ConverterCurrent}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_max_dc_current(d)
+get_variable_upper_bound(::Type{SquaredConverterCurrent}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_max_dc_current(d)^2
+get_variable_upper_bound(::Type{SquaredDCVoltage}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = PSY.get_voltage_limits(d.dc_bus).max^2
+get_variable_upper_bound(::Type{<:InterpolationVariableType}, d::PSY.InterconnectingConverter, ::Type{<:AbstractConverterFormulation}) = 1.0
+get_variable_upper_bound(::Type{ConverterPositiveCurrent}, d::PSY.InterconnectingConverter,::Type{<:AbstractConverterFormulation}) = PSY.get_max_dc_current(d)
+get_variable_upper_bound(::Type{ConverterNegativeCurrent}, d::PSY.InterconnectingConverter,::Type{<:AbstractConverterFormulation}) = PSY.get_max_dc_current(d)
 
 
 function get_default_attributes(
@@ -199,8 +199,8 @@ function add_to_expression!(
     W <: AbstractDCLineFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression = get_expression(container, T(), PSY.DCBus)
+    variable = get_variable(container, U, V)
+    expression = get_expression(container, T, PSY.DCBus)
     for d in devices
         arc = PSY.get_arc(d)
         to_bus_number = PSY.get_number(PSY.get_to(arc))
@@ -286,9 +286,9 @@ function _add_to_expression!(
     W <: AbstractConverterFormulation,
     X <: AbstractPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression_dc = get_expression(container, T(), PSY.DCBus)
-    expression_ac = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
+    expression_ac = get_expression(container, T, PSY.ACBus)
     for d in devices, t in get_time_steps(container)
         name = PSY.get_name(d)
         bus_number_dc = PSY.get_number(PSY.get_dc_bus(d))
@@ -337,9 +337,9 @@ function add_to_expression!(
     V <: PSY.InterconnectingConverter,
     W <: AbstractConverterFormulation,
 }
-    variable = get_variable(container, U(), V)
-    expression_dc = get_expression(container, T(), PSY.DCBus)
-    expression_ac = get_expression(container, T(), PSY.ACBus)
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
+    expression_ac = get_expression(container, T, PSY.ACBus)
     for d in devices, t in get_time_steps(container)
         name = PSY.get_name(d)
         bus_number_dc = PSY.get_number(PSY.get_dc_bus(d))
@@ -387,9 +387,9 @@ function add_to_expression!(
     V <: PSY.InterconnectingConverter,
     W <: AbstractConverterFormulation,
 }
-    variable = get_variable(container, U(), V)
-    expression_dc = get_expression(container, T(), PSY.DCBus)
-    sys_expr = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
+    sys_expr = get_expression(container, T, PSY.System)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
@@ -399,7 +399,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 sys_expr[ref_bus, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 expression_dc[bus_number_dc, t],
@@ -424,8 +424,8 @@ function add_to_expression!(
     V <: PSY.InterconnectingConverter,
     W <: QuadraticLossConverter,
 }
-    variable = get_variable(container, U(), V)
-    sys_expr = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    sys_expr = get_expression(container, T, PSY.System)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
@@ -434,7 +434,7 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 sys_expr[ref_bus, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
         end
     end
@@ -454,8 +454,8 @@ function add_to_expression!(
     V <: PSY.InterconnectingConverter,
     W <: QuadraticLossConverter,
 }
-    variable = get_variable(container, U(), V)
-    expression_dc = get_expression(container, T(), PSY.DCBus)
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
     for d in devices
         name = PSY.get_name(d)
         bus_number_dc = PSY.get_number(PSY.get_dc_bus(d))
@@ -484,10 +484,10 @@ function add_to_expression!(
     W <: AbstractConverterFormulation,
     X <: PTDFPowerModel,
 }
-    variable = get_variable(container, U(), V)
-    expression_dc = get_expression(container, T(), PSY.DCBus)
-    expression_ac = get_expression(container, T(), PSY.ACBus)
-    sys_expr = get_expression(container, T(), PSY.System)
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
+    expression_ac = get_expression(container, T, PSY.ACBus)
+    sys_expr = get_expression(container, T, PSY.System)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
@@ -498,12 +498,12 @@ function add_to_expression!(
             add_proportional_to_jump_expression!(
                 sys_expr[ref_bus, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 expression_ac[bus_number_ac, t],
                 variable[name, t],
-                get_variable_multiplier(U(), V, W()),
+                get_variable_multiplier(U, V, W),
             )
             add_proportional_to_jump_expression!(
                 expression_dc[bus_number_dc, t],
@@ -528,12 +528,10 @@ function add_constraints!(
     model::DeviceModel{T, U},
     network_model::NetworkModel{V},
 ) where {T <: PSY.TModelHVDCLine, U <: DCLossyLine, V <: AbstractPowerModel}
-    variable = get_variable(container, DCLineCurrent(), T)
-    dc_voltage = get_variable(container, DCVoltage(), PSY.DCBus)
+    variable = get_variable(container, DCLineCurrent, T)
+    dc_voltage = get_variable(container, DCVoltage, PSY.DCBus)
     time_steps = get_time_steps(container)
-    constraints = add_constraints_container!(
-        container,
-        DCLineCurrentConstraint(),
+    constraints = add_constraints_container!(container, DCLineCurrentConstraint,
         T,
         PSY.get_name.(devices),
         time_steps,
@@ -578,26 +576,22 @@ function add_constraints!(
     X <: AbstractActivePowerModel,
 }
     time_steps = get_time_steps(container)
-    varcurrent = get_variable(container, ConverterCurrent(), U)
-    var_dcvoltage = get_variable(container, DCVoltage(), PSY.DCBus)
-    var_sq_current = get_variable(container, SquaredConverterCurrent(), U)
-    var_sq_voltage = get_variable(container, SquaredDCVoltage(), U)
-    var_bilinear = get_variable(container, AuxBilinearConverterVariable(), U)
-    var_sq_bilinear = get_variable(container, AuxBilinearSquaredConverterVariable(), U)
-    var_dc_power = get_variable(container, ConverterDCPower(), U)
+    varcurrent = get_variable(container, ConverterCurrent, U)
+    var_dcvoltage = get_variable(container, DCVoltage, PSY.DCBus)
+    var_sq_current = get_variable(container, SquaredConverterCurrent, U)
+    var_sq_voltage = get_variable(container, SquaredDCVoltage, U)
+    var_bilinear = get_variable(container, AuxBilinearConverterVariable, U)
+    var_sq_bilinear = get_variable(container, AuxBilinearSquaredConverterVariable, U)
+    var_dc_power = get_variable(container, ConverterDCPower, U)
     ipc_names = axes(varcurrent, 1)
     constraint =
-        add_constraints_container!(
-            container,
-            ConverterPowerCalculationConstraint(),
+        add_constraints_container!(container, ConverterPowerCalculationConstraint,
             U,
             ipc_names,
             time_steps,
         )
     constraint_aux =
-        add_constraints_container!(
-            container,
-            ConverterPowerCalculationConstraint(),
+        add_constraints_container!(container, ConverterPowerCalculationConstraint,
             U,
             ipc_names,
             time_steps;
@@ -639,41 +633,33 @@ function add_constraints!(
     X <: AbstractActivePowerModel,
 }
     time_steps = get_time_steps(container)
-    varcurrent = get_variable(container, ConverterCurrent(), U)
-    var_dcvoltage = get_variable(container, DCVoltage(), PSY.DCBus)
-    var_dc_power = get_variable(container, ConverterDCPower(), U)
+    varcurrent = get_variable(container, ConverterCurrent, U)
+    var_dcvoltage = get_variable(container, DCVoltage, PSY.DCBus)
+    var_dc_power = get_variable(container, ConverterDCPower, U)
     ipc_names = axes(varcurrent, 1)
     constraint1_under =
-        add_constraints_container!(
-            container,
-            ConverterMcCormickEnvelopes(),
+        add_constraints_container!(container, ConverterMcCormickEnvelopes,
             U,
             ipc_names,
             time_steps;
             meta = "under_1",
         )
     constraint2_under =
-        add_constraints_container!(
-            container,
-            ConverterMcCormickEnvelopes(),
+        add_constraints_container!(container, ConverterMcCormickEnvelopes,
             U,
             ipc_names,
             time_steps;
             meta = "under_2",
         )
     constraint1_over =
-        add_constraints_container!(
-            container,
-            ConverterMcCormickEnvelopes(),
+        add_constraints_container!(container, ConverterMcCormickEnvelopes,
             U,
             ipc_names,
             time_steps;
             meta = "over_1",
         )
     constraint2_over =
-        add_constraints_container!(
-            container,
-            ConverterMcCormickEnvelopes(),
+        add_constraints_container!(container, ConverterMcCormickEnvelopes,
             U,
             ipc_names,
             time_steps;
@@ -729,14 +715,12 @@ function add_constraints!(
     X <: AbstractActivePowerModel,
 }
     time_steps = get_time_steps(container)
-    var_sq_current = get_variable(container, SquaredConverterCurrent(), U)
-    var_ac_power = get_variable(container, ActivePowerVariable(), U)
-    var_dc_power = get_variable(container, ConverterDCPower(), U)
+    var_sq_current = get_variable(container, SquaredConverterCurrent, U)
+    var_ac_power = get_variable(container, ActivePowerVariable, U)
+    var_dc_power = get_variable(container, ConverterDCPower, U)
     ipc_names = axes(var_sq_current, 1)
     constraint =
-        add_constraints_container!(
-            container,
-            ConverterLossConstraint(),
+        add_constraints_container!(container, ConverterLossConstraint,
             U,
             ipc_names,
             time_steps,
@@ -744,8 +728,8 @@ function add_constraints!(
 
     use_linear_loss = get_attribute(model, "use_linear_loss")
     if use_linear_loss
-        pos_current = get_variable(container, ConverterPositiveCurrent(), U)
-        neg_current = get_variable(container, ConverterNegativeCurrent(), U)
+        pos_current = get_variable(container, ConverterPositiveCurrent, U)
+        neg_current = get_variable(container, ConverterNegativeCurrent, U)
     end
 
     for device in devices
@@ -792,32 +776,26 @@ function add_constraints!(
     names = [PSY.get_name(d) for d in devices]
     JuMPmodel = get_jump_model(container)
     # current vars #
-    current_var = get_variable(container, ConverterCurrent(), U) # From direction
-    current_var_pos = get_variable(container, ConverterPositiveCurrent(), U) # From direction
-    current_var_neg = get_variable(container, ConverterNegativeCurrent(), U) # From direction
-    current_dir = get_variable(container, ConverterCurrentDirection(), U)
+    current_var = get_variable(container, ConverterCurrent, U) # From direction
+    current_var_pos = get_variable(container, ConverterPositiveCurrent, U) # From direction
+    current_var_neg = get_variable(container, ConverterNegativeCurrent, U) # From direction
+    current_dir = get_variable(container, ConverterCurrentDirection, U)
 
     constraint =
-        add_constraints_container!(
-            container,
-            CurrentAbsoluteValueConstraint(),
+        add_constraints_container!(container, CurrentAbsoluteValueConstraint,
             U,
             names,
             time_steps,
         )
     constraint_pos_ub =
-        add_constraints_container!(
-            container,
-            CurrentAbsoluteValueConstraint(),
+        add_constraints_container!(container, CurrentAbsoluteValueConstraint,
             U,
             names,
             time_steps;
             meta = "pos_ub",
         )
     constraint_neg_ub =
-        add_constraints_container!(
-            container,
-            CurrentAbsoluteValueConstraint(),
+        add_constraints_container!(container, CurrentAbsoluteValueConstraint,
             U,
             names,
             time_steps;

--- a/src/mt_hvdc_models/HVDCsystems.jl
+++ b/src/mt_hvdc_models/HVDCsystems.jl
@@ -130,14 +130,14 @@ get_variable_binary(::Type{SquaredDCVoltage}, ::Type{PSY.InterconnectingConverte
 get_variable_binary(::Type{AuxBilinearConverterVariable}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
 get_variable_binary(::Type{AuxBilinearSquaredConverterVariable}, ::Type{PSY.InterconnectingConverter}, ::Type{<:AbstractConverterFormulation}) = false
 function get_variable_binary(
-    ::W,
+    ::Type{W},
     ::Type{PSY.InterconnectingConverter},
     ::Type{<:AbstractConverterFormulation}
 ) where W <: InterpolationVariableType
     return false
 end
 function get_variable_binary(
-    ::W,
+    ::Type{W},
     ::Type{PSY.InterconnectingConverter},
     ::Type{<:AbstractConverterFormulation}
 ) where W <: BinaryInterpolationVariableType
@@ -848,11 +848,11 @@ function add_constraints!(
 
     _add_generic_incremental_interpolation_constraint!(
         container,
-        DCVoltage(),
-        SquaredDCVoltage(),
-        InterpolationSquaredVoltageVariable(),
-        InterpolationBinarySquaredVoltageVariable(),
-        InterpolationVoltageConstraints(),
+        DCVoltage,
+        SquaredDCVoltage,
+        InterpolationSquaredVoltageVariable,
+        InterpolationBinarySquaredVoltageVariable,
+        InterpolationVoltageConstraints,
         devices,
         dic_var_bkpts,
         dic_function_bkpts,
@@ -886,11 +886,11 @@ function add_constraints!(
 
     _add_generic_incremental_interpolation_constraint!(
         container,
-        ConverterCurrent(),
-        SquaredConverterCurrent(),
-        InterpolationSquaredCurrentVariable(),
-        InterpolationBinarySquaredCurrentVariable(),
-        InterpolationCurrentConstraints(),
+        ConverterCurrent,
+        SquaredConverterCurrent,
+        InterpolationSquaredCurrentVariable,
+        InterpolationBinarySquaredCurrentVariable,
+        InterpolationCurrentConstraints,
         devices,
         dic_var_bkpts,
         dic_function_bkpts,
@@ -927,11 +927,11 @@ function add_constraints!(
 
     _add_generic_incremental_interpolation_constraint!(
         container,
-        AuxBilinearConverterVariable(),
-        AuxBilinearSquaredConverterVariable(),
-        InterpolationSquaredBilinearVariable(),
-        InterpolationBinarySquaredBilinearVariable(),
-        InterpolationBilinearConstraints(),
+        AuxBilinearConverterVariable,
+        AuxBilinearSquaredConverterVariable,
+        InterpolationSquaredBilinearVariable,
+        InterpolationBinarySquaredBilinearVariable,
+        InterpolationBilinearConstraints,
         devices,
         dic_var_bkpts,
         dic_function_bkpts,

--- a/src/mt_hvdc_models/hvdcsystems_constructor.jl
+++ b/src/mt_hvdc_models/hvdcsystems_constructor.jl
@@ -9,7 +9,7 @@ function construct_device!(
         model,
         sys,
     )
-    add_variables!(container, ActivePowerVariable, devices, LosslessConverter())
+    add_variables!(container, ActivePowerVariable, devices, LosslessConverter)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -60,46 +60,46 @@ function construct_device!(
     #####################
 
     # Add Power Variable
-    add_variables!(container, ActivePowerVariable, devices, QuadraticLossConverter()) # p_c^{ac}
-    add_variables!(container, ConverterDCPower, devices, QuadraticLossConverter()) # p_c
+    add_variables!(container, ActivePowerVariable, devices, QuadraticLossConverter) # p_c^{ac}
+    add_variables!(container, ConverterDCPower, devices, QuadraticLossConverter) # p_c
     # Add Current Variables: i, i+, i-
-    add_variables!(container, ConverterCurrent, devices, QuadraticLossConverter()) # i
-    add_variables!(container, SquaredConverterCurrent, devices, QuadraticLossConverter()) # i^sq
+    add_variables!(container, ConverterCurrent, devices, QuadraticLossConverter) # i
+    add_variables!(container, SquaredConverterCurrent, devices, QuadraticLossConverter) # i^sq
     use_linear_loss = get_attribute(model, "use_linear_loss")
     if use_linear_loss
         add_variables!(
             container,
             ConverterPositiveCurrent,
             devices,
-            QuadraticLossConverter(),
+            QuadraticLossConverter,
         ) # i^+
         add_variables!(
             container,
             ConverterNegativeCurrent,
             devices,
-            QuadraticLossConverter(),
+            QuadraticLossConverter,
         ) # i^-
         add_variables!(
             container,
             ConverterCurrentDirection,
             devices,
-            QuadraticLossConverter(),
+            QuadraticLossConverter,
         ) # ν
     end
     # Add Voltage Variables: v^sq
-    add_variables!(container, SquaredDCVoltage, devices, QuadraticLossConverter())
+    add_variables!(container, SquaredDCVoltage, devices, QuadraticLossConverter)
     # Add Bilinear Variables: γ, γ^{sq}
     add_variables!(
         container,
         AuxBilinearConverterVariable,
         devices,
-        QuadraticLossConverter(),
+        QuadraticLossConverter,
     ) # γ
     add_variables!(
         container,
         AuxBilinearSquaredConverterVariable,
         devices,
-        QuadraticLossConverter(),
+        QuadraticLossConverter,
     ) # γ^{sq}
 
     #### Add Interpolation Variables ####
@@ -239,7 +239,7 @@ function construct_device!(
         model,
         sys,
     )
-    add_variables!(container, FlowActivePowerVariable, devices, LosslessLine())
+    add_variables!(container, FlowActivePowerVariable, devices, LosslessLine)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -273,7 +273,7 @@ function construct_device!(
         sys,
     )
 
-    add_variables!(container, DCLineCurrent, devices, DCLossyLine())
+    add_variables!(container, DCLineCurrent, devices, DCLossyLine)
     add_to_expression!(
         container,
         DCCurrentBalance,

--- a/src/mt_hvdc_models/hvdcsystems_constructor.jl
+++ b/src/mt_hvdc_models/hvdcsystems_constructor.jl
@@ -121,9 +121,7 @@ function construct_device!(
     ]
 
     for (T, len_segments) in vars_vector
-        add_sparse_pwl_interpolation_variables!(
-            container,
-            T(),
+        add_sparse_pwl_interpolation_variables!(container, T,
             devices,
             model,
             len_segments,

--- a/src/network_models/area_balance_model.jl
+++ b/src/network_models/area_balance_model.jl
@@ -4,12 +4,10 @@ function add_constraints!(
     sys::PSY.System,
     model::NetworkModel{AreaBalancePowerModel},
 )
-    expressions = get_expression(container, ActivePowerBalance(), PSY.Area)
+    expressions = get_expression(container, ActivePowerBalance, PSY.Area)
     area_names, time_steps = axes(expressions)
 
-    constraints = add_constraints_container!(
-        container,
-        CopperPlateBalanceConstraint(),
+    constraints = add_constraints_container!(container, CopperPlateBalanceConstraint,
         PSY.Area,
         area_names,
         time_steps,
@@ -33,14 +31,12 @@ function agc_area_balance(
     time_steps = get_time_steps(container)
     nodal_net_balance = get_expression(container, expression)
 
-    constraint = add_constraints_container!(
-        container,
-        CopperPlateBalanceConstraint(),
+    constraint = add_constraints_container!(container, CopperPlateBalanceConstraint,
         PSY.Area,
         keys(area_mapping),
         time_steps,
     )
-    area_balance = get_variable(container, ActivePowerVariable(), PSY.Area)
+    area_balance = get_variable(container, ActivePowerVariable, PSY.Area)
     for (k, buses_in_area) in area_mapping
         for t in time_steps
             area_net = JuMP.AffExpr(0.0)
@@ -52,20 +48,16 @@ function agc_area_balance(
         end
     end
 
-    expr_up = get_expression(container, EmergencyUp(), PSY.Area)
-    expr_dn = get_expression(container, EmergencyDown(), PSY.Area)
+    expr_up = get_expression(container, EmergencyUp, PSY.Area)
+    expr_dn = get_expression(container, EmergencyDown, PSY.Area)
 
-    participation_assignment_up = add_constraints_container!(
-        container,
-        AreaParticipationAssignmentConstraint(),
+    participation_assignment_up = add_constraints_container!(container, AreaParticipationAssignmentConstraint,
         PSY.Area,
         keys(area_mapping),
         time_steps;
         meta = "up",
     )
-    participation_assignment_dn = add_constraints_container!(
-        container,
-        AreaParticipationAssignmentConstraint(),
+    participation_assignment_dn = add_constraints_container!(container, AreaParticipationAssignmentConstraint,
         PSY.Area,
         keys(area_mapping),
         time_steps;

--- a/src/network_models/copperplate_model.jl
+++ b/src/network_models/copperplate_model.jl
@@ -9,9 +9,9 @@ function add_constraints!(
     V <: Union{CopperPlatePowerModel, PTDFPowerModel, SecurityConstrainedPTDFPowerModel},
 }
     time_steps = get_time_steps(container)
-    expressions = get_expression(container, ActivePowerBalance(), U)
+    expressions = get_expression(container, ActivePowerBalance, U)
     subnets = collect(keys(model.subnetworks))
-    constraint = add_constraints_container!(container, T(), U, subnets, time_steps)
+    constraint = add_constraints_container!(container, T, U, subnets, time_steps)
     for t in time_steps, k in keys(model.subnetworks)
         constraint[k, t] =
             JuMP.@constraint(get_jump_model(container), expressions[k, t] == 0)
@@ -76,10 +76,10 @@ function add_constraints!(
     V <: Union{AreaPTDFPowerModel, SecurityConstrainedAreaPTDFPowerModel},
 }
     time_steps = get_time_steps(container)
-    expressions = get_expression(container, ActivePowerBalance(), PSY.Area)
+    expressions = get_expression(container, ActivePowerBalance, PSY.Area)
     area_names = PSY.get_name.(get_available_components(network_model, PSY.Area, sys))
     constraint =
-        add_constraints_container!(container, T(), PSY.Area, area_names, time_steps)
+        add_constraints_container!(container, T, PSY.Area, area_names, time_steps)
     jm = get_jump_model(container)
     for t in time_steps, k in area_names
         constraint[k, t] = JuMP.@constraint(jm, expressions[k, t] == 0)

--- a/src/network_models/hvdc_networks.jl
+++ b/src/network_models/hvdc_networks.jl
@@ -1,10 +1,26 @@
 ## To add method of upper_bounds and lower_bounds for DCVoltage
-get_variable_binary(::DCVoltage, ::Type{PSY.DCBus}, ::AbstractHVDCNetworkModel) = false
-get_variable_warm_start_value(::DCVoltage, ::PSY.DCBus, ::AbstractHVDCNetworkModel) =
+get_variable_binary(
+    ::Type{DCVoltage},
+    ::Type{PSY.DCBus},
+    ::Type{<:AbstractHVDCNetworkModel},
+) = false
+get_variable_warm_start_value(
+    ::Type{DCVoltage},
+    ::PSY.DCBus,
+    ::Type{<:AbstractHVDCNetworkModel},
+) =
     nothing
-get_variable_lower_bound(::DCVoltage, d::PSY.DCBus, ::AbstractHVDCNetworkModel) =
+get_variable_lower_bound(
+    ::Type{DCVoltage},
+    d::PSY.DCBus,
+    ::Type{<:AbstractHVDCNetworkModel},
+) =
     PSY.get_voltage_limits(d).min
-get_variable_upper_bound(::DCVoltage, d::PSY.DCBus, ::AbstractHVDCNetworkModel) =
+get_variable_upper_bound(
+    ::Type{DCVoltage},
+    d::PSY.DCBus,
+    ::Type{<:AbstractHVDCNetworkModel},
+) =
     PSY.get_voltage_limits(d).max
 
 function add_constraints!(
@@ -20,14 +36,13 @@ function add_constraints!(
     end
 
     time_steps = get_time_steps(container)
-    dc_expr = get_expression(container, ActivePowerBalance(), PSY.DCBus)
-    balance_constraint = add_constraints_container!(
-        container,
-        NodalBalanceActiveConstraint(),
-        PSY.DCBus,
-        axes(dc_expr)[1],
-        time_steps,
-    )
+    dc_expr = get_expression(container, ActivePowerBalance, PSY.DCBus)
+    balance_constraint =
+        add_constraints_container!(container, NodalBalanceActiveConstraint,
+            PSY.DCBus,
+            axes(dc_expr)[1],
+            time_steps,
+        )
     for d in dc_buses
         dc_bus_no = PSY.get_number(d)
         for t in time_steps
@@ -51,14 +66,13 @@ function add_constraints!(
     end
 
     time_steps = get_time_steps(container)
-    dc_expr = get_expression(container, DCCurrentBalance(), PSY.DCBus)
-    balance_constraint = add_constraints_container!(
-        container,
-        NodalBalanceCurrentConstraint(),
-        PSY.DCBus,
-        axes(dc_expr)[1],
-        time_steps,
-    )
+    dc_expr = get_expression(container, DCCurrentBalance, PSY.DCBus)
+    balance_constraint =
+        add_constraints_container!(container, NodalBalanceCurrentConstraint,
+            PSY.DCBus,
+            axes(dc_expr)[1],
+            time_steps,
+        )
     for d in dc_buses
         dc_bus_no = PSY.get_number(d)
         for t in time_steps

--- a/src/network_models/network_slack_variables.jl
+++ b/src/network_models/network_slack_variables.jl
@@ -1,8 +1,8 @@
 #! format: off
-get_variable_multiplier(::SystemBalanceSlackUp, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::AbstractDeviceFormulation) = 1.0
-get_variable_multiplier(::SystemBalanceSlackDown, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::AbstractDeviceFormulation) = -1.0
-get_variable_multiplier(::SystemBalanceSlackUp, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractPowerModel}) = 1.0
-get_variable_multiplier(::SystemBalanceSlackDown, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractPowerModel}) = -1.0
+get_variable_multiplier(::Type{SystemBalanceSlackUp}, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractDeviceFormulation}) = 1.0
+get_variable_multiplier(::Type{SystemBalanceSlackDown}, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractDeviceFormulation}) = -1.0
+get_variable_multiplier(::Type{SystemBalanceSlackUp}, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractPowerModel}) = 1.0
+get_variable_multiplier(::Type{SystemBalanceSlackDown}, ::Type{<: Union{PSY.ACBus, PSY.Area, PSY.System}}, ::Type{<:AbstractPowerModel}) = -1.0
 #! format: on
 
 function add_variables!(
@@ -17,7 +17,7 @@ function add_variables!(
     time_steps = get_time_steps(container)
     reference_buses = get_reference_buses(network_model)
     variable =
-        add_variable_container!(container, T(), PSY.System, reference_buses, time_steps)
+        add_variable_container!(container, T, PSY.System, reference_buses, time_steps)
 
     for t in time_steps, bus in reference_buses
         variable[bus, t] = JuMP.@variable(
@@ -41,7 +41,7 @@ function add_variables!(
     time_steps = get_time_steps(container)
     areas = get_name.(get_available_components(network_model, PSY.Area, sys))
     variable =
-        add_variable_container!(container, T(), PSY.Area, areas, time_steps)
+        add_variable_container!(container, T, PSY.Area, areas, time_steps)
 
     for t in time_steps, area in areas
         variable[area, t] = JuMP.@variable(
@@ -72,7 +72,7 @@ function add_variables!(
         bus_numbers = collect(keys(PNM.get_bus_reduction_map(network_reduction)))
     end
 
-    variable = add_variable_container!(container, T(), PSY.ACBus, bus_numbers, time_steps)
+    variable = add_variable_container!(container, T, PSY.ACBus, bus_numbers, time_steps)
     for t in time_steps, n in bus_numbers
         variable[n, t] = JuMP.@variable(
             get_jump_model(container),
@@ -101,9 +101,9 @@ function add_variables!(
         bus_numbers = collect(keys(PNM.get_bus_reduction_map(network_reduction)))
     end
     variable_active =
-        add_variable_container!(container, T(), PSY.ACBus, "P", bus_numbers, time_steps)
+        add_variable_container!(container, T, PSY.ACBus, "P", bus_numbers, time_steps)
     variable_reactive =
-        add_variable_container!(container, T(), PSY.ACBus, "Q", bus_numbers, time_steps)
+        add_variable_container!(container, T, PSY.ACBus, "Q", bus_numbers, time_steps)
 
     for t in time_steps, n in bus_numbers
         variable_active[n, t] = JuMP.@variable(
@@ -125,8 +125,8 @@ function add_to_objective_function!(
     sys::PSY.System,
     network_model::NetworkModel{T},
 ) where {T <: Union{CopperPlatePowerModel, PTDFPowerModel}}
-    variable_up = get_variable(container, SystemBalanceSlackUp(), PSY.System)
-    variable_dn = get_variable(container, SystemBalanceSlackDown(), PSY.System)
+    variable_up = get_variable(container, SystemBalanceSlackUp, PSY.System)
+    variable_dn = get_variable(container, SystemBalanceSlackDown, PSY.System)
     reference_buses = get_reference_buses(network_model)
 
     for t in get_time_steps(container), n in reference_buses
@@ -143,8 +143,8 @@ function add_to_objective_function!(
     sys::PSY.System,
     network_model::NetworkModel{T},
 ) where {T <: Union{AreaBalancePowerModel, AreaPTDFPowerModel}}
-    variable_up = get_variable(container, SystemBalanceSlackUp(), PSY.Area)
-    variable_dn = get_variable(container, SystemBalanceSlackDown(), PSY.Area)
+    variable_up = get_variable(container, SystemBalanceSlackUp, PSY.Area)
+    variable_dn = get_variable(container, SystemBalanceSlackDown, PSY.Area)
     areas = PSY.get_name.(get_available_components(network_model, PSY.Area, sys))
 
     for t in get_time_steps(container), n in areas
@@ -161,8 +161,8 @@ function add_to_objective_function!(
     sys::PSY.System,
     network_model::NetworkModel{T},
 ) where {T <: AbstractActivePowerModel}
-    variable_up = get_variable(container, SystemBalanceSlackUp(), PSY.ACBus)
-    variable_dn = get_variable(container, SystemBalanceSlackDown(), PSY.ACBus)
+    variable_up = get_variable(container, SystemBalanceSlackUp, PSY.ACBus)
+    variable_dn = get_variable(container, SystemBalanceSlackDown, PSY.ACBus)
     bus_numbers = axes(variable_up)[1]
     IS.@assert_op bus_numbers == axes(variable_dn)[1]
     for t in get_time_steps(container), n in bus_numbers
@@ -179,10 +179,10 @@ function add_to_objective_function!(
     sys::PSY.System,
     network_model::NetworkModel{T},
 ) where {T <: AbstractPowerModel}
-    variable_p_up = get_variable(container, SystemBalanceSlackUp(), PSY.ACBus, "P")
-    variable_p_dn = get_variable(container, SystemBalanceSlackDown(), PSY.ACBus, "P")
-    variable_q_up = get_variable(container, SystemBalanceSlackUp(), PSY.ACBus, "Q")
-    variable_q_dn = get_variable(container, SystemBalanceSlackDown(), PSY.ACBus, "Q")
+    variable_p_up = get_variable(container, SystemBalanceSlackUp, PSY.ACBus, "P")
+    variable_p_dn = get_variable(container, SystemBalanceSlackDown, PSY.ACBus, "P")
+    variable_q_up = get_variable(container, SystemBalanceSlackUp, PSY.ACBus, "Q")
+    variable_q_dn = get_variable(container, SystemBalanceSlackDown, PSY.ACBus, "Q")
     bus_numbers = axes(variable_p_up)[1]
     IS.@assert_op bus_numbers == axes(variable_q_dn)[1]
     for t in get_time_steps(container), n in bus_numbers

--- a/src/network_models/powermodels_interface.jl
+++ b/src/network_models/powermodels_interface.jl
@@ -423,7 +423,13 @@ function add_pm_variable_refs!(
     for (pm_v, ps_v) in pm_variable_map[PSY.ACBus]
         if pm_v in pm_variable_types
             var_container =
-                add_variable_container!(container, ps_v, PSY.ACBus, bus_names, time_steps)
+                add_variable_container!(
+                    container,
+                    typeof(ps_v),
+                    PSY.ACBus,
+                    bus_names,
+                    time_steps,
+                )
             for t in time_steps, (pm_bus, bus) in bus_dict
                 name = PSY.get_name(bus)
                 var_container[name, t] = PM.var(container.pm, t, pm_v)[pm_bus] # pm_vars[pm_v][pm_bus]
@@ -475,7 +481,7 @@ function add_pm_variable_refs!(
                     get_branch_argument_variable_axis(net_reduction_data, d_type)
                 var_container = add_variable_container!(
                     container,
-                    var_type,
+                    typeof(var_type),
                     d_type,
                     branch_names,
                     time_steps,
@@ -524,7 +530,7 @@ function add_pm_variable_refs!(
                     var_type === nothing && continue
                     var_container = add_variable_container!(
                         container,
-                        var_type,
+                        typeof(var_type),
                         d_type,
                         [PSY.get_name(d[2]) for d in devices],
                         time_steps,
@@ -556,7 +562,7 @@ function add_pm_constraint_refs!(
         if pm_v in pm_constraint_names
             cons_container = add_constraints_container!(
                 container,
-                ps_v,
+                typeof(ps_v),
                 PSY.ACBus,
                 [PSY.get_name(b) for b in values(bus_dict)],
                 time_steps,

--- a/src/network_models/security_constrained_models.jl
+++ b/src/network_models/security_constrained_models.jl
@@ -35,7 +35,7 @@ function add_constraints!(
 
     con_lb = add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         T,
         get_name.(branches_outages),
         device_names,
@@ -45,7 +45,7 @@ function add_constraints!(
 
     con_ub = add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         T,
         get_name.(branches_outages),
         device_names,
@@ -53,7 +53,7 @@ function add_constraints!(
         meta = "ub",
     )
 
-    expressions = get_expression(container, PostContingencyBranchFlow(), T)
+    expressions = get_expression(container, PostContingencyBranchFlow, T)
 
     param_keys = get_parameter_keys(container)
 

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -1,48 +1,48 @@
 #! format: off
-get_variable_multiplier(::VariableType, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = NaN
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = NaN
 ########################## ActivePowerVariable, AGC ###########################
 
 ########################## SteadyStateFrequencyDeviation ##################################
-get_variable_binary(::SteadyStateFrequencyDeviation, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
+get_variable_binary(::Type{SteadyStateFrequencyDeviation}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.Area}, ::Type{<:AbstractAGCFormulation}) = false
 ########################## SmoothACE, AggregationTopology ###########################
 
-get_variable_binary(::SmoothACE, ::Type{<:PSY.AggregationTopology}, ::AbstractAGCFormulation) = false
-get_variable_binary(::SmoothACE, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
+get_variable_binary(::Type{SmoothACE}, ::Type{<:PSY.AggregationTopology}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_binary(::Type{SmoothACE}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
 
 ########################## DeltaActivePowerUpVariable, AGC ###########################
 
-get_variable_binary(::DeltaActivePowerUpVariable, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
-get_variable_lower_bound(::DeltaActivePowerUpVariable, ::PSY.AGC, ::AbstractAGCFormulation) = 0.0
+get_variable_binary(::Type{DeltaActivePowerUpVariable}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_lower_bound(::Type{DeltaActivePowerUpVariable}, ::PSY.AGC, ::Type{<:AbstractAGCFormulation}) = 0.0
 
 ########################## DeltaActivePowerDownVariable, AGC ###########################
 
-get_variable_binary(::DeltaActivePowerDownVariable, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
-get_variable_lower_bound(::DeltaActivePowerDownVariable, ::PSY.AGC, ::AbstractAGCFormulation) = 0.0
+get_variable_binary(::Type{DeltaActivePowerDownVariable}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_lower_bound(::Type{DeltaActivePowerDownVariable}, ::PSY.AGC, ::Type{<:AbstractAGCFormulation}) = 0.0
 
 ########################## AdditionalDeltaPowerUpVariable, Area ###########################
 
-get_variable_binary(::AdditionalDeltaActivePowerUpVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
-get_variable_lower_bound(::AdditionalDeltaActivePowerUpVariable, ::PSY.Area, ::AbstractAGCFormulation) = 0.0
+get_variable_binary(::Type{AdditionalDeltaActivePowerUpVariable}, ::Type{<:PSY.Area}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_lower_bound(::Type{AdditionalDeltaActivePowerUpVariable}, ::PSY.Area, ::Type{<:AbstractAGCFormulation}) = 0.0
 
 ########################## AdditionalDeltaPowerDownVariable, Area ###########################
 
-get_variable_binary(::AdditionalDeltaActivePowerDownVariable, ::Type{<:PSY.Area}, ::AbstractAGCFormulation) = false
-get_variable_lower_bound(::AdditionalDeltaActivePowerDownVariable, ::PSY.Area, ::AbstractAGCFormulation) = 0.0
+get_variable_binary(::Type{AdditionalDeltaActivePowerDownVariable}, ::Type{<:PSY.Area}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_lower_bound(::Type{AdditionalDeltaActivePowerDownVariable}, ::PSY.Area, ::Type{<:AbstractAGCFormulation}) = 0.0
 
 ########################## AreaMismatchVariable, AGC ###########################
-get_variable_binary(::AreaMismatchVariable, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
+get_variable_binary(::Type{AreaMismatchVariable}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
 
 ########################## LiftVariable, Area ###########################
-get_variable_binary(::LiftVariable, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = false
-get_variable_lower_bound(::LiftVariable, ::PSY.AGC, ::AbstractAGCFormulation) = 0.0
+get_variable_binary(::Type{LiftVariable}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = false
+get_variable_lower_bound(::Type{LiftVariable}, ::PSY.AGC, ::Type{<:AbstractAGCFormulation}) = 0.0
 
 initial_condition_default(::AreaControlError, d::PSY.AGC, ::AbstractAGCFormulation) = PSY.get_initial_ace(d)
 initial_condition_variable(::AreaControlError, d::PSY.AGC, ::AbstractAGCFormulation) = AreaMismatchVariable()
 
 # Per-device bias multiplier (-10 * get_bias(d)) computed inline at add_to_expression! call sites.
-get_variable_multiplier(::SteadyStateFrequencyDeviation, ::Type{<:PSY.AGC}, ::AbstractAGCFormulation) = 1.0
+get_variable_multiplier(::Type{SteadyStateFrequencyDeviation}, ::Type{<:PSY.AGC}, ::Type{<:AbstractAGCFormulation}) = 1.0
 
 #! format: on
 
@@ -68,7 +68,7 @@ function add_agc_variables!(
     ::Type{T},
 ) where {T <: SteadyStateFrequencyDeviation}
     time_steps = get_time_steps(container)
-    variable = add_variable_container!(container, T(), PSY.AGC, time_steps)
+    variable = add_variable_container!(container, T, PSY.AGC, time_steps)
     for t in time_steps
         variable[t] = JuMP.@variable(container.JuMPmodel, base_name = "ΔF_{$(t)}")
     end
@@ -95,11 +95,11 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     agc_names = PSY.get_name.(agcs)
     container_lb =
-        add_constraints_container!(container, T(), U, agc_names, time_steps; meta = "lb")
+        add_constraints_container!(container, T, U, agc_names, time_steps; meta = "lb")
     container_ub =
-        add_constraints_container!(container, T(), U, agc_names, time_steps; meta = "ub")
-    mismatch = get_variable(container, AreaMismatchVariable(), U)
-    z = get_variable(container, LiftVariable(), U)
+        add_constraints_container!(container, T, U, agc_names, time_steps; meta = "ub")
+    mismatch = get_variable(container, AreaMismatchVariable, U)
+    z = get_variable(container, LiftVariable, U)
     jump_model = get_jump_model(container)
 
     for t in time_steps, a in agc_names
@@ -141,16 +141,16 @@ function add_constraints!(
     # This value is the one updated later in simulation based on the UC result
     inv_frequency_response = 1 / frequency_response
 
-    area_balance = get_variable(container, ActivePowerVariable(), PSY.Area)
-    frequency = get_variable(container, SteadyStateFrequencyDeviation(), U)
-    R_up = get_variable(container, DeltaActivePowerUpVariable(), U)
-    R_dn = get_variable(container, DeltaActivePowerDownVariable(), U)
+    area_balance = get_variable(container, ActivePowerVariable, PSY.Area)
+    frequency = get_variable(container, SteadyStateFrequencyDeviation, U)
+    R_up = get_variable(container, DeltaActivePowerUpVariable, U)
+    R_dn = get_variable(container, DeltaActivePowerDownVariable, U)
     R_up_emergency =
-        get_variable(container, AdditionalDeltaActivePowerUpVariable(), PSY.Area)
+        get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
     R_dn_emergency =
-        get_variable(container, AdditionalDeltaActivePowerUpVariable(), PSY.Area)
+        get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
 
-    const_container = add_constraints_container!(container, T(), PSY.System, time_steps)
+    const_container = add_constraints_container!(container, T, PSY.System, time_steps)
 
     for t in time_steps
         system_balance = sum(area_balance.data[:, t])
@@ -182,11 +182,9 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     agc_names = PSY.get_name.(services)
     area_names = [PSY.get_name(PSY.get_area(s)) for s in services]
-    RAW_ACE = get_expression(container, RawACE(), U)
-    SACE = get_variable(container, SmoothACE(), U)
-    SACE_pid = add_constraints_container!(
-        container,
-        SACEPIDAreaConstraint(),
+    RAW_ACE = get_expression(container, RawACE, U)
+    SACE = get_variable(container, SmoothACE, U)
+    SACE_pid = add_constraints_container!(container, SACEPIDAreaConstraint,
         U,
         agc_names,
         time_steps,
@@ -230,21 +228,19 @@ function add_constraints!(
 ) where {T <: BalanceAuxConstraint, U <: PSY.AGC, V <: PIDSmoothACE}
     time_steps = get_time_steps(container)
     agc_names = PSY.get_name.(agcs)
-    aux_equation = add_constraints_container!(
-        container,
-        BalanceAuxConstraint(),
+    aux_equation = add_constraints_container!(container, BalanceAuxConstraint,
         PSY.System,
         agc_names,
         time_steps,
     )
-    area_mismatch = get_variable(container, AreaMismatchVariable(), PSY.AGC)
-    SACE = get_variable(container, SmoothACE(), PSY.AGC)
-    R_up = get_variable(container, DeltaActivePowerUpVariable(), PSY.AGC)
-    R_dn = get_variable(container, DeltaActivePowerDownVariable(), PSY.AGC)
+    area_mismatch = get_variable(container, AreaMismatchVariable, PSY.AGC)
+    SACE = get_variable(container, SmoothACE, PSY.AGC)
+    R_up = get_variable(container, DeltaActivePowerUpVariable, PSY.AGC)
+    R_dn = get_variable(container, DeltaActivePowerDownVariable, PSY.AGC)
     R_up_emergency =
-        get_variable(container, AdditionalDeltaActivePowerUpVariable(), PSY.Area)
+        get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
     R_dn_emergency =
-        get_variable(container, AdditionalDeltaActivePowerUpVariable(), PSY.Area)
+        get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
 
     for t in time_steps
         for agc in agcs
@@ -302,7 +298,7 @@ function add_service_proportional_cost!(
     agcs::IS.FlattenIteratorWrapper{T},
     ::PIDSmoothACE,
 ) where {T <: PSY.AGC, U <: LiftVariable}
-    lift_variable = get_variable(container, U(), T)
+    lift_variable = get_variable(container, U, T)
     for index in Iterators.product(axes(lift_variable)...)
         add_to_objective_invariant_expression!(
             container,

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -145,6 +145,8 @@ function add_constraints!(
     frequency = get_variable(container, SteadyStateFrequencyDeviation, U)
     R_up = get_variable(container, DeltaActivePowerUpVariable, U)
     R_dn = get_variable(container, DeltaActivePowerDownVariable, U)
+    # FIXME dead code, file is unincluded, but likely bug: UpVariable for both.
+    # PSI issue #1593.
     R_up_emergency =
         get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
     R_dn_emergency =

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -19,9 +19,7 @@ function check_activeservice_variables(
     contributing_services::Vector{T},
 ) where {T <: PSY.Service}
     for service in contributing_services
-        get_variable(
-            container,
-            ActivePowerReserveVariable(),
+        get_variable(container, ActivePowerReserveVariable,
             typeof(service),
             PSY.get_name(service),
         )
@@ -42,9 +40,7 @@ function add_constraints!(
 ) where {SR <: PSY.ConstantReserveGroup}
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
-    add_constraints_container!(
-        container,
-        RequirementConstraint(),
+    add_constraints_container!(container, RequirementConstraint,
         SR,
         [service_name],
         time_steps;
@@ -53,7 +49,8 @@ function add_constraints!(
     constraint = get_constraint(container, RequirementConstraint(), SR, service_name)
     use_slacks = get_use_slacks(model)
     reserve_variables = [
-        get_variable(container, ActivePowerReserveVariable(), typeof(r), PSY.get_name(r)) for r in contributing_services
+        get_variable(container, ActivePowerReserveVariable, typeof(r), PSY.get_name(r))
+        for r in contributing_services
     ]
 
     requirement = PSY.get_requirement(service)

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -46,7 +46,7 @@ function add_constraints!(
         time_steps;
         meta = service_name,
     )
-    constraint = get_constraint(container, RequirementConstraint(), SR, service_name)
+    constraint = get_constraint(container, RequirementConstraint, SR, service_name)
     use_slacks = get_use_slacks(model)
     reserve_variables = [
         get_variable(container, ActivePowerReserveVariable, typeof(r), PSY.get_name(r))

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -1,46 +1,46 @@
 #! format: off
 ############################### Reserve Variables #########################################
 
-get_variable_multiplier(::VariableType, ::Type{<:PSY.Reserve}, ::AbstractReservesFormulation) = NaN
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.Reserve}, ::Type{<:AbstractReservesFormulation}) = NaN
 ############################### PostContingencyActivePowerReserveDeploymentVariable, Reserve #########################################
-get_variable_binary(::PostContingencyActivePowerReserveDeploymentVariable, ::Type{<:PSY.Reserve}, ::AbstractSecurityConstrainedReservesFormulation) = false
-function get_variable_upper_bound(::PostContingencyActivePowerReserveDeploymentVariable, r::PSY.Reserve, d::PSY.Device, ::AbstractSecurityConstrainedReservesFormulation)
+get_variable_binary(::Type{PostContingencyActivePowerReserveDeploymentVariable}, ::Type{<:PSY.Reserve}, ::Type{<:AbstractSecurityConstrainedReservesFormulation}) = false
+function get_variable_upper_bound(::Type{PostContingencyActivePowerReserveDeploymentVariable}, r::PSY.Reserve, d::PSY.Device, ::Type{<:AbstractSecurityConstrainedReservesFormulation})
     return  PSY.get_max_active_power(d)
 end
-get_variable_lower_bound(::PostContingencyActivePowerReserveDeploymentVariable, ::PSY.Reserve, ::PSY.Device, _) = 0.0
-get_variable_warm_start_value(::PostContingencyActivePowerReserveDeploymentVariable, d::PSY.Reserve, ::AbstractSecurityConstrainedReservesFormulation) = 0.0
-get_variable_multiplier(::AbstractContingencyVariableType, ::Type{<:PSY.Reserve{PSY.ReserveDown}}, ::AbstractSecurityConstrainedReservesFormulation) = -1.0
-get_variable_multiplier(::AbstractContingencyVariableType, ::Type{<:PSY.Reserve{PSY.ReserveUp}}, ::AbstractSecurityConstrainedReservesFormulation) = 1.0
-get_variable_multiplier(::VariableType, ::Type{<:PSY.Generator}, ::AbstractSecurityConstrainedReservesFormulation) = -1.0
+get_variable_lower_bound(::Type{PostContingencyActivePowerReserveDeploymentVariable}, ::PSY.Reserve, ::PSY.Device, ::Type) = 0.0
+get_variable_warm_start_value(::Type{PostContingencyActivePowerReserveDeploymentVariable}, d::PSY.Reserve, ::Type{<:AbstractSecurityConstrainedReservesFormulation}) = 0.0
+get_variable_multiplier(::Type{<:AbstractContingencyVariableType}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}, ::Type{<:AbstractSecurityConstrainedReservesFormulation}) = -1.0
+get_variable_multiplier(::Type{<:AbstractContingencyVariableType}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}, ::Type{<:AbstractSecurityConstrainedReservesFormulation}) = 1.0
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.Generator}, ::Type{<:AbstractSecurityConstrainedReservesFormulation}) = -1.0
 
 ############################### ActivePowerReserveVariable, Reserve #########################################
-get_variable_binary(::ActivePowerReserveVariable, ::Type{<:PSY.Reserve}, ::AbstractReservesFormulation) = false
-function get_variable_upper_bound(::ActivePowerReserveVariable, r::PSY.Reserve, d::PSY.Device, ::AbstractReservesFormulation)
+get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Reserve}, ::Type{<:AbstractReservesFormulation}) = false
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.Reserve, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_max_active_power(d)
 end
-get_variable_upper_bound(::ActivePowerReserveVariable, r::PSY.ReserveDemandCurve, d::PSY.Device, ::AbstractReservesFormulation) = PSY.get_max_active_power(d)
-get_variable_lower_bound(::ActivePowerReserveVariable, ::PSY.Reserve, ::PSY.Device, _) = 0.0
+get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.ReserveDemandCurve, d::PSY.Device, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d)
+get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.Reserve, ::PSY.Device, ::Type) = 0.0
 
 ############################### ActivePowerReserveVariable, ReserveNonSpinning #########################################
-get_variable_binary(::ActivePowerReserveVariable, ::Type{<:PSY.ReserveNonSpinning}, ::AbstractReservesFormulation) = false
-function get_variable_upper_bound(::ActivePowerReserveVariable, r::PSY.ReserveNonSpinning, d::PSY.Device, ::AbstractReservesFormulation)
+get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ReserveNonSpinning}, ::Type{<:AbstractReservesFormulation}) = false
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.ReserveNonSpinning, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_max_active_power(d)
 end
-get_variable_lower_bound(::ActivePowerReserveVariable, ::PSY.ReserveNonSpinning, ::PSY.Device, _) = 0.0
+get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.ReserveNonSpinning, ::PSY.Device, ::Type) = 0.0
 
 ############################### ServiceRequirementVariable, ReserveDemandCurve ################################
 
-get_variable_binary(::ServiceRequirementVariable, ::Type{<:PSY.ReserveDemandCurve}, ::AbstractReservesFormulation) = false
-get_variable_upper_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, d::PSY.Component, ::AbstractReservesFormulation) = PSY.get_max_active_power(d)
-get_variable_lower_bound(::ServiceRequirementVariable, ::PSY.ReserveDemandCurve, ::PSY.Component, ::AbstractReservesFormulation) = 0.0
+get_variable_binary(::Type{ServiceRequirementVariable}, ::Type{<:PSY.ReserveDemandCurve}, ::Type{<:AbstractReservesFormulation}) = false
+get_variable_upper_bound(::Type{ServiceRequirementVariable}, ::PSY.ReserveDemandCurve, d::PSY.Component, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d)
+get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::PSY.ReserveDemandCurve, ::PSY.Component, ::Type{<:AbstractReservesFormulation}) = 0.0
 
-get_multiplier_value(::RequirementTimeSeriesParameter, d::PSY.Reserve, ::AbstractReservesFormulation) = PSY.get_requirement(d)
-get_multiplier_value(::RequirementTimeSeriesParameter, d::PSY.ReserveNonSpinning, ::AbstractReservesFormulation) = PSY.get_requirement(d)
+get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.Reserve, ::Type{<:AbstractReservesFormulation}) = PSY.get_requirement(d)
+get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.ReserveNonSpinning, ::Type{<:AbstractReservesFormulation}) = PSY.get_requirement(d)
 
-get_parameter_multiplier(::VariableValueParameter, d::Type{<:PSY.AbstractReserve}, ::AbstractReservesFormulation) = 1.0
-get_initial_parameter_value(::VariableValueParameter, d::Type{<:PSY.AbstractReserve}, ::AbstractReservesFormulation) = 0.0
+get_parameter_multiplier(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 1.0
+get_initial_parameter_value(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 0.0
 
-objective_function_multiplier(::ServiceRequirementVariable, ::StepwiseCostReserve) = -1.0
+objective_function_multiplier(::Type{ServiceRequirementVariable}, ::Type{StepwiseCostReserve}) = -1.0
 uses_compact_power(::PSY.ReserveDemandCurve, ::StepwiseCostReserve)=false
 #! format: on
 
@@ -149,16 +149,14 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
     # TODO: Add a method for services that handles this better
-    constraint = add_constraints_container!(
-        container,
-        T(),
+    constraint = add_constraints_container!(container, T,
         SR,
         [service_name],
         time_steps;
         meta = service_name,
     )
     reserve_variable =
-        get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+        get_variable(container, ActivePowerReserveVariable, SR, service_name)
     use_slacks = get_use_slacks(model)
 
     ts_vector = IOM.get_time_series(container, service, "requirement")
@@ -168,7 +166,7 @@ function add_constraints!(
     jump_model = get_jump_model(container)
     if built_for_recurrent_solves(container)
         param_container =
-            get_parameter(container, RequirementTimeSeriesParameter(), SR, service_name)
+            get_parameter(container, RequirementTimeSeriesParameter, SR, service_name)
         param = get_parameter_column_refs(param_container, service_name)
         for t in time_steps
             if use_slacks
@@ -218,20 +216,18 @@ function add_constraints!(
 
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
-    cons = add_constraints_container!(
-        container,
-        T(),
+    cons = add_constraints_container!(container, T,
         SR,
         [PSY.get_name(d) for d in contributing_devices],
         time_steps;
         meta = service_name,
     )
-    var_r = get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+    var_r = get_variable(container, ActivePowerReserveVariable, SR, service_name)
     jump_model = get_jump_model(container)
     requirement = PSY.get_requirement(service)
     ts_vector = IOM.get_time_series(container, service, "requirement")
     param_container =
-        get_parameter(container, RequirementTimeSeriesParameter(), SR, service_name)
+        get_parameter(container, RequirementTimeSeriesParameter, SR, service_name)
     param = get_parameter_column_refs(param_container, service_name)
     for t in time_steps, d in contributing_devices
         name = PSY.get_name(d)
@@ -266,16 +262,14 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
     # TODO: The constraint addition is still not clean enough
-    constraint = add_constraints_container!(
-        container,
-        T(),
+    constraint = add_constraints_container!(container, T,
         SR,
         [service_name],
         time_steps;
         meta = service_name,
     )
     reserve_variable =
-        get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+        get_variable(container, ActivePowerReserveVariable, SR, service_name)
     use_slacks = get_use_slacks(model)
     use_slacks && (slack_vars = reserve_slacks!(container, service))
 
@@ -301,7 +295,7 @@ function add_to_objective_function!(
     service::SR,
     ::ServiceModel{SR, T},
 ) where {SR <: PSY.AbstractReserve, T <: AbstractReservesFormulation}
-    add_reserves_proportional_cost!(container, ActivePowerReserveVariable(), service, T())
+    add_reserves_proportional_cost!(container, ActivePowerReserveVariable, service, T)
     return
 end
 
@@ -317,18 +311,16 @@ function add_constraints!(
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
-    constraint = add_constraints_container!(
-        container,
-        T(),
+    constraint = add_constraints_container!(container, T,
         SR,
         [service_name],
         time_steps;
         meta = service_name,
     )
     reserve_variable =
-        get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+        get_variable(container, ActivePowerReserveVariable, SR, service_name)
     requirement_variable =
-        get_variable(container, ServiceRequirementVariable(), SR, service_name)
+        get_variable(container, ServiceRequirementVariable, SR, service_name)
     jump_model = get_jump_model(container)
     for t in time_steps
         constraint[service_name, t] = JuMP.@constraint(
@@ -383,11 +375,9 @@ function add_constraints!(
         jump_model = get_jump_model(container)
         time_steps = get_time_steps(container)
         time_frame = PSY.get_time_frame(service)
-        variable = get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+        variable = get_variable(container, ActivePowerReserveVariable, SR, service_name)
         device_name_set = [PSY.get_name(d) for d in ramp_devices]
-        con_up = add_constraints_container!(
-            container,
-            T(),
+        con_up = add_constraints_container!(container, T,
             SR,
             device_name_set,
             time_steps;
@@ -424,11 +414,9 @@ function add_constraints!(
         jump_model = get_jump_model(container)
         time_steps = get_time_steps(container)
         time_frame = PSY.get_time_frame(service)
-        variable = get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+        variable = get_variable(container, ActivePowerReserveVariable, SR, service_name)
         device_name_set = [PSY.get_name(d) for d in ramp_devices]
-        con_down = add_constraints_container!(
-            container,
-            T(),
+        con_down = add_constraints_container!(container, T,
             SR,
             device_name_set,
             time_steps;
@@ -468,21 +456,19 @@ function add_constraints!(
         minutes_per_period = Dates.value(Dates.Second(resolution)) / 60
     end
     service_name = PSY.get_name(service)
-    cons = add_constraints_container!(
-        container,
-        T(),
+    cons = add_constraints_container!(container, T,
         SR,
         [PSY.get_name(d) for d in contributing_devices],
         time_steps;
         meta = service_name,
     )
-    var_r = get_variable(container, ActivePowerReserveVariable(), SR, service_name)
+    var_r = get_variable(container, ActivePowerReserveVariable, SR, service_name)
     reserve_response_time = PSY.get_time_frame(service)
     jump_model = get_jump_model(container)
     for d in contributing_devices
         component_type = typeof(d)
         name = PSY.get_name(d)
-        varstatus = get_variable(container, OnVariable(), component_type)
+        varstatus = get_variable(container, OnVariable, component_type)
         startup_time = PSY.get_time_limits(d).up
         ramp_limits = _get_ramp_limits(d)
         if reserve_response_time > startup_time
@@ -507,26 +493,26 @@ function add_to_objective_function!(
     service::PSY.ReserveDemandCurve{T},
     ::ServiceModel{PSY.ReserveDemandCurve{T}, SR},
 ) where {T <: PSY.ReserveDirection, SR <: StepwiseCostReserve}
-    add_reserves_variable_cost!(container, ServiceRequirementVariable(), service, SR())
+    add_reserves_variable_cost!(container, ServiceRequirementVariable, service, SR)
     return
 end
 
 # originally was add_variable_cost!, but I don't see other call sites besides the above.
 function add_reserves_variable_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     service::T,
-    ::V,
+    ::Type{V},
 ) where {T <: PSY.ReserveDemandCurve, U <: VariableType, V <: StepwiseCostReserve}
-    _add_reserves_variable_cost_to_objective!(container, U(), service, V())
+    _add_reserves_variable_cost_to_objective!(container, U, service, V)
     return
 end
 
 function _add_reserves_variable_cost_to_objective!(
     container::OptimizationContainer,
-    ::T,
+    ::Type{T},
     component::PSY.Reserve,
-    ::U,
+    ::Type{U},
 ) where {T <: VariableType, U <: StepwiseCostReserve}
     component_name = PSY.get_name(component)
     @debug "PWL Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
@@ -543,7 +529,7 @@ function _add_reserves_variable_cost_to_objective!(
     end
 
     pwl_cost_expressions =
-        add_pwl_term_delta!(container, component, variable_cost, T(), U())
+        add_pwl_term_delta!(container, component, variable_cost, T, U)
     for t in time_steps
         add_to_expression!(
             container,
@@ -559,16 +545,16 @@ end
 
 function add_reserves_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     service::T,
-    ::V,
+    ::Type{V},
 ) where {
     T <: Union{PSY.Reserve, PSY.ReserveNonSpinning},
     U <: ActivePowerReserveVariable,
     V <: AbstractReservesFormulation,
 }
     base_p = get_model_base_power(container)
-    reserve_variable = get_variable(container, U(), T, PSY.get_name(service))
+    reserve_variable = get_variable(container, U, T, PSY.get_name(service))
     for index in Iterators.product(axes(reserve_variable)...)
         add_to_objective_invariant_expression!(
             container,

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -111,10 +111,9 @@ function add_reserve_variables!(
 }
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
-    variable_type = T()
     variable = add_variable_container!(
         container,
-        variable_type,
+        T,
         D,
         [service_name],
         time_steps;

--- a/src/services_models/service_slacks.jl
+++ b/src/services_models/service_slacks.jl
@@ -3,9 +3,7 @@ function reserve_slacks!(
     service::T,
 ) where {T <: Union{PSY.Reserve, PSY.ReserveNonSpinning}}
     time_steps = get_time_steps(container)
-    variable = add_variable_container!(
-        container,
-        ReserveRequirementSlack(),
+    variable = add_variable_container!(container, ReserveRequirementSlack,
         T,
         PSY.get_name(service),
         time_steps,

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -532,9 +532,7 @@ function construct_service!(
         transmission_interface_slacks!(container, interface)
     end
     # Lazy container addition for the expressions.
-    lazy_container_addition!(
-        container,
-        InterfaceTotalFlow(),
+    lazy_container_addition!(container, InterfaceTotalFlow,
         T,
         PSY.get_name.(interfaces),
         get_time_steps(container),
@@ -561,9 +559,7 @@ function construct_service!(
         transmission_interface_slacks!(container, interface)
     end
     # Lazy container addition for the expressions.
-    lazy_container_addition!(
-        container,
-        InterfaceTotalFlow(),
+    lazy_container_addition!(container, InterfaceTotalFlow,
         PSY.TransmissionInterface,
         PSY.get_name.(interfaces),
         get_time_steps(container),
@@ -803,9 +799,7 @@ function construct_service!(
         transmission_interface_slacks!(container, interface)
     end
     # Lazy container addition for the expressions.
-    lazy_container_addition!(
-        container,
-        InterfaceTotalFlow(),
+    lazy_container_addition!(container, InterfaceTotalFlow,
         PSY.TransmissionInterface,
         PSY.get_name.(interfaces),
         get_time_steps(container),

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -99,7 +99,7 @@ function construct_service!(
         ActivePowerReserveVariable,
         service,
         contributing_devices,
-        RangeReserve(),
+        RangeReserve,
     )
     add_to_expression!(container, ActivePowerReserveVariable, model, devices_template)
     add_feedforward_arguments!(container, model, service)
@@ -156,7 +156,7 @@ function construct_service!(
         ActivePowerReserveVariable,
         service,
         contributing_devices,
-        RangeReserve(),
+        RangeReserve,
     )
     add_to_expression!(container, ActivePowerReserveVariable, model, devices_template)
     add_feedforward_arguments!(container, model, service)
@@ -217,7 +217,7 @@ function construct_service!(
         ActivePowerReserveVariable,
         service,
         contributing_devices,
-        StepwiseCostReserve(),
+        StepwiseCostReserve,
     )
     add_to_expression!(container, ActivePowerReserveVariable, model, devices_template)
     add_expressions!(container, ProductionCostExpression, [service], model)
@@ -270,14 +270,14 @@ function construct_service!(
     end
 
     add_agc_variables!(container, SteadyStateFrequencyDeviation)
-    add_variables!(container, AreaMismatchVariable, services, T())
-    add_variables!(container, SmoothACE, services, T())
-    add_variables!(container, LiftVariable, services, T())
-    add_variables!(container, ActivePowerVariable, areas, T())
-    add_variables!(container, DeltaActivePowerUpVariable, services, T())
-    add_variables!(container, DeltaActivePowerDownVariable, services, T())
-    add_variables!(container, AdditionalDeltaActivePowerUpVariable, areas, T())
-    add_variables!(container, AdditionalDeltaActivePowerDownVariable, areas, T())
+    add_variables!(container, AreaMismatchVariable, services, T)
+    add_variables!(container, SmoothACE, services, T)
+    add_variables!(container, LiftVariable, services, T)
+    add_variables!(container, ActivePowerVariable, areas, T)
+    add_variables!(container, DeltaActivePowerUpVariable, services, T)
+    add_variables!(container, DeltaActivePowerDownVariable, services, T)
+    add_variables!(container, AdditionalDeltaActivePowerUpVariable, areas, T)
+    add_variables!(container, AdditionalDeltaActivePowerDownVariable, areas, T)
 
     add_initial_condition!(container, services, T(), AreaControlError())
 
@@ -411,7 +411,7 @@ function construct_service!(
         ActivePowerReserveVariable,
         service,
         contributing_devices,
-        RampReserve(),
+        RampReserve,
     )
     add_to_expression!(container, ActivePowerReserveVariable, model, devices_template)
     add_feedforward_arguments!(container, model, service)
@@ -470,7 +470,7 @@ function construct_service!(
         ActivePowerReserveVariable,
         service,
         contributing_devices,
-        NonSpinningReserve(),
+        NonSpinningReserve,
     )
     add_feedforward_arguments!(container, model, service)
     return

--- a/src/services_models/transmission_interface.jl
+++ b/src/services_models/transmission_interface.jl
@@ -1,16 +1,16 @@
 #! format: off
-get_variable_binary(::VariableType, ::Type{PSY.TransmissionInterface}, ::ConstantMaxInterfaceFlow) = false
-get_variable_lower_bound(::InterfaceFlowSlackUp, ::PSY.TransmissionInterface, ::ConstantMaxInterfaceFlow) = 0.0
-get_variable_lower_bound(::InterfaceFlowSlackDown, ::PSY.TransmissionInterface, ::ConstantMaxInterfaceFlow) = 0.0
+get_variable_binary(::Type{<:VariableType}, ::Type{PSY.TransmissionInterface}, ::Type{ConstantMaxInterfaceFlow}) = false
+get_variable_lower_bound(::Type{InterfaceFlowSlackUp}, ::PSY.TransmissionInterface, ::Type{ConstantMaxInterfaceFlow}) = 0.0
+get_variable_lower_bound(::Type{InterfaceFlowSlackDown}, ::PSY.TransmissionInterface, ::Type{ConstantMaxInterfaceFlow}) = 0.0
 
-get_variable_multiplier(::InterfaceFlowSlackUp, ::Type{PSY.TransmissionInterface}, ::ConstantMaxInterfaceFlow) = 1.0
-get_variable_multiplier(::InterfaceFlowSlackDown, ::Type{PSY.TransmissionInterface}, ::ConstantMaxInterfaceFlow) = -1.0
+get_variable_multiplier(::Type{InterfaceFlowSlackUp}, ::Type{PSY.TransmissionInterface}, ::Type{ConstantMaxInterfaceFlow}) = 1.0
+get_variable_multiplier(::Type{InterfaceFlowSlackDown}, ::Type{PSY.TransmissionInterface}, ::Type{ConstantMaxInterfaceFlow}) = -1.0
 
-get_variable_multiplier(::InterfaceFlowSlackUp, ::Type{PSY.TransmissionInterface}, ::VariableMaxInterfaceFlow) = 1.0
-get_variable_multiplier(::InterfaceFlowSlackDown, ::Type{PSY.TransmissionInterface}, ::VariableMaxInterfaceFlow) = -1.0
+get_variable_multiplier(::Type{InterfaceFlowSlackUp}, ::Type{PSY.TransmissionInterface}, ::Type{VariableMaxInterfaceFlow}) = 1.0
+get_variable_multiplier(::Type{InterfaceFlowSlackDown}, ::Type{PSY.TransmissionInterface}, ::Type{VariableMaxInterfaceFlow}) = -1.0
 
-get_multiplier_value(::MinInterfaceFlowLimitParameter, d::PSY.TransmissionInterface, ::VariableMaxInterfaceFlow) = PSY.get_min_active_power_flow_limit(d)
-get_multiplier_value(::MaxInterfaceFlowLimitParameter, d::PSY.TransmissionInterface, ::VariableMaxInterfaceFlow) = PSY.get_max_active_power_flow_limit(d)
+get_multiplier_value(::Type{MinInterfaceFlowLimitParameter}, d::PSY.TransmissionInterface, ::Type{VariableMaxInterfaceFlow}) = PSY.get_min_active_power_flow_limit(d)
+get_multiplier_value(::Type{MaxInterfaceFlowLimitParameter}, d::PSY.TransmissionInterface, ::Type{VariableMaxInterfaceFlow}) = PSY.get_max_active_power_flow_limit(d)
 
 #! format: On
 function get_default_time_series_names(
@@ -55,19 +55,15 @@ function add_constraints!(
     interface::T,
     model::ServiceModel{T, ConstantMaxInterfaceFlow},
 ) where {T <: PSY.TransmissionInterface}
-    expr = get_expression(container, InterfaceTotalFlow(), T)
+    expr = get_expression(container, InterfaceTotalFlow, T)
     interfaces, time_steps = axes(expr)
-    constraint_container_ub = lazy_container_addition!(
-        container,
-        InterfaceFlowLimit(),
+    constraint_container_ub = lazy_container_addition!(container, InterfaceFlowLimit,
         T,
         interfaces,
         time_steps;
         meta = "ub",
     )
-    constraint_container_lb = lazy_container_addition!(
-        container,
-        InterfaceFlowLimit(),
+    constraint_container_lb = lazy_container_addition!(container, InterfaceFlowLimit,
         T,
         interfaces,
         time_steps;
@@ -90,19 +86,15 @@ function add_constraints!(
     interface::T,
     model::ServiceModel{T, VariableMaxInterfaceFlow},
 ) where {T <: PSY.TransmissionInterface}
-    expr = get_expression(container, InterfaceTotalFlow(), T)
+    expr = get_expression(container, InterfaceTotalFlow, T)
     interfaces, timesteps = axes(expr)
-    constraint_container_ub = lazy_container_addition!(
-        container,
-        InterfaceFlowLimit(),
+    constraint_container_ub = lazy_container_addition!(container, InterfaceFlowLimit,
         T,
         interfaces,
         timesteps;
         meta = "ub",
     )
-    constraint_container_lb = lazy_container_addition!(
-        container,
-        InterfaceFlowLimit(),
+    constraint_container_lb = lazy_container_addition!(container, InterfaceFlowLimit,
         T,
         interfaces,
         timesteps;
@@ -110,18 +102,14 @@ function add_constraints!(
     )
     int_name = PSY.get_name(interface)
     param_container_min =
-        get_parameter(container, MinInterfaceFlowLimitParameter(), PSY.TransmissionInterface, int_name)
-    param_multiplier_min = get_parameter_multiplier_array(
-        container,
-        MinInterfaceFlowLimitParameter(),
+        get_parameter(container, MinInterfaceFlowLimitParameter, PSY.TransmissionInterface, int_name)
+    param_multiplier_min = get_parameter_multiplier_array(container, MinInterfaceFlowLimitParameter,
         PSY.TransmissionInterface,
         int_name,
     )
     param_container_max =
-        get_parameter(container, MaxInterfaceFlowLimitParameter(), PSY.TransmissionInterface, int_name)
-    param_multiplier_max = get_parameter_multiplier_array(
-        container,
-        MaxInterfaceFlowLimitParameter(),
+        get_parameter(container, MaxInterfaceFlowLimitParameter, PSY.TransmissionInterface, int_name)
+    param_multiplier_max = get_parameter_multiplier_array(container, MaxInterfaceFlowLimitParameter,
         PSY.TransmissionInterface,
         int_name,
     )

--- a/src/static_injector_models/electric_loads.jl
+++ b/src/static_injector_models/electric_loads.jl
@@ -1,39 +1,39 @@
 #! format: off
 ########################### ElectricLoad ####################################
 
-get_variable_multiplier(::VariableType, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = -1.0
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.ElectricLoad}, ::Type{<:AbstractLoadFormulation}) = -1.0
 
 ########################### ActivePowerVariable, ElectricLoad ####################################
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_max_active_power(d)
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.ElectricLoad}, ::Type{<:AbstractLoadFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.ElectricLoad, ::Type{<:AbstractLoadFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.ElectricLoad, ::Type{<:AbstractLoadFormulation}) = PSY.get_max_active_power(d)
 
 ########################### ReactivePowerVariable, ElectricLoad ####################################
 
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = false
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.ElectricLoad}, ::Type{<:AbstractLoadFormulation}) = false
 
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = 0.0
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ElectricLoad, ::AbstractLoadFormulation) = PSY.get_max_reactive_power(d)
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.ElectricLoad, ::Type{<:AbstractLoadFormulation}) = 0.0
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.ElectricLoad, ::Type{<:AbstractLoadFormulation}) = PSY.get_max_reactive_power(d)
 
 ########################### ReactivePowerVariable, ElectricLoad ####################################
 
-get_variable_binary(::OnVariable, ::Type{<:PSY.ElectricLoad}, ::AbstractLoadFormulation) = true
+get_variable_binary(::Type{OnVariable}, ::Type{<:PSY.ElectricLoad}, ::Type{<:AbstractLoadFormulation}) = true
 
-get_multiplier_value(::TimeSeriesParameter, d::PSY.ElectricLoad, ::StaticPowerLoad) = -1*PSY.get_max_active_power(d)
-get_multiplier_value(::ReactivePowerTimeSeriesParameter, d::PSY.ElectricLoad, ::StaticPowerLoad) = -1*PSY.get_max_reactive_power(d)
-get_multiplier_value(::TimeSeriesParameter, d::PSY.ElectricLoad, ::AbstractControllablePowerLoadFormulation) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.ElectricLoad, ::Type{StaticPowerLoad}) = -1*PSY.get_max_active_power(d)
+get_multiplier_value(::Type{ReactivePowerTimeSeriesParameter}, d::PSY.ElectricLoad, ::Type{StaticPowerLoad}) = -1*PSY.get_max_reactive_power(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.ElectricLoad, ::Type{<:AbstractControllablePowerLoadFormulation}) = PSY.get_max_active_power(d)
 
 # To avoid ambiguity with default_interface_methods.jl:
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, ::PSY.ElectricLoad, ::StaticPowerLoad) = 1.0
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, ::PSY.ElectricLoad, ::AbstractControllablePowerLoadFormulation) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.ElectricLoad, ::Type{StaticPowerLoad}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.ElectricLoad, ::Type{<:AbstractControllablePowerLoadFormulation}) = 1.0
 
 
 ########################Objective Function##################################################
-proportional_cost(cost::Nothing, ::OnVariable, ::PSY.ElectricLoad, ::AbstractControllablePowerLoadFormulation)=1.0
-proportional_cost(cost::PSY.OperationalCost, ::OnVariable, ::PSY.ElectricLoad, ::AbstractControllablePowerLoadFormulation)=PSY.get_fixed(cost)
+proportional_cost(cost::Nothing, ::Type{OnVariable}, ::PSY.ElectricLoad, ::Type{<:AbstractControllablePowerLoadFormulation})=1.0
+proportional_cost(cost::PSY.OperationalCost, ::Type{OnVariable}, ::PSY.ElectricLoad, ::Type{<:AbstractControllablePowerLoadFormulation})=PSY.get_fixed(cost)
 
-objective_function_multiplier(::VariableType, ::AbstractControllablePowerLoadFormulation)=OBJECTIVE_FUNCTION_NEGATIVE
+objective_function_multiplier(::Type{<:VariableType}, ::Type{<:AbstractControllablePowerLoadFormulation})=OBJECTIVE_FUNCTION_NEGATIVE
 
 #! format: on
 
@@ -41,15 +41,15 @@ objective_function_multiplier(::VariableType, ::AbstractControllablePowerLoadFor
 # see also the definition in thermal_generation.jl
 add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::PowerLoadInterruption,
+    ::Type{PowerLoadInterruption},
 ) where {U <: OnVariable, T <: PSY.ControllableLoad} =
     add_proportional_cost_maybe_time_variant!(
         container,
-        U(),
+        U,
         devices,
-        PowerLoadInterruption(),
+        PowerLoadInterruption,
     )
 
 function get_default_time_series_names(
@@ -98,9 +98,7 @@ function add_constraints!(
     X <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    constraint = add_constraints_container!(
-        container,
-        T(),
+    constraint = add_constraints_container!(container, T,
         V,
         PSY.get_name.(devices),
         time_steps,
@@ -109,8 +107,8 @@ function add_constraints!(
     for t in time_steps, d in devices
         name = PSY.get_name(d)
         pf = sin(atan((PSY.get_max_reactive_power(d) / PSY.get_max_active_power(d))))
-        reactive = get_variable(container, U(), V)[name, t]
-        real = get_variable(container, ActivePowerVariable(), V)[name, t]
+        reactive = get_variable(container, U, V)[name, t]
+        real = get_variable(container, ActivePowerVariable, V)[name, t]
         constraint[name, t] = JuMP.@constraint(jump_model, reactive == real * pf)
     end
 end
@@ -164,16 +162,14 @@ function add_constraints!(
     ::NetworkModel{X},
 ) where {V <: PSY.ControllableLoad, W <: PowerLoadInterruption, X <: AbstractPowerModel}
     time_steps = get_time_steps(container)
-    constraint = add_constraints_container!(
-        container,
-        T(),
+    constraint = add_constraints_container!(container, T,
         V,
         PSY.get_name.(devices),
         time_steps;
         meta = "binary",
     )
-    on_variable = get_variable(container, U(), V)
-    power = get_variable(container, ActivePowerVariable(), V)
+    on_variable = get_variable(container, U, V)
+    power = get_variable(container, ActivePowerVariable, V)
     jump_model = get_jump_model(container)
     for t in time_steps, d in devices
         name = PSY.get_name(d)
@@ -191,7 +187,7 @@ function add_to_objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ControllableLoad, U <: PowerLoadDispatch}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
     return
 end
 
@@ -201,8 +197,8 @@ function add_to_objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ControllableLoad, U <: PowerLoadInterruption}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
-    add_proportional_cost!(container, OnVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
+    add_proportional_cost!(container, OnVariable, devices, U)
     return
 end
 
@@ -211,9 +207,9 @@ end
 function proportional_cost(
     container::OptimizationContainer,
     cost::PSY.LoadCost,
-    S::OnVariable,
+    S::Type{OnVariable},
     T::PSY.ControllableLoad,
-    U::PowerLoadInterruption,
+    U::Type{PowerLoadInterruption},
     t::Int,
 )
     return onvar_cost(container, cost, S, T, U, t) +
@@ -224,9 +220,9 @@ end
 function onvar_cost(
     container::OptimizationContainer,
     cost::PSY.LoadCost,
-    ::OnVariable,
+    ::Type{OnVariable},
     d::PSY.ControllableLoad,
-    ::PowerLoadInterruption,
+    ::Type{PowerLoadInterruption},
     t::Int,
 )
     return _onvar_cost(container, PSY.get_variable(cost), d, t)
@@ -235,18 +231,18 @@ end
 is_time_variant_term(
     ::OptimizationContainer,
     ::PSY.LoadCost,
-    ::OnVariable,
+    ::Type{OnVariable},
     ::PSY.ControllableLoad,
-    ::AbstractLoadFormulation,
+    ::Type{<:AbstractLoadFormulation},
     ::Int,
 ) = false
 
 is_time_variant_term(
     ::OptimizationContainer,
     cost::PSY.MarketBidCost,
-    ::OnVariable,
+    ::Type{OnVariable},
     ::PSY.ControllableLoad,
-    ::PowerLoadInterruption,
+    ::Type{PowerLoadInterruption},
     ::Int,
 ) =
     is_time_variant(PSY.get_decremental_initial_input(cost))
@@ -254,16 +250,16 @@ is_time_variant_term(
 function proportional_cost(
     container::OptimizationContainer,
     cost::PSY.MarketBidCost,
-    ::OnVariable,
+    ::Type{OnVariable},
     comp::T,
-    ::PowerLoadInterruption,
+    ::Type{PowerLoadInterruption},
     t::Int,
 ) where {T <: PSY.ControllableLoad}
     if is_time_variant(PSY.get_decremental_initial_input(cost))
         name = get_name(comp)
-        param_arr = get_parameter_array(container, DecrementalCostAtMinParameter(), T)
+        param_arr = get_parameter_array(container, DecrementalCostAtMinParameter, T)
         param_mult =
-            get_parameter_multiplier_array(container, DecrementalCostAtMinParameter(), T)
+            get_parameter_multiplier_array(container, DecrementalCostAtMinParameter, T)
         return param_arr[name, t] * param_mult[name, t]
     else
         return PSY.get_initial_input(

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -482,7 +482,7 @@ function add_variables!(
     variable_type::Type{T},
     turbines::U,
     reservoirs::W,
-    ::X,
+    ::Type{X},
 ) where {
     T <: HydroTurbineFlowRateVariable,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -3,13 +3,13 @@
 # Helper for proportional cost terms in objective function
 function _add_proportional_term!(
     container::OptimizationContainer,
-    ::T,
+    ::Type{T},
     component::U,
     linear_term::Float64,
     time_period::Int,
 ) where {T <: VariableType, U <: PSY.Component}
     component_name = PSY.get_name(component)
-    variable = get_variable(container, T(), U)[component_name, time_period]
+    variable = get_variable(container, T, U)[component_name, time_period]
     lin_cost = variable * linear_term
     add_to_objective_invariant_expression!(container, lin_cost)
     return lin_cost
@@ -19,64 +19,64 @@ end
 requires_initialization(::AbstractHydroReservoirFormulation) = false
 requires_initialization(::AbstractHydroUnitCommitment) = true
 
-get_variable_multiplier(::VariableType, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = 1.0
-get_variable_multiplier(::ActivePowerPumpVariable, ::Type{<:PSY.HydroPumpTurbine}, ::AbstractHydroPumpFormulation) = -1.0
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation}) = 1.0
+get_variable_multiplier(::Type{ActivePowerPumpVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = -1.0
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
 
 ########################### ActivePowerVariable, HydroGen #################################
 # These methods are defined in PowerSimulations
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_warm_start_value(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_active_power(d)
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).min
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroUnitCommitment) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).max
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_warm_start_value(::Type{ActivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_active_power(d)
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_active_power_limits(d).min
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroUnitCommitment}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_active_power_limits(d).max
 
 ############## ReactivePowerVariable, HydroGen ####################
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroDispatchFormulation) = false
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = false
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroUnitCommitment) = false
-get_variable_warm_start_value(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_active_power(d)
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_active_power_limits(d).max
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroDispatchFormulation}) = false
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroUnitCommitment}) = false
+get_variable_warm_start_value(::Type{ReactivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_active_power(d)
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_active_power_limits(d).max
 
 ############## EnergyVariable, HydroGen ####################
 # These methods are defined in PowerSimulations
-get_variable_binary(::EnergyVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = false
-get_variable_warm_start_value(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_initial_storage(d)
-get_variable_lower_bound(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = 0.0
-get_variable_upper_bound(::EnergyVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_storage_capacity(d)
+get_variable_binary(::Type{EnergyVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+get_variable_warm_start_value(::Type{EnergyVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_initial_storage(d)
+get_variable_lower_bound(::Type{EnergyVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = 0.0
+get_variable_upper_bound(::Type{EnergyVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_storage_capacity(d)
 
 ########################### ActivePowerInVariable, HydroGen #################################
-get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = false
-get_variable_lower_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerInVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = nothing
-get_variable_multiplier(::ActivePowerInVariable, d::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = -1.0
+get_variable_binary(::Type{ActivePowerInVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerInVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerInVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = nothing
+get_variable_multiplier(::Type{ActivePowerInVariable}, d::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = -1.0
 
 ########################### ActivePowerOutVariable, HydroGen #################################
-get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = false
-get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = nothing
-get_variable_multiplier(::ActivePowerOutVariable, d::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = 1.0
+get_variable_binary(::Type{ActivePowerOutVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerOutVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerOutVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = nothing
+get_variable_multiplier(::Type{ActivePowerOutVariable}, d::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = 1.0
 
 ############## OnVariable, HydroGen ####################
 # These methods are defined in PowerSimulations
-get_variable_binary(::OnVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = true
-get_variable_binary(::OnVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroUnitCommitment) = true
-get_variable_warm_start_value(::OnVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_active_power(d) > 0 ? 1.0 : 0.0
+get_variable_binary(::Type{OnVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = true
+get_variable_binary(::Type{OnVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroUnitCommitment}) = true
+get_variable_warm_start_value(::Type{OnVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_active_power(d) > 0 ? 1.0 : 0.0
 
 ############## WaterSpillageVariable, HydroGen ####################
-get_variable_binary(::WaterSpillageVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::WaterSpillageVariable, d::PSY.HydroGen, ::AbstractHydroFormulation) = 0.0
-get_variable_binary(::WaterSpillageVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroReservoirFormulation) = false
-function get_variable_lower_bound(::WaterSpillageVariable, d::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)
+get_variable_binary(::Type{WaterSpillageVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{WaterSpillageVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = 0.0
+get_variable_binary(::Type{WaterSpillageVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+function get_variable_lower_bound(::Type{WaterSpillageVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})
    spillage_limits = PSY.get_spillage_limits(d)
    if typeof(spillage_limits) <: PSY.MinMax
        return PSY.get_spillage_limits(d).min
    end
    return 0.0
 end
-function get_variable_upper_bound(::WaterSpillageVariable, d::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)
+function get_variable_upper_bound(::Type{WaterSpillageVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})
     spillage_limits = PSY.get_spillage_limits(d)
     if typeof(spillage_limits) <: PSY.MinMax
         return PSY.get_spillage_limits(d).max
@@ -85,86 +85,86 @@ function get_variable_upper_bound(::WaterSpillageVariable, d::PSY.HydroReservoir
 end
 
 ############## ReservationVariable, HydroGen ####################
-get_variable_binary(::ReservationVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = true
+get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation}) = true
 
 ############## EnergyShortageVariable, HydroGen ####################
-get_variable_binary(::HydroEnergyShortageVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::HydroEnergyShortageVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = 0.0
-get_variable_upper_bound(::HydroEnergyShortageVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_storage_capacity(d)
-get_variable_lower_bound(::HydroEnergyShortageVariable, d::PSY.HydroDispatch, ::HydroDispatchRunOfRiverBudget) = 0.0
-get_variable_upper_bound(::HydroEnergyShortageVariable, d::PSY.HydroDispatch, ::HydroDispatchRunOfRiverBudget) = nothing
+get_variable_binary(::Type{HydroEnergyShortageVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = 0.0
+get_variable_upper_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = PSY.get_storage_capacity(d)
+get_variable_lower_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroDispatch, ::Type{HydroDispatchRunOfRiverBudget}) = 0.0
+get_variable_upper_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroDispatch, ::Type{HydroDispatchRunOfRiverBudget}) = nothing
 
 ############## HydroEnergySurplusVariable, HydroGen ####################
-get_variable_binary(::HydroEnergySurplusVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation) = false
-get_variable_upper_bound(::HydroEnergySurplusVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = 0.0
-get_variable_lower_bound(::HydroEnergySurplusVariable, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = - PSY.get_storage_capacity(d)
+get_variable_binary(::Type{HydroEnergySurplusVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation}) = false
+get_variable_upper_bound(::Type{HydroEnergySurplusVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = 0.0
+get_variable_lower_bound(::Type{HydroEnergySurplusVariable}, d::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation}) = - PSY.get_storage_capacity(d)
 
 ############## HydroReservoir ####################
 
-get_variable_binary(::EnergyVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-get_variable_binary(::HydroEnergyShortageVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-get_variable_binary(::HydroEnergySurplusVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::EnergyVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).min / PSY.get_system_base_power(d)
-get_variable_upper_bound(::EnergyVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
+get_variable_binary(::Type{EnergyVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_binary(::Type{HydroEnergyShortageVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_binary(::Type{HydroEnergySurplusVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{EnergyVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).min / PSY.get_system_base_power(d)
+get_variable_upper_bound(::Type{EnergyVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
 
 ############## PSY.HydroTurbine ####################
-get_variable_binary(::HydroTurbineFlowRateVariable, ::Type{<:PSY.HydroTurbine}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::HydroTurbineFlowRateVariable, d::PSY.HydroTurbine, ::AbstractHydroFormulation) = isnothing(PSY.get_outflow_limits(d)) ? 0.0 : PSY.get_outflow_limits(d).min
-get_variable_upper_bound(::HydroTurbineFlowRateVariable, d::PSY.HydroTurbine, ::AbstractHydroFormulation) = isnothing(PSY.get_outflow_limits(d)) ? nothing : PSY.get_outflow_limits(d).max
+get_variable_binary(::Type{HydroTurbineFlowRateVariable}, ::Type{<:PSY.HydroTurbine}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{HydroTurbineFlowRateVariable}, d::PSY.HydroTurbine, ::Type{<:AbstractHydroFormulation}) = isnothing(PSY.get_outflow_limits(d)) ? 0.0 : PSY.get_outflow_limits(d).min
+get_variable_upper_bound(::Type{HydroTurbineFlowRateVariable}, d::PSY.HydroTurbine, ::Type{<:AbstractHydroFormulation}) = isnothing(PSY.get_outflow_limits(d)) ? nothing : PSY.get_outflow_limits(d).max
 
 ############## HydroEnergyBlock ####################
-get_variable_lower_bound(::HydroReservoirVolumeVariable, d::PSY.HydroReservoir, ::HydroWaterFactorModel) = isnothing(PSY.get_storage_level_limits(d)) ? 0.0 : PSY.get_storage_level_limits(d).min
-get_variable_upper_bound(::HydroReservoirVolumeVariable, d::PSY.HydroReservoir, ::HydroWaterFactorModel) = isnothing(PSY.get_storage_level_limits(d)) ? nothing : PSY.get_storage_level_limits(d).max
+get_variable_lower_bound(::Type{HydroReservoirVolumeVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterFactorModel}) = isnothing(PSY.get_storage_level_limits(d)) ? 0.0 : PSY.get_storage_level_limits(d).min
+get_variable_upper_bound(::Type{HydroReservoirVolumeVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterFactorModel}) = isnothing(PSY.get_storage_level_limits(d)) ? nothing : PSY.get_storage_level_limits(d).max
 
 ############## HydroPumpTurbine ####################
-get_variable_binary(::ReservationVariable, ::Type{<:PSY.HydroPumpTurbine}, ::AbstractHydroPumpFormulation) = true
-get_variable_binary(::OnVariable, ::Type{<:PSY.HydroPumpTurbine}, ::HydroPumpEnergyCommitment) = true
+get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = true
+get_variable_binary(::Type{OnVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{HydroPumpEnergyCommitment}) = true
 
 # ActivePowerVariable
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.HydroPumpTurbine}, ::AbstractHydroPumpFormulation) = false
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_active_power_limits(d).min
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.HydroPumpTurbine, ::HydroPumpEnergyCommitment) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_active_power_limits(d).max
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_active_power_limits(d).min
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.HydroPumpTurbine, ::Type{HydroPumpEnergyCommitment}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_active_power_limits(d).max
 # ActivePowerPumpVariable
-get_variable_binary(::ActivePowerPumpVariable, ::Type{<:PSY.HydroPumpTurbine}, ::AbstractHydroPumpFormulation) = false
-get_variable_lower_bound(::ActivePowerPumpVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_active_power_limits_pump(d).min
-get_variable_lower_bound(::ActivePowerPumpVariable, d::PSY.HydroPumpTurbine, ::HydroPumpEnergyCommitment) = 0.0
-get_variable_upper_bound(::ActivePowerPumpVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_active_power_limits_pump(d).max
+get_variable_binary(::Type{ActivePowerPumpVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerPumpVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_active_power_limits_pump(d).min
+get_variable_lower_bound(::Type{ActivePowerPumpVariable}, d::PSY.HydroPumpTurbine, ::Type{HydroPumpEnergyCommitment}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerPumpVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_active_power_limits_pump(d).max
 # ReactivePowerVariable
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.HydroPumpTurbine}, ::AbstractHydroPumpFormulation) = false
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_reactive_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.HydroPumpTurbine, ::AbstractHydroPumpFormulation) = PSY.get_reactive_power_limits(d).max
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = false
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_reactive_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.HydroPumpTurbine, ::Type{<:AbstractHydroPumpFormulation}) = PSY.get_reactive_power_limits(d).max
 
 
 ############## EnergyShortageVariable, HydroReservoir ####################
-get_variable_binary(::HydroEnergyShortageVariable, ::Type{<:PSY.HydroReservoir}, ::HydroEnergyModelReservoir) = false
-get_variable_lower_bound(::HydroEnergyShortageVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = 0.0
-get_variable_upper_bound(::HydroEnergyShortageVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).max
-get_variable_binary(::HydroWaterShortageVariable, ::Type{<:PSY.HydroReservoir}, ::HydroWaterModelReservoir) = false
-get_variable_lower_bound(::HydroWaterShortageVariable, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = 0.0
-get_variable_upper_bound(::HydroWaterShortageVariable, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroEnergyShortageVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{HydroEnergyModelReservoir}) = false
+get_variable_lower_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = 0.0
+get_variable_upper_bound(::Type{HydroEnergyShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroWaterShortageVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{HydroWaterModelReservoir}) = false
+get_variable_lower_bound(::Type{HydroWaterShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = 0.0
+get_variable_upper_bound(::Type{HydroWaterShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = PSY.get_storage_level_limits(d).max
 
 ############## HydroEnergySurplusVariable, HydroReservoir ####################
-get_variable_binary(::HydroEnergySurplusVariable, ::Type{<:PSY.HydroReservoir}, ::HydroEnergyModelReservoir) = false
-get_variable_upper_bound(::HydroEnergySurplusVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = 0.0
-get_variable_lower_bound(::HydroEnergySurplusVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = - PSY.get_storage_level_limits(d).max
-get_variable_binary(::HydroWaterSurplusVariable, ::Type{<:PSY.HydroReservoir}, ::HydroWaterModelReservoir) = false
-get_variable_upper_bound(::HydroWaterSurplusVariable, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = 0.0
-get_variable_lower_bound(::HydroWaterSurplusVariable, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = - PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroEnergySurplusVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{HydroEnergyModelReservoir}) = false
+get_variable_upper_bound(::Type{HydroEnergySurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = 0.0
+get_variable_lower_bound(::Type{HydroEnergySurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = - PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroWaterSurplusVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{HydroWaterModelReservoir}) = false
+get_variable_upper_bound(::Type{HydroWaterSurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = 0.0
+get_variable_lower_bound(::Type{HydroWaterSurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = - PSY.get_storage_level_limits(d).max
 
 ############## BalanceShortageVariable, HydroReservoir ####################
-get_variable_binary(::HydroBalanceShortageVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::HydroBalanceShortageVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = 0.0
-get_variable_upper_bound(::HydroBalanceShortageVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroBalanceShortageVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{HydroBalanceShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = 0.0
+get_variable_upper_bound(::Type{HydroBalanceShortageVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).max
 
 ############## BalanceSurplusVariable, HydroReservoir ####################
-get_variable_binary(::HydroBalanceSurplusVariable, ::Type{<:PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-get_variable_lower_bound(::HydroBalanceSurplusVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = 0.0
-get_variable_upper_bound(::HydroBalanceSurplusVariable, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).max
+get_variable_binary(::Type{HydroBalanceSurplusVariable}, ::Type{<:PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+get_variable_lower_bound(::Type{HydroBalanceSurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = 0.0
+get_variable_upper_bound(::Type{HydroBalanceSurplusVariable}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).max
 
 ############## HydroReservoirHeadVariable, HydroReservoir ####################
-get_variable_binary(::HydroReservoirHeadVariable, ::Type{PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-function get_variable_upper_bound(::HydroReservoirHeadVariable, d::PSY.HydroReservoir, ::AbstractHydroFormulation)
+get_variable_binary(::Type{HydroReservoirHeadVariable}, ::Type{PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+function get_variable_upper_bound(::Type{HydroReservoirHeadVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation})
     if PSY.get_level_data_type(d) == PSY.ReservoirDataType.HEAD
         head_limits = PSY.get_storage_level_limits(d)
         if typeof(head_limits) <: PSY.MinMax
@@ -173,7 +173,7 @@ function get_variable_upper_bound(::HydroReservoirHeadVariable, d::PSY.HydroRese
     end
     return nothing
 end
-function get_variable_lower_bound(::HydroReservoirHeadVariable, d::PSY.HydroReservoir, ::AbstractHydroFormulation)
+function get_variable_lower_bound(::Type{HydroReservoirHeadVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation})
     if PSY.get_level_data_type(d) == PSY.ReservoirDataType.HEAD
         head_limits = PSY.get_storage_level_limits(d)
         if typeof(head_limits) <: PSY.MinMax
@@ -184,8 +184,8 @@ function get_variable_lower_bound(::HydroReservoirHeadVariable, d::PSY.HydroRese
 end
 
 ############## HydroReservoirVolumeVariable, HydroReservoir ####################
-get_variable_binary(::HydroReservoirVolumeVariable, ::Type{PSY.HydroReservoir}, ::AbstractHydroFormulation) = false
-function get_variable_upper_bound(::HydroReservoirVolumeVariable, d::PSY.HydroReservoir, ::AbstractHydroFormulation)
+get_variable_binary(::Type{HydroReservoirVolumeVariable}, ::Type{PSY.HydroReservoir}, ::Type{<:AbstractHydroFormulation}) = false
+function get_variable_upper_bound(::Type{HydroReservoirVolumeVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation})
     if (PSY.get_level_data_type(d) == PSY.ReservoirDataType.USABLE_VOLUME) || (PSY.get_level_data_type(d) == PSY.ReservoirDataType.TOTAL_VOLUME)
         head_limits = PSY.get_storage_level_limits(d)
         if typeof(head_limits) <: PSY.MinMax
@@ -194,7 +194,7 @@ function get_variable_upper_bound(::HydroReservoirVolumeVariable, d::PSY.HydroRe
     end
     return nothing
 end
-function get_variable_lower_bound(::HydroReservoirVolumeVariable, d::PSY.HydroReservoir, ::AbstractHydroFormulation)
+function get_variable_lower_bound(::Type{HydroReservoirVolumeVariable}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation})
     if (PSY.get_level_data_type(d) == PSY.ReservoirDataType.USABLE_VOLUME) || (PSY.get_level_data_type(d) == PSY.ReservoirDataType.TOTAL_VOLUME)
         head_limits = PSY.get_storage_level_limits(d)
         if typeof(head_limits) <: PSY.MinMax
@@ -205,31 +205,31 @@ function get_variable_lower_bound(::HydroReservoirVolumeVariable, d::PSY.HydroRe
 end
 
 ########################### Parameter related set functions ################################
-get_multiplier_value(::EnergyBudgetTimeSeriesParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{EnergyBudgetTimeSeriesParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_max_active_power(d)
 # get_multiplier_value(::EnergyBudgetTimeSeriesParameter, d::PSY.HydroEnergyReservoir, ::AbstractHydroFormulation) = PSY.get_storage_capacity(d)
-get_multiplier_value(::EnergyBudgetTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
-get_multiplier_value(::WaterBudgetTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = 1.0 # Data already in m3/s
-get_multiplier_value(::EnergyTargetTimeSeriesParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_storage_capacity(d)
-get_multiplier_value(::EnergyTargetTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_level_targets(d) * PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
-get_multiplier_value(::WaterTargetTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroWaterModelReservoir) = 1.0 # Data already in head meters
-get_multiplier_value(::InflowTimeSeriesParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_inflow(d) * PSY.get_conversion_factor(d)
-get_multiplier_value(::OutflowTimeSeriesParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_outflow(d) * PSY.get_conversion_factor(d)
-get_multiplier_value(::InflowTimeSeriesParameter, d::PSY.HydroReservoir, ::AbstractHydroFormulation) = 1.0 # Data already in m3/s
-get_multiplier_value(::OutflowTimeSeriesParameter, d::PSY.HydroReservoir, ::AbstractHydroFormulation) = 1.0 # Data already in m3/s
-get_multiplier_value(::InflowTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroEnergyModelReservoir) = PSY.get_inflow(d) # Data normalized
-get_multiplier_value(::InflowTimeSeriesParameter, d::PSY.HydroReservoir, ::HydroWaterFactorModel) = PSY.get_inflow(d)
-get_multiplier_value(::TimeSeriesParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_max_active_power(d)
-get_multiplier_value(::TimeSeriesParameter, d::PSY.HydroGen, ::FixedOutput) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{EnergyBudgetTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
+get_multiplier_value(::Type{WaterBudgetTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = 1.0 # Data already in m3/s
+get_multiplier_value(::Type{EnergyTargetTimeSeriesParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_storage_capacity(d)
+get_multiplier_value(::Type{EnergyTargetTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_level_targets(d) * PSY.get_storage_level_limits(d).max / PSY.get_system_base_power(d)
+get_multiplier_value(::Type{WaterTargetTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroWaterModelReservoir}) = 1.0 # Data already in head meters
+get_multiplier_value(::Type{InflowTimeSeriesParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_inflow(d) * PSY.get_conversion_factor(d)
+get_multiplier_value(::Type{OutflowTimeSeriesParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_outflow(d) * PSY.get_conversion_factor(d)
+get_multiplier_value(::Type{InflowTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation}) = 1.0 # Data already in m3/s
+get_multiplier_value(::Type{OutflowTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation}) = 1.0 # Data already in m3/s
+get_multiplier_value(::Type{InflowTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroEnergyModelReservoir}) = PSY.get_inflow(d) # Data normalized
+get_multiplier_value(::Type{InflowTimeSeriesParameter}, d::PSY.HydroReservoir, ::Type{HydroWaterFactorModel}) = PSY.get_inflow(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.HydroGen, ::Type{FixedOutput}) = PSY.get_max_active_power(d)
 # next 2 needed to avoid ambiguity errors
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, d::PSY.HydroGen, ::FixedOutput) = PSY.get_max_active_power(d)
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, d::PSY.HydroGen, ::Type{FixedOutput}) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_max_active_power(d)
 
-get_parameter_multiplier(::VariableValueParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = 1.0
-get_initial_parameter_value(::VariableValueParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = 1.0
-get_initial_parameter_value(::HydroUsageLimitParameter, d::PSY.HydroGen, ::AbstractHydroFormulation) = 1e6 #unbounded
-get_initial_parameter_value(::WaterLevelBudgetParameter, d::PSY.HydroReservoir, ::AbstractHydroFormulation) = 1e6 #unbounded
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionUB, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).max
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionLB, d::PSY.HydroGen, ::AbstractHydroFormulation) = PSY.get_active_power_limits(d).min
+get_parameter_multiplier(::Type{<:VariableValueParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = 1.0
+get_initial_parameter_value(::Type{<:VariableValueParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = 1.0
+get_initial_parameter_value(::Type{HydroUsageLimitParameter}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = 1e6 #unbounded
+get_initial_parameter_value(::Type{WaterLevelBudgetParameter}, d::PSY.HydroReservoir, ::Type{<:AbstractHydroFormulation}) = 1e6 #unbounded
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_active_power_limits(d).max
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.HydroGen, ::Type{<:AbstractHydroFormulation}) = PSY.get_active_power_limits(d).min
 
 #################### Initial Conditions for models ###############
 initial_condition_default(::DeviceStatus, d::PSY.HydroGen, ::AbstractHydroReservoirFormulation) = PSY.get_status(d)
@@ -260,43 +260,42 @@ end
 initial_condition_variable(::InitialReservoirVolume, d::PSY.HydroReservoir, ::AbstractHydroFormulation) = HydroReservoirVolumeVariable()
 
 ########################Objective Function##################################################
-# FIXME: why is this first one (cost, gen, variable, formulation), when all others have variable 2nd and gen 3rd?
-proportional_cost(cost::Nothing, ::PSY.HydroGen, ::ActivePowerVariable, ::AbstractHydroFormulation)=0.0
-proportional_cost(cost::PSY.OperationalCost, ::OnVariable, ::PSY.HydroGen, ::AbstractHydroFormulation)=PSY.get_fixed(cost)
-proportional_cost(cost::PSY.OperationalCost, ::HydroEnergySurplusVariable, ::PSY.HydroGen, ::AbstractHydroReservoirFormulation)=0.0
-proportional_cost(cost::PSY.OperationalCost, ::HydroEnergyShortageVariable, ::PSY.HydroGen, ::AbstractHydroReservoirFormulation)=0.0
-proportional_cost(cost::PSY.OperationalCost, ::HydroEnergyShortageVariable, ::PSY.HydroGen, ::HydroDispatchRunOfRiverBudget)=CONSTRAINT_VIOLATION_SLACK_COST
-proportional_cost(cost::PSY.HydroReservoirCost, ::HydroEnergySurplusVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=PSY.get_level_surplus_cost(cost)
-proportional_cost(cost::PSY.HydroReservoirCost, ::HydroEnergyShortageVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=PSY.get_level_shortage_cost(cost)
-proportional_cost(cost::PSY.HydroReservoirCost, ::HydroWaterSurplusVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=PSY.get_level_surplus_cost(cost)
-proportional_cost(cost::PSY.HydroReservoirCost, ::HydroWaterShortageVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=PSY.get_level_shortage_cost(cost)
-proportional_cost(cost::PSY.HydroReservoirCost, ::WaterSpillageVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=PSY.get_spillage_cost(cost)
-proportional_cost(::PSY.HydroReservoirCost, ::HydroBalanceSurplusVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=CONSTRAINT_VIOLATION_SLACK_COST
-proportional_cost(::PSY.HydroReservoirCost, ::HydroBalanceShortageVariable, ::PSY.HydroReservoir, ::AbstractHydroReservoirFormulation)=CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(cost::Nothing, ::Type{ActivePowerVariable}, ::PSY.HydroGen, ::Type{<:AbstractHydroFormulation})=0.0
+proportional_cost(cost::PSY.OperationalCost, ::Type{OnVariable}, ::PSY.HydroGen, ::Type{<:AbstractHydroFormulation})=PSY.get_fixed(cost)
+proportional_cost(cost::PSY.OperationalCost, ::Type{HydroEnergySurplusVariable}, ::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation})=0.0
+proportional_cost(cost::PSY.OperationalCost, ::Type{HydroEnergyShortageVariable}, ::PSY.HydroGen, ::Type{<:AbstractHydroReservoirFormulation})=0.0
+proportional_cost(cost::PSY.OperationalCost, ::Type{HydroEnergyShortageVariable}, ::PSY.HydroGen, ::Type{HydroDispatchRunOfRiverBudget})=CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(cost::PSY.HydroReservoirCost, ::Type{HydroEnergySurplusVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=PSY.get_level_surplus_cost(cost)
+proportional_cost(cost::PSY.HydroReservoirCost, ::Type{HydroEnergyShortageVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=PSY.get_level_shortage_cost(cost)
+proportional_cost(cost::PSY.HydroReservoirCost, ::Type{HydroWaterSurplusVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=PSY.get_level_surplus_cost(cost)
+proportional_cost(cost::PSY.HydroReservoirCost, ::Type{HydroWaterShortageVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=PSY.get_level_shortage_cost(cost)
+proportional_cost(cost::PSY.HydroReservoirCost, ::Type{WaterSpillageVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=PSY.get_spillage_cost(cost)
+proportional_cost(::PSY.HydroReservoirCost, ::Type{HydroBalanceSurplusVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(::PSY.HydroReservoirCost, ::Type{HydroBalanceShortageVariable}, ::PSY.HydroReservoir, ::Type{<:AbstractHydroReservoirFormulation})=CONSTRAINT_VIOLATION_SLACK_COST
 
-objective_function_multiplier(::ActivePowerVariable, ::AbstractHydroFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::ActivePowerPumpVariable, ::AbstractHydroFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::OnVariable, ::AbstractHydroFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::HydroEnergyShortageVariable, ::AbstractHydroFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::HydroEnergySurplusVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_NEGATIVE
-objective_function_multiplier(::HydroEnergyShortageVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::HydroBalanceSurplusVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::HydroBalanceShortageVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::HydroWaterSurplusVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_NEGATIVE
-objective_function_multiplier(::HydroWaterShortageVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_POSITIVE
-objective_function_multiplier(::WaterSpillageVariable, ::AbstractHydroReservoirFormulation)=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{ActivePowerVariable}, ::Type{<:AbstractHydroFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{ActivePowerPumpVariable}, ::Type{<:AbstractHydroFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{OnVariable}, ::Type{<:AbstractHydroFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{HydroEnergyShortageVariable}, ::Type{<:AbstractHydroFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{HydroEnergySurplusVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_NEGATIVE
+objective_function_multiplier(::Type{HydroEnergyShortageVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{HydroBalanceSurplusVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{HydroBalanceShortageVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{HydroWaterSurplusVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_NEGATIVE
+objective_function_multiplier(::Type{HydroWaterShortageVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{WaterSpillageVariable}, ::Type{<:AbstractHydroReservoirFormulation})=OBJECTIVE_FUNCTION_POSITIVE
 # objective_function_multiplier(::ActivePowerOutVariable, ::HydroWaterFactorModel)=OBJECTIVE_FUNCTION_POSITIVE
 
 sos_status(::PSY.HydroGen, ::AbstractHydroReservoirFormulation)=SOSStatusVariable.NO_VARIABLE
 sos_status(::PSY.HydroGen, ::AbstractHydroUnitCommitment)=SOSStatusVariable.VARIABLE
 
-variable_cost(::Nothing, ::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroReservoirFormulation)=0.0
-variable_cost(cost::PSY.OperationalCost, ::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation)=PSY.get_variable(cost)
-variable_cost(cost::PSY.OperationalCost, ::ActivePowerPumpVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation)=PSY.get_variable(cost)
+variable_cost(::Nothing, ::Type{ActivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroReservoirFormulation})=0.0
+variable_cost(cost::PSY.OperationalCost, ::Type{ActivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation})=PSY.get_variable(cost)
+variable_cost(cost::PSY.OperationalCost, ::Type{ActivePowerPumpVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation})=PSY.get_variable(cost)
 
 # variable_cost(cost::PSY.OperationalCost, ::ActivePowerOutVariable, ::PSY.HydroTurbine, ::AbstractHydroFormulation)=PSY.get_variable(cost)
 
-variable_cost(cost::PSY.StorageCost, ::ActivePowerVariable, ::Type{<:PSY.HydroGen}, ::AbstractHydroFormulation)=PSY.get_discharge_variable_cost(cost)
+variable_cost(cost::PSY.StorageCost, ::Type{ActivePowerVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:AbstractHydroFormulation})=PSY.get_discharge_variable_cost(cost)
 
 #! format: on
 
@@ -483,7 +482,7 @@ function add_variables!(
     variable_type::Type{T},
     turbines::U,
     reservoirs::W,
-    formulation::X,
+    ::X,
 ) where {
     T <: HydroTurbineFlowRateVariable,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
@@ -496,7 +495,7 @@ function add_variables!(
     time_steps = get_time_steps(container)
     variable = add_variable_container!(
         container,
-        variable_type(),
+        variable_type,
         D,
         [PSY.get_name(d) for d in turbines],
         [PSY.get_name(d) for d in reservoirs],
@@ -510,10 +509,10 @@ function add_variables!(
             get_jump_model(container),
             base_name = "$(T)_$(D)_{$(name), $(name_res), $(t)}",
         )
-        ub = get_variable_upper_bound(variable_type(), d, formulation)
+        ub = get_variable_upper_bound(variable_type, d, X)
         ub !== nothing && JuMP.set_upper_bound(variable[name, name_res, t], ub)
 
-        lb = get_variable_lower_bound(variable_type(), d, formulation)
+        lb = get_variable_lower_bound(variable_type, d, X)
         lb !== nothing && JuMP.set_lower_bound(variable[name, name_res, t], lb)
     end
 end
@@ -548,10 +547,10 @@ function add_variables!(
             get_jump_model(container),
             base_name = "$(T)_$(E)_{$(name_res), $(t)}",
         )
-        ub = get_variable_upper_bound(variable_type(), r, formulation)
+        ub = get_variable_upper_bound(variable_type, r, formulation)
         ub !== nothing && JuMP.set_upper_bound(variable[name_res, t], ub)
 
-        lb = get_variable_lower_bound(variable_type(), r, formulation)
+        lb = get_variable_lower_bound(variable_type, r, formulation)
         lb !== nothing && JuMP.set_lower_bound(variable[name_res, t], lb)
     end
 end
@@ -807,26 +806,24 @@ function add_constraints!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
     initial_conditions = get_initial_condition(container, InitialEnergyLevel(), V)
-    energy_var = get_variable(container, EnergyVariable(), V)
-    power_var = get_variable(container, ActivePowerVariable(), PSY.HydroTurbine)
-    spillage_var = get_variable(container, WaterSpillageVariable(), V)
+    energy_var = get_variable(container, EnergyVariable, V)
+    power_var = get_variable(container, ActivePowerVariable, PSY.HydroTurbine)
+    spillage_var = get_variable(container, WaterSpillageVariable, V)
     power_in_from_turbines =
-        get_expression(container, TotalHydroPowerReservoirIncoming(), V)
+        get_expression(container, TotalHydroPowerReservoirIncoming, V)
     power_out_to_turbines =
-        get_expression(container, TotalHydroPowerReservoirOutgoing(), V)
+        get_expression(container, TotalHydroPowerReservoirOutgoing, V)
     spillage_in_from_reservoirs =
-        get_expression(container, TotalSpillagePowerReservoirIncoming(), V)
+        get_expression(container, TotalSpillagePowerReservoirIncoming, V)
 
-    constraint = add_constraints_container!(
-        container,
-        EnergyBalanceConstraint(),
+    constraint = add_constraints_container!(container, EnergyBalanceConstraint,
         V,
         names,
         time_steps,
     )
-    param_container = get_parameter(container, InflowTimeSeriesParameter(), V)
+    param_container = get_parameter(container, InflowTimeSeriesParameter, V)
     multiplier =
-        get_parameter_multiplier_array(container, InflowTimeSeriesParameter(), V)
+        get_parameter_multiplier_array(container, InflowTimeSeriesParameter, V)
 
     for ic in initial_conditions
         device = get_component(ic)
@@ -834,9 +831,9 @@ function add_constraints!(
         param = get_parameter_column_values(param_container, name)
         if get_use_slacks(model)
             surplus_var =
-                get_variable(container, HydroBalanceSurplusVariable(), V)[name, 1]
+                get_variable(container, HydroBalanceSurplusVariable, V)[name, 1]
             shortage_var =
-                get_variable(container, HydroBalanceShortageVariable(), V)[name, 1]
+                get_variable(container, HydroBalanceShortageVariable, V)[name, 1]
         else
             surplus_var = 0.0
             shortage_var = 0.0
@@ -866,12 +863,12 @@ function add_constraints!(
             else
                 if get_use_slacks(model)
                     surplus_var =
-                        get_variable(container, HydroBalanceSurplusVariable(), V)[
+                        get_variable(container, HydroBalanceSurplusVariable, V)[
                             name,
                             t,
                         ]
                     shortage_var =
-                        get_variable(container, HydroBalanceShortageVariable(), V)[
+                        get_variable(container, HydroBalanceShortageVariable, V)[
                             name,
                             t,
                         ]
@@ -911,20 +908,18 @@ function add_constraints!(
 }
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
-    constraint = add_constraints_container!(
-        container,
-        EnergyTargetConstraint(),
+    constraint = add_constraints_container!(container, EnergyTargetConstraint,
         V,
         set_name,
         time_steps,
     )
 
-    e_var = get_variable(container, EnergyVariable(), V)
-    shortage_var = get_variable(container, HydroEnergyShortageVariable(), V)
-    surplus_var = get_variable(container, HydroEnergySurplusVariable(), V)
-    param_container = get_parameter(container, EnergyTargetTimeSeriesParameter(), V)
+    e_var = get_variable(container, EnergyVariable, V)
+    shortage_var = get_variable(container, HydroEnergyShortageVariable, V)
+    surplus_var = get_variable(container, HydroEnergySurplusVariable, V)
+    param_container = get_parameter(container, EnergyTargetTimeSeriesParameter, V)
     multiplier =
-        get_parameter_multiplier_array(container, EnergyTargetTimeSeriesParameter(), V)
+        get_parameter_multiplier_array(container, EnergyTargetTimeSeriesParameter, V)
 
     for d in devices
         name = PSY.get_name(d)
@@ -971,20 +966,18 @@ function add_constraints!(
 }
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
-    constraint = add_constraints_container!(
-        container,
-        EnergyTargetConstraint(),
+    constraint = add_constraints_container!(container, EnergyTargetConstraint,
         V,
         set_name,
         [time_steps[end]],
     )
 
-    e_var = get_variable(container, EnergyVariable(), V)
-    shortage_var = get_variable(container, HydroEnergyShortageVariable(), V)
-    surplus_var = get_variable(container, HydroEnergySurplusVariable(), V)
-    param_container = get_parameter(container, EnergyTargetTimeSeriesParameter(), V)
+    e_var = get_variable(container, EnergyVariable, V)
+    shortage_var = get_variable(container, HydroEnergyShortageVariable, V)
+    surplus_var = get_variable(container, HydroEnergySurplusVariable, V)
+    param_container = get_parameter(container, EnergyTargetTimeSeriesParameter, V)
     multiplier =
-        get_parameter_multiplier_array(container, EnergyTargetTimeSeriesParameter(), V)
+        get_parameter_multiplier_array(container, EnergyTargetTimeSeriesParameter, V)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1026,20 +1019,18 @@ function add_constraints!(
 }
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
-    constraint = add_constraints_container!(
-        container,
-        WaterTargetConstraint(),
+    constraint = add_constraints_container!(container, WaterTargetConstraint,
         V,
         set_name,
         [time_steps[end]],
     )
 
-    h_var = get_variable(container, HydroReservoirHeadVariable(), V)
-    shortage_var = get_variable(container, HydroWaterShortageVariable(), V)
-    surplus_var = get_variable(container, HydroWaterSurplusVariable(), V)
-    param_container = get_parameter(container, WaterTargetTimeSeriesParameter(), V)
+    h_var = get_variable(container, HydroReservoirHeadVariable, V)
+    shortage_var = get_variable(container, HydroWaterShortageVariable, V)
+    surplus_var = get_variable(container, HydroWaterSurplusVariable, V)
+    param_container = get_parameter(container, WaterTargetTimeSeriesParameter, V)
     multiplier =
-        get_parameter_multiplier_array(container, WaterTargetTimeSeriesParameter(), V)
+        get_parameter_multiplier_array(container, WaterTargetTimeSeriesParameter, V)
     for d in devices
         name = PSY.get_name(d)
         reservoir_type = PSY.get_level_data_type(d)
@@ -1091,15 +1082,13 @@ function add_constraints!(
     names = [PSY.get_name(x) for x in devices]
 
     energy_var =
-        get_variable(container, HydroReservoirVolumeVariable(), PSY.HydroReservoir)
+        get_variable(container, HydroReservoirVolumeVariable, PSY.HydroReservoir)
     turbined_out_flow_var =
-        get_variable(container, HydroTurbineFlowRateVariable(), PSY.HydroTurbine)
+        get_variable(container, HydroTurbineFlowRateVariable, PSY.HydroTurbine)
 
-    hydro_power = get_variable(container, ActivePowerVariable(), PSY.HydroTurbine)
+    hydro_power = get_variable(container, ActivePowerVariable, PSY.HydroTurbine)
 
-    constraint = add_constraints_container!(
-        container,
-        HydroPowerConstraint(),
+    constraint = add_constraints_container!(container, HydroPowerConstraint,
         PSY.HydroTurbine,
         names,
         time_steps,
@@ -1177,20 +1166,18 @@ function add_constraints!(
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
     names = [PSY.get_name(x) for x in devices]
 
-    energy_var = get_variable(container, HydroReservoirVolumeVariable(), V)
+    energy_var = get_variable(container, HydroReservoirVolumeVariable, V)
     turbined_out_flow_var =
-        get_variable(container, HydroTurbineFlowRateVariable(), PSY.HydroTurbine)
-    spillage_var = get_variable(container, WaterSpillageVariable(), V)
+        get_variable(container, HydroTurbineFlowRateVariable, PSY.HydroTurbine)
+    spillage_var = get_variable(container, WaterSpillageVariable, V)
 
-    constraint = add_constraints_container!(
-        container,
-        ReservoirInventoryConstraint(),
+    constraint = add_constraints_container!(container, ReservoirInventoryConstraint,
         V,
         names,
         time_steps,
     )
 
-    param_container = get_parameter(container, InflowTimeSeriesParameter(), V)
+    param_container = get_parameter(container, InflowTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
 
     t_first = first(time_steps)
@@ -1268,10 +1255,10 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint(), V, set_name)
+        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
 
-    variable_out = get_variable(container, ActivePowerVariable(), V)
-    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter(), V)
+    variable_out = get_variable(container, ActivePowerVariable, V)
+    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
 
     for d in devices
@@ -1300,15 +1287,15 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint(), V, set_name)
-    variable_out = get_variable(container, ActivePowerVariable(), V)
-    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter(), V)
+        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
+    variable_out = get_variable(container, ActivePowerVariable, V)
+    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
     for d in devices
         name = PSY.get_name(d)
         if get_use_slacks(model)
             slack_var =
-                sum(get_variable(container, HydroEnergyShortageVariable(), V)[name, :])
+                sum(get_variable(container, HydroEnergyShortageVariable, V)[name, :])
         else
             slack_var = 0.0
         end
@@ -1321,9 +1308,7 @@ function add_constraints!(
     end
     hydro_budget_interval = get_attribute(model, "hydro_budget_interval")
     if !isnothing(hydro_budget_interval)
-        constraint_aux = add_constraints_container!(
-            container,
-            EnergyBudgetConstraint(),
+        constraint_aux = add_constraints_container!(container, EnergyBudgetConstraint,
             V,
             set_name;
             meta = "interval",
@@ -1365,17 +1350,17 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint(), V, set_name)
+        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
 
-    total_power_out = get_expression(container, TotalHydroPowerReservoirOutgoing(), V)
-    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter(), V)
+    total_power_out = get_expression(container, TotalHydroPowerReservoirOutgoing, V)
+    param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
 
     for d in devices
         name = PSY.get_name(d)
         if get_use_slacks(model)
             slack_var =
-                sum(get_variable(container, HydroEnergyShortageVariable(), V)[name, :])
+                sum(get_variable(container, HydroEnergyShortageVariable, V)[name, :])
         else
             slack_var = 0.0
         end
@@ -1409,10 +1394,10 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, WaterBudgetConstraint(), V, set_name)
+        add_constraints_container!(container, WaterBudgetConstraint, V, set_name)
 
-    total_flow_out = get_expression(container, TotalHydroFlowRateReservoirOutgoing(), V)
-    param_container = get_parameter(container, WaterBudgetTimeSeriesParameter(), V)
+    total_flow_out = get_expression(container, TotalHydroFlowRateReservoirOutgoing, V)
+    param_container = get_parameter(container, WaterBudgetTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
 
     for d in devices
@@ -1442,12 +1427,10 @@ function add_constraints!(
 ) where {
     X <: AbstractPowerModel,
 }
-    bal_expr = get_expression(container, EnergyBalanceExpression(), PSY.System)
+    bal_expr = get_expression(container, EnergyBalanceExpression, PSY.System)
     buses_ax, times_ax = axes(bal_expr)
 
-    constraint = add_constraints_container!(
-        container,
-        EnergyBalanceConstraint(),
+    constraint = add_constraints_container!(container, EnergyBalanceConstraint,
         PSY.System,
         buses_ax,
         times_ax,
@@ -1479,18 +1462,14 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = [PSY.get_name(d) for d in devices]
     constraint_ub =
-        add_constraints_container!(
-            container,
-            ReservoirLevelLimitConstraint(),
+        add_constraints_container!(container, ReservoirLevelLimitConstraint,
             V,
             names,
             time_steps;
             meta = "ub",
         )
     constraint_lb =
-        add_constraints_container!(
-            container,
-            ReservoirLevelLimitConstraint(),
+        add_constraints_container!(container, ReservoirLevelLimitConstraint,
             V,
             names,
             time_steps;
@@ -1501,9 +1480,9 @@ function add_constraints!(
         name = PSY.get_name(d)
         if (PSY.get_level_data_type(d) == PSY.ReservoirDataType.USABLE_VOLUME) ||
            (PSY.get_level_data_type(d) == PSY.ReservoirDataType.TOTAL_VOLUME)
-            var = get_variable(container, HydroReservoirVolumeVariable(), V)
+            var = get_variable(container, HydroReservoirVolumeVariable, V)
         else
-            var = get_variable(container, HydroReservoirHeadVariable(), V)
+            var = get_variable(container, HydroReservoirHeadVariable, V)
         end
         level_limits = PSY.get_storage_level_limits(d)
         if isa(level_limits, PSY.TimeSeriesKey)
@@ -1543,20 +1522,18 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(
-            container,
-            ReservoirInventoryConstraint(),
+        add_constraints_container!(container, ReservoirInventoryConstraint,
             V,
             names,
             time_steps,
         )
-    turbine_in = get_expression(container, TotalHydroFlowRateReservoirIncoming(), V)
-    turbine_out = get_expression(container, TotalHydroFlowRateReservoirOutgoing(), V)
-    volume = get_variable(container, HydroReservoirVolumeVariable(), V)
-    spillage_var = get_variable(container, WaterSpillageVariable(), V)
-    spillage_in = get_expression(container, TotalSpillageFlowRateReservoirIncoming(), V)
-    param_container = get_parameter(container, InflowTimeSeriesParameter(), V)
-    param_container_outflow = get_parameter(container, OutflowTimeSeriesParameter(), V)
+    turbine_in = get_expression(container, TotalHydroFlowRateReservoirIncoming, V)
+    turbine_out = get_expression(container, TotalHydroFlowRateReservoirOutgoing, V)
+    volume = get_variable(container, HydroReservoirVolumeVariable, V)
+    spillage_var = get_variable(container, WaterSpillageVariable, V)
+    spillage_in = get_expression(container, TotalSpillageFlowRateReservoirIncoming, V)
+    param_container = get_parameter(container, InflowTimeSeriesParameter, V)
+    param_container_outflow = get_parameter(container, OutflowTimeSeriesParameter, V)
 
     initial_conditions = get_initial_condition(
         container,
@@ -1615,9 +1592,7 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
     constraint =
-        add_constraints_container!(
-            container,
-            ReservoirLevelTargetConstraint(),
+        add_constraints_container!(container, ReservoirLevelTargetConstraint,
             V,
             names,
         )
@@ -1627,9 +1602,9 @@ function add_constraints!(
         level_targets = PSY.get_level_targets(d) * PSY.get_storage_level_limits(d).max
         if (PSY.get_level_data_type(d) == PSY.ReservoirDataType.USABLE_VOLUME) ||
            (PSY.get_level_data_type(d) == PSY.ReservoirDataType.TOTAL_VOLUME)
-            var = get_variable(container, HydroReservoirVolumeVariable(), V)
+            var = get_variable(container, HydroReservoirVolumeVariable, V)
         else
-            var = get_variable(container, HydroReservoirHeadVariable(), V)
+            var = get_variable(container, HydroReservoirHeadVariable, V)
         end
 
         constraint[name] = JuMP.@constraint(
@@ -1657,9 +1632,7 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
     constraint =
-        add_constraints_container!(
-            container,
-            ReservoirLevelTargetConstraint(),
+        add_constraints_container!(container, ReservoirLevelTargetConstraint,
             V,
             names,
         )
@@ -1675,10 +1648,10 @@ function add_constraints!(
         end
         if (PSY.get_level_data_type(d) == PSY.ReservoirDataType.USABLE_VOLUME) ||
            (PSY.get_level_data_type(d) == PSY.ReservoirDataType.TOTAL_VOLUME)
-            var = get_variable(container, HydroReservoirVolumeVariable(), V)
+            var = get_variable(container, HydroReservoirVolumeVariable, V)
         else
             var =
-                get_variable(container, HydroReservoirVolumeVariable(), V) / h2v_factor
+                get_variable(container, HydroReservoirVolumeVariable, V) / h2v_factor
         end
 
         constraint[name] = JuMP.@constraint(
@@ -1707,15 +1680,13 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
     constraint =
-        add_constraints_container!(
-            container,
-            ReservoirHeadToVolumeConstraint(),
+        add_constraints_container!(container, ReservoirHeadToVolumeConstraint,
             V,
             names,
             time_steps,
         )
-    volume = get_variable(container, HydroReservoirVolumeVariable(), V)
-    head = get_variable(container, HydroReservoirHeadVariable(), V)
+    volume = get_variable(container, HydroReservoirVolumeVariable, V)
+    head = get_variable(container, HydroReservoirHeadVariable, V)
 
     for d in devices
         name = PSY.get_name(d)
@@ -1749,16 +1720,14 @@ function add_constraints!(
     base_power = get_model_base_power(container)
     names = PSY.get_name.(devices)
     constraint =
-        add_constraints_container!(
-            container,
-            TurbinePowerOutputConstraint(),
+        add_constraints_container!(container, TurbinePowerOutputConstraint,
             V,
             names,
             time_steps,
         )
-    power = get_variable(container, ActivePowerVariable(), V)
-    flow = get_variable(container, HydroTurbineFlowRateVariable(), V)
-    head = get_variable(container, HydroReservoirHeadVariable(), PSY.HydroReservoir)
+    power = get_variable(container, ActivePowerVariable, V)
+    flow = get_variable(container, HydroTurbineFlowRateVariable, V)
+    head = get_variable(container, HydroReservoirHeadVariable, PSY.HydroReservoir)
     for d in devices
         name = PSY.get_name(d)
         conversion_factor = PSY.get_conversion_factor(d)
@@ -1799,15 +1768,13 @@ function add_constraints!(
     base_power = get_model_base_power(container)
     names = PSY.get_name.(devices)
     constraint =
-        add_constraints_container!(
-            container,
-            TurbinePowerOutputConstraint(),
+        add_constraints_container!(container, TurbinePowerOutputConstraint,
             V,
             names,
             time_steps,
         )
-    power = get_variable(container, ActivePowerVariable(), V)
-    flow = get_variable(container, HydroTurbineFlowRateVariable(), V)
+    power = get_variable(container, ActivePowerVariable, V)
+    flow = get_variable(container, HydroTurbineFlowRateVariable, V)
     fraction_max_head = get_attribute(model, "head_fraction_usage")
     for d in devices
         name = PSY.get_name(d)
@@ -1850,15 +1817,13 @@ function add_expressions!(
     W <: AbstractHydroFormulation,
 }
     time_steps = get_time_steps(container)
-    expression = add_expression_container!(
-        container,
-        U(),
+    expression = add_expression_container!(container, U,
         V,
         [PSY.get_name(d) for d in devices],
         time_steps,
     )
 
-    variable = get_variable(container, HydroTurbineFlowRateVariable(), PSY.HydroTurbine)
+    variable = get_variable(container, HydroTurbineFlowRateVariable, PSY.HydroTurbine)
 
     for d in devices
         turbines = get_available_turbines(d, U)
@@ -1883,15 +1848,13 @@ function add_expressions!(
     W <: AbstractHydroFormulation,
 }
     time_steps = get_time_steps(container)
-    expression = add_expression_container!(
-        container,
-        TotalHydroFlowRateTurbineOutgoing(),
+    expression = add_expression_container!(container, TotalHydroFlowRateTurbineOutgoing,
         V,
         [PSY.get_name(d) for d in devices],
         time_steps,
     )
 
-    variable = get_variable(container, HydroTurbineFlowRateVariable(), PSY.HydroTurbine)
+    variable = get_variable(container, HydroTurbineFlowRateVariable, PSY.HydroTurbine)
 
     for d in devices
         reservoirs = filter(PSY.get_available, PSY.get_connected_head_reservoirs(sys, d))
@@ -1915,9 +1878,7 @@ function add_expressions!(
     W <: HydroEnergyModelReservoir,
 }
     time_steps = get_time_steps(container)
-    expression = add_expression_container!(
-        container,
-        U(),
+    expression = add_expression_container!(container, U,
         V,
         [PSY.get_name(d) for d in devices],
         time_steps,
@@ -1930,7 +1891,7 @@ function add_expressions!(
             PSY.get_upstream_turbines(d),
         )
         isempty(turbines) && continue
-        variable = get_variable(container, ActivePowerVariable(), PSY.HydroTurbine)
+        variable = get_variable(container, ActivePowerVariable, PSY.HydroTurbine)
         turbine_names = PSY.get_name.(turbines)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
@@ -1946,7 +1907,7 @@ function add_expressions!(
         )
         isempty(pumps) && continue
         turbine_power =
-            get_variable(container, ActivePowerVariable(), PSY.HydroPumpTurbine)
+            get_variable(container, ActivePowerVariable, PSY.HydroPumpTurbine)
         pump_names = PSY.get_name.(pumps)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
@@ -1962,7 +1923,7 @@ function add_expressions!(
         )
         isempty(pumps) && continue
         pump_power =
-            get_variable(container, ActivePowerPumpVariable(), PSY.HydroPumpTurbine)
+            get_variable(container, ActivePowerPumpVariable, PSY.HydroPumpTurbine)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
             JuMP.add_to_expression!(expression[reservoir_name, t],
@@ -1986,9 +1947,7 @@ function add_expressions!(
     W <: HydroEnergyModelReservoir,
 }
     time_steps = get_time_steps(container)
-    expression = add_expression_container!(
-        container,
-        U(),
+    expression = add_expression_container!(container, U,
         V,
         [PSY.get_name(d) for d in devices],
         time_steps,
@@ -2001,7 +1960,7 @@ function add_expressions!(
             PSY.get_downstream_turbines(d),
         )
         isempty(turbines) && continue
-        variable = get_variable(container, ActivePowerVariable(), PSY.HydroTurbine)
+        variable = get_variable(container, ActivePowerVariable, PSY.HydroTurbine)
         turbine_names = PSY.get_name.(turbines)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
@@ -2017,7 +1976,7 @@ function add_expressions!(
         )
         isempty(pumps) && continue
         turbine_power =
-            get_variable(container, ActivePowerVariable(), PSY.HydroPumpTurbine)
+            get_variable(container, ActivePowerVariable, PSY.HydroPumpTurbine)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
             # More power has to be taken from the head reservoir to produce the turbine power in the PumpTurbine
@@ -2036,7 +1995,7 @@ function add_expressions!(
         )
         isempty(pumps) && continue
         pump_power =
-            get_variable(container, ActivePowerPumpVariable(), PSY.HydroPumpTurbine)
+            get_variable(container, ActivePowerPumpVariable, PSY.HydroPumpTurbine)
         reservoir_name = PSY.get_name(d)
         for t in time_steps
             JuMP.add_to_expression!(expression[reservoir_name, t],
@@ -2057,15 +2016,13 @@ function add_expressions!(
     W <: AbstractHydroReservoirFormulation,
 }
     time_steps = get_time_steps(container)
-    expression = add_expression_container!(
-        container,
-        U(),
+    expression = add_expression_container!(container, U,
         V,
         [PSY.get_name(d) for d in devices],
         time_steps,
     )
 
-    variable = get_variable(container, WaterSpillageVariable(), PSY.HydroReservoir)
+    variable = get_variable(container, WaterSpillageVariable, PSY.HydroReservoir)
 
     for d in devices
         upstream_reservoirs = filter(PSY.get_available, PSY.get_upstream_reservoirs(d))
@@ -2095,10 +2052,10 @@ function add_to_balance_expression!(
     Y <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    expression = get_expression(container, U(), PSY.System)
+    expression = get_expression(container, U, PSY.System)
     ref_buses, time_ax = axes(expression)
     ref_bus = only(ref_buses)
-    variable = get_variable(container, V(), W)
+    variable = get_variable(container, V, W)
 
     for d in devices
         name = PSY.get_name(d)
@@ -2126,13 +2083,11 @@ function add_to_balance_expression!(
     Y <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    expression = get_expression(container, U(), PSY.System)
+    expression = get_expression(container, U, PSY.System)
     ref_buses, time_ax = axes(expression)
     ref_bus = only(ref_buses)
-    param_container = get_parameter(container, V(), W)
-    param_multiplier = get_parameter_multiplier_array(
-        container,
-        V(),
+    param_container = get_parameter(container, V, W)
+    param_multiplier = get_parameter_multiplier_array(container, V,
         W,
     )
 
@@ -2156,18 +2111,14 @@ function add_slack_to_balance_expression!(
     U <: PSY.System,
 }
     time_steps = get_time_steps(container)
-    expression = get_expression(container, EnergyBalanceExpression(), PSY.System)
+    expression = get_expression(container, EnergyBalanceExpression, PSY.System)
     ref_buses, time_ax = axes(expression)
-    sl_up = add_variable_container!(
-        container,
-        SystemBalanceSlackUp(),
+    sl_up = add_variable_container!(container, SystemBalanceSlackUp,
         PSY.System,
         ref_buses,
         time_steps,
     )
-    sl_dn = add_variable_container!(
-        container,
-        SystemBalanceSlackDown(),
+    sl_dn = add_variable_container!(container, SystemBalanceSlackDown,
         PSY.System,
         ref_buses,
         time_steps,
@@ -2207,15 +2158,15 @@ function calculate_aux_variable_value!(
     time_steps = get_time_steps(container)
     resolution = get_resolution(container)
     fraction_of_hour = Dates.value(Dates.Minute(resolution)) / MINUTES_IN_HOUR
-    p_variable_output = get_variable(container, ActivePowerVariable(), T)
-    aux_variable_container = get_aux_variable(container, HydroEnergyOutput(), T)
+    p_variable_output = get_variable(container, ActivePowerVariable, T)
+    aux_variable_container = get_aux_variable(container, HydroEnergyOutput, T)
     devices_names = axes(aux_variable_container, 1)
     for name in devices_names
         d = PSY.get_component(T, system, name)
         for t in time_steps
             if has_container_key(container, HydroServedReserveUpExpression, typeof(d))
                 served_regup = jump_value(
-                    get_expression(container, HydroServedReserveUpExpression(), T)[
+                    get_expression(container, HydroServedReserveUpExpression, T)[
                         name,
                         t,
                     ],
@@ -2225,7 +2176,7 @@ function calculate_aux_variable_value!(
             end
             if has_container_key(container, HydroServedReserveUpExpression, typeof(d))
                 served_regdn = jump_value(
-                    get_expression(container, HydroServedReserveDownExpression(), T)[
+                    get_expression(container, HydroServedReserveDownExpression, T)[
                         name,
                         t,
                     ],
@@ -2251,8 +2202,8 @@ function objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroGen, U <: AbstractHydroUnitCommitment}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
-    add_proportional_cost!(container, OnVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
+    add_proportional_cost!(container, OnVariable, devices, U)
     return
 end
 
@@ -2262,43 +2213,43 @@ end
 proportional_cost(
     ::OptimizationContainer,
     cost::PSY.HydroGenerationCost,
-    ::U,
+    ::Type{U},
     comp::PSY.HydroGen,
-    ::V,
+    ::Type{V},
     ::Int,
 ) where {U <: OnVariable, V <: AbstractHydroUnitCommitment} =
-    proportional_cost(cost, U(), comp, V())
+    proportional_cost(cost, U, comp, V)
 
 # copy-paste from PSI, just with types changed (HydroFoo => ThermalFoo):
 is_time_variant_term(
     ::OptimizationContainer,
     ::PSY.HydroGenerationCost,
-    ::OnVariable,
-    ::PSY.HydroGen,
-    ::AbstractHydroFormulation,
+    ::Type{OnVariable},
+    ::Type{<:PSY.HydroGen},
+    ::Type{<:AbstractHydroFormulation},
     t::Int,
 ) = false
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::V,
+    ::Type{V},
 ) where {T <: PSY.HydroGen, U <: OnVariable, V <: AbstractHydroUnitCommitment}
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     for d in devices
         op_cost_data = PSY.get_operation_cost(d)
         for t in get_time_steps(container)
-            cost_term = proportional_cost(container, op_cost_data, U(), d, V(), t)
+            cost_term = proportional_cost(container, op_cost_data, U, d, V, t)
             add_as_time_variant =
-                is_time_variant_term(container, op_cost_data, U(), d, V(), t)
+                is_time_variant_term(container, op_cost_data, U, T, V, t)
             iszero(cost_term) && continue
             cost_term *= multiplier
             exp = if d isa PSY.HydroPumpTurbine && PSY.get_must_run(d)
                 cost_term  # note we do not add this to the objective function
             else
                 _add_proportional_term_maybe_variant!(
-                    Val(add_as_time_variant), container, U(), d, cost_term, t)
+                    Val(add_as_time_variant), container, U, d, cost_term, t)
             end
             add_to_expression!(container, ProductionCostExpression, exp, d, t)
         end
@@ -2309,9 +2260,9 @@ end
 proportional_cost(
     container::OptimizationContainer,
     cost::PSY.MarketBidCost,
-    ::OnVariable,
+    ::Type{OnVariable},
     comp::PSY.HydroGen,
-    ::AbstractHydroUnitCommitment,
+    ::Type{<:AbstractHydroUnitCommitment},
     t::Int,
 ) =
     _lookup_maybe_time_variant_param(container, comp, t,
@@ -2322,9 +2273,9 @@ proportional_cost(
 is_time_variant_term(
     ::OptimizationContainer,
     cost::PSY.MarketBidCost,
-    ::OnVariable,
-    ::PSY.HydroGen,
-    ::AbstractHydroUnitCommitment,
+    ::Type{OnVariable},
+    ::Type{<:PSY.HydroGen},
+    ::Type{<:AbstractHydroUnitCommitment},
     t::Int,
 ) =
     is_time_variant(PSY.get_incremental_initial_input(cost))
@@ -2334,33 +2285,33 @@ is_time_variant_term(
 # These _include_{constant}_min_gen_power functions are needed for MarketBidCost.
 # Commitment has an on/off choice, so add OnVariable * breakpoint1 to power constraint.
 _include_min_gen_power_in_constraint(
-    ::PSY.HydroGen,
-    ::ActivePowerVariable,
-    ::HydroCommitmentRunOfRiver,
+    ::Type{<:PSY.HydroGen},
+    ::Type{ActivePowerVariable},
+    ::Type{HydroCommitmentRunOfRiver},
 ) = true
 # Dispatch with ActivePower (not PowerAboveMinimum) means generator is on,
 # so add constant breakpoint1 to power constraint.
 _include_min_gen_power_in_constraint(
-    ::PSY.HydroGen,
-    ::ActivePowerVariable,
-    ::HydroDispatchRunOfRiver,
+    ::Type{<:PSY.HydroGen},
+    ::Type{ActivePowerVariable},
+    ::Type{HydroDispatchRunOfRiver},
 ) = false
 
 _include_constant_min_gen_power_in_constraint(
-    ::PSY.HydroGen,
-    ::ActivePowerVariable,
-    ::HydroDispatchRunOfRiver,
+    ::Type{<:PSY.HydroGen},
+    ::Type{ActivePowerVariable},
+    ::Type{HydroDispatchRunOfRiver},
 ) = true
 
 _include_min_gen_power_in_constraint(
-    ::PSY.EnergyReservoirStorage,
-    ::ActivePowerInVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{<:PSY.EnergyReservoirStorage},
+    ::Type{ActivePowerInVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 _include_min_gen_power_in_constraint(
-    ::PSY.EnergyReservoirStorage,
-    ::ActivePowerOutVariable,
-    ::AbstractDeviceFormulation,
+    ::Type{<:PSY.EnergyReservoirStorage},
+    ::Type{ActivePowerOutVariable},
+    ::Type{<:AbstractDeviceFormulation},
 ) = false
 
 function objective_function!(
@@ -2369,7 +2320,7 @@ function objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroGen, U <: AbstractHydroDispatchFormulation}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
     return
 end
 
@@ -2379,9 +2330,9 @@ function objective_function!(
     model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroGen, U <: HydroDispatchRunOfRiverBudget}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
     if get_use_slacks(model)
-        add_proportional_cost!(container, HydroEnergyShortageVariable(), devices, U())
+        add_proportional_cost!(container, HydroEnergyShortageVariable, devices, U)
     end
     return
 end
@@ -2392,12 +2343,12 @@ function objective_function!(
     model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroReservoir, U <: HydroEnergyModelReservoir}
-    add_proportional_cost!(container, HydroEnergySurplusVariable(), devices, U())
-    add_proportional_cost!(container, HydroEnergyShortageVariable(), devices, U())
-    add_proportional_cost!(container, WaterSpillageVariable(), devices, U())
+    add_proportional_cost!(container, HydroEnergySurplusVariable, devices, U)
+    add_proportional_cost!(container, HydroEnergyShortageVariable, devices, U)
+    add_proportional_cost!(container, WaterSpillageVariable, devices, U)
     if get_use_slacks(model)
-        add_proportional_cost!(container, HydroBalanceShortageVariable(), devices, U())
-        add_proportional_cost!(container, HydroBalanceSurplusVariable(), devices, U())
+        add_proportional_cost!(container, HydroBalanceShortageVariable, devices, U)
+        add_proportional_cost!(container, HydroBalanceSurplusVariable, devices, U)
     end
     return
 end
@@ -2408,9 +2359,9 @@ function objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroReservoir, U <: HydroWaterModelReservoir}
-    add_proportional_cost!(container, HydroWaterSurplusVariable(), devices, U())
-    add_proportional_cost!(container, HydroWaterShortageVariable(), devices, U())
-    add_proportional_cost!(container, WaterSpillageVariable(), devices, U())
+    add_proportional_cost!(container, HydroWaterSurplusVariable, devices, U)
+    add_proportional_cost!(container, HydroWaterShortageVariable, devices, U)
+    add_proportional_cost!(container, WaterSpillageVariable, devices, U)
     return
 end
 
@@ -2420,16 +2371,16 @@ function objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.HydroPumpTurbine, U <: AbstractHydroPumpFormulation}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
-    add_variable_cost!(container, ActivePowerPumpVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
+    add_variable_cost!(container, ActivePowerPumpVariable, devices, U)
     return
 end
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::V,
+    ::Type{V},
 ) where {
     T <: PSY.Component,
     U <:
@@ -2437,15 +2388,15 @@ function add_proportional_cost!(
     V <: AbstractDeviceFormulation,
 }
     base_p = get_model_base_power(container)
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     for d in devices
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, U(), d, V())
+        cost_term = proportional_cost(op_cost_data, U, d, V)
         iszero(cost_term) && continue
         for t in get_time_steps(container)
             _add_proportional_term!(
                 container,
-                U(),
+                U,
                 d,
                 cost_term * multiplier * base_p,
                 t,
@@ -2457,9 +2408,9 @@ end
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::V,
+    ::Type{V},
 ) where {
     T <: PSY.HydroReservoir,
     U <:
@@ -2467,15 +2418,15 @@ function add_proportional_cost!(
     V <: HydroEnergyModelReservoir,
 }
     base_p = get_model_base_power(container)
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     for d in devices
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, U(), d, V())
+        cost_term = proportional_cost(op_cost_data, U, d, V)
         iszero(cost_term) && continue
         for t in get_time_steps(container)
             _add_proportional_term!(
                 container,
-                U(),
+                U,
                 d,
                 cost_term * multiplier * base_p,
                 t,
@@ -2487,25 +2438,25 @@ end
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::V,
+    ::Type{V},
 ) where {
     T <: PSY.HydroReservoir,
     U <: Union{HydroBalanceShortageVariable, HydroBalanceSurplusVariable},
     V <: HydroEnergyModelReservoir,
 }
     base_p = get_model_base_power(container)
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     for d in devices
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, U(), d, V())
+        cost_term = proportional_cost(op_cost_data, U, d, V)
         iszero(cost_term) && continue
         time_steps = get_time_steps(container)
         for t in time_steps
             _add_proportional_term!(
                 container,
-                U(),
+                U,
                 d,
                 cost_term * multiplier * base_p,
                 t,
@@ -2517,24 +2468,24 @@ end
 
 function add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    ::V,
+    ::Type{V},
 ) where {
     T <: PSY.HydroReservoir,
     U <: Union{HydroWaterSurplusVariable, HydroWaterShortageVariable},
     V <: HydroWaterModelReservoir,
 }
     base_p = get_model_base_power(container)
-    multiplier = objective_function_multiplier(U(), V())
+    multiplier = objective_function_multiplier(U, V)
     for d in devices
         op_cost_data = PSY.get_operation_cost(d)
-        cost_term = proportional_cost(op_cost_data, U(), d, V())
+        cost_term = proportional_cost(op_cost_data, U, d, V)
         iszero(cost_term) && continue
         for t in get_time_steps(container)
             _add_proportional_term!(
                 container,
-                U(),
+                U,
                 d,
                 cost_term * multiplier * base_p,
                 t,
@@ -2593,13 +2544,11 @@ function add_constraints!(
     if !get_attribute(model, "reservation")
         add_range_constraints!(container, T, U, devices, model, X)
     else
-        array = get_expression(container, U(), V)
-        reservation = get_variable(container, ReservationVariable(), V)
+        array = get_expression(container, U, V)
+        reservation = get_variable(container, ReservationVariable, V)
         time_steps = get_time_steps(container)
         device_names = [PSY.get_name(d) for d in devices]
-        con_lb = add_constraints_container!(
-            container,
-            T(),
+        con_lb = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
@@ -2636,13 +2585,11 @@ function add_constraints!(
     if !get_attribute(model, "reservation")
         add_range_constraints!(container, T, U, devices, model, X)
     else
-        array = get_expression(container, U(), V)
-        reservation = get_variable(container, ReservationVariable(), V)
+        array = get_expression(container, U, V)
+        reservation = get_variable(container, ReservationVariable, V)
         time_steps = get_time_steps(container)
         device_names = [PSY.get_name(d) for d in devices]
-        con_ub = add_constraints_container!(
-            container,
-            T(),
+        con_ub = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
@@ -2679,22 +2626,18 @@ function add_constraints!(
     if !get_attribute(model, "reservation")
         add_semicontinuous_range_constraints!(container, T, U, devices, model, X)
     else
-        array = get_expression(container, U(), V)
-        reservation = get_variable(container, ReservationVariable(), V)
-        onvar = get_variable(container, OnVariable(), V)
+        array = get_expression(container, U, V)
+        reservation = get_variable(container, ReservationVariable, V)
+        onvar = get_variable(container, OnVariable, V)
         time_steps = get_time_steps(container)
         device_names = [PSY.get_name(d) for d in devices]
-        con_lb = add_constraints_container!(
-            container,
-            T(),
+        con_lb = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
             meta = "lb",
         )
-        con_lb_aux = add_constraints_container!(
-            container,
-            T(),
+        con_lb_aux = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
@@ -2736,22 +2679,18 @@ function add_constraints!(
     if !get_attribute(model, "reservation")
         add_semicontinuous_range_constraints!(container, T, U, devices, model, X)
     else
-        array = get_expression(container, U(), V)
-        reservation = get_variable(container, ReservationVariable(), V)
-        onvar = get_variable(container, OnVariable(), V)
+        array = get_expression(container, U, V)
+        reservation = get_variable(container, ReservationVariable, V)
+        onvar = get_variable(container, OnVariable, V)
         time_steps = get_time_steps(container)
         device_names = [PSY.get_name(d) for d in devices]
-        con_ub = add_constraints_container!(
-            container,
-            T(),
+        con_ub = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
             meta = "ub",
         )
-        con_ub_aux = add_constraints_container!(
-            container,
-            T(),
+        con_ub_aux = add_constraints_container!(container, T,
             V,
             device_names,
             time_steps;
@@ -2808,20 +2747,19 @@ function add_constraints!(
 }
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    power_var = get_variable(container, ActivePowerPumpVariable(), V)
-    reservation_var = get_variable(container, ReservationVariable(), V)
+    power_var = get_variable(container, ActivePowerPumpVariable, V)
+    reservation_var = get_variable(container, ReservationVariable, V)
 
-    constraint = add_constraints_container!(
-        container,
-        ActivePowerPumpReservationConstraint(),
-        V,
-        names,
-        time_steps,
-    )
+    constraint =
+        add_constraints_container!(container, ActivePowerPumpReservationConstraint,
+            V,
+            names,
+            time_steps,
+        )
 
     for device in devices
         name = PSY.get_name(device)
-        pump_max = get_variable_upper_bound(ActivePowerPumpVariable(), device, W())
+        pump_max = get_variable_upper_bound(ActivePowerPumpVariable, device, W)
         for t in time_steps
             constraint[name, t] = JuMP.@constraint(
                 container.JuMPmodel,
@@ -2871,7 +2809,7 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices
         name = PSY.get_name(d)
         service_models = get_services(model)
@@ -2886,9 +2824,7 @@ function add_to_expression!(
             service = services[service_ix]
             if isa(service, PSY.Reserve{PSY.ReserveUp})
                 deployed_fraction = PSY.get_deployed_fraction(service)
-                variable = get_variable(
-                    container,
-                    U(),
+                variable = get_variable(container, U,
                     typeof(service),
                     service_name,
                 )
@@ -2918,7 +2854,7 @@ function add_to_expression!(
     W <: AbstractDeviceFormulation,
     X <: AbstractPowerModel,
 }
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices
         name = PSY.get_name(d)
         service_models = get_services(model)
@@ -2934,9 +2870,7 @@ function add_to_expression!(
             service = services[service_ix]
             if isa(service, PSY.Reserve{PSY.ReserveDown})
                 deployed_fraction = PSY.get_deployed_fraction(service)
-                variable = get_variable(
-                    container,
-                    U(),
+                variable = get_variable(container, U,
                     typeof(service),
                     service_name,
                 )
@@ -2975,7 +2909,7 @@ function _add_parameters!(
     mult = fraction_of_hour * length(time_steps) / HOURS_IN_DAY
     key = AuxVarKey{HydroEnergyOutput, D}("")
     parameter_container =
-        add_param_container!(container, T(), D, key, names, [time_steps[end]])
+        add_param_container!(container, T, D, key, names, [time_steps[end]])
     jump_model = get_jump_model(container)
 
     for d in devices
@@ -2984,7 +2918,7 @@ function _add_parameters!(
         set_parameter!(
             parameter_container,
             jump_model,
-            mult * get_initial_parameter_value(T(), d, W()),
+            mult * get_initial_parameter_value(T, d, W),
             name,
             time_steps[end],
         )
@@ -3006,11 +2940,11 @@ function add_to_expression!(
     W <: AbstractReservesFormulation,
 }
     service_name = get_service_name(model)
-    variable = get_variable(container, U(), X, service_name)
+    variable = get_variable(container, U, X, service_name)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices, t in get_time_steps(container)
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(expression[name, t], variable[name, t], 1.0)
@@ -3032,11 +2966,11 @@ function add_to_expression!(
     W <: AbstractReservesFormulation,
 }
     service_name = get_service_name(model)
-    variable = get_variable(container, U(), X, service_name)
+    variable = get_variable(container, U, X, service_name)
     if !has_container_key(container, T, V)
         add_expressions!(container, T, devices, model)
     end
-    expression = get_expression(container, T(), V)
+    expression = get_expression(container, T, V)
     for d in devices, t in get_time_steps(container)
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(expression[name, t], variable[name, t], -1.0)
@@ -3065,7 +2999,7 @@ function _add_parameters!(
     mult = fraction_of_hour * length(time_steps) / HOURS_IN_DAY
     key = ExpressionKey{TotalHydroFlowRateReservoirOutgoing, D}("")
     parameter_container =
-        add_param_container!(container, T(), D, key, names, time_steps)
+        add_param_container!(container, T, D, key, names, time_steps)
     jump_model = get_jump_model(container)
 
     for d in devices
@@ -3075,7 +3009,7 @@ function _add_parameters!(
             set_parameter!(
                 parameter_container,
                 jump_model,
-                mult * get_initial_parameter_value(T(), d, W()),
+                mult * get_initial_parameter_value(T, d, W),
                 name,
                 t,
             )

--- a/src/static_injector_models/hydrogeneration_constructor.jl
+++ b/src/static_injector_models/hydrogeneration_constructor.jl
@@ -96,9 +96,9 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -231,8 +231,8 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -350,9 +350,9 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -377,7 +377,7 @@ function construct_device!(
             container,
             HydroEnergyShortageVariable,
             devices,
-            D(),
+            D,
         )
     end
     process_market_bid_parameters!(container, devices, model)
@@ -493,8 +493,8 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -511,7 +511,7 @@ function construct_device!(
             container,
             HydroEnergyShortageVariable,
             devices,
-            D(),
+            D,
         )
     end
     process_market_bid_parameters!(container, devices, model)
@@ -618,10 +618,10 @@ function construct_device!(
 ) where {H <: PSY.HydroGen, D <: HydroCommitmentRunOfRiver, S <: AbstractPowerModel}
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -687,9 +687,9 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -811,25 +811,25 @@ function construct_device!(
         container,
         EnergyVariable,
         devices,
-        T(),
+        T,
     )
     add_variables!(
         container,
         WaterSpillageVariable,
         devices,
-        T(),
+        T,
     )
     add_variables!(
         container,
         HydroEnergyShortageVariable,
         devices,
-        T(),
+        T,
     )
     add_variables!(
         container,
         HydroEnergySurplusVariable,
         devices,
-        T(),
+        T,
     )
 
     add_parameters!(container, InflowTimeSeriesParameter, devices, model)
@@ -845,13 +845,13 @@ function construct_device!(
             container,
             HydroBalanceSurplusVariable,
             devices,
-            T(),
+            T,
         )
         add_variables!(
             container,
             HydroBalanceShortageVariable,
             devices,
-            T(),
+            T,
         )
     end
 
@@ -958,9 +958,9 @@ function construct_device!(
     # why is there no add_parameters here?
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1090,8 +1090,8 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1209,10 +1209,10 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1342,9 +1342,9 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
-    add_variables!(container, OnVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
+    add_variables!(container, OnVariable, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1463,13 +1463,13 @@ function construct_device!(
         container,
         WaterSpillageVariable,
         devices,
-        HydroWaterFactorModel(),
+        HydroWaterFactorModel,
     )
     add_variables!(
         container,
         HydroReservoirVolumeVariable,
         devices,
-        HydroWaterFactorModel(),
+        HydroWaterFactorModel,
     )
 
     add_parameters!(container, InflowTimeSeriesParameter, devices, model)
@@ -1535,11 +1535,11 @@ function construct_device!(
         container,
         HydroTurbineFlowRateVariable,
         devices,
-        HydroWaterFactorModel(),
+        HydroWaterFactorModel,
     )
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, HydroEnergyOutput, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, HydroEnergyOutput, devices, D)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1661,31 +1661,31 @@ function construct_device!(
         container,
         HydroReservoirHeadVariable,
         devices,
-        R(),
+        R,
     )
     add_variables!(
         container,
         HydroReservoirVolumeVariable,
         devices,
-        R(),
+        R,
     )
     add_variables!(
         container,
         WaterSpillageVariable,
         devices,
-        R(),
+        R,
     )
     add_variables!(
         container,
         HydroWaterShortageVariable,
         devices,
-        R(),
+        R,
     )
     add_variables!(
         container,
         HydroWaterSurplusVariable,
         devices,
-        R(),
+        R,
     )
 
     add_parameters!(container, InflowTimeSeriesParameter, devices, model)
@@ -1820,10 +1820,10 @@ function construct_device!(
         HydroTurbineFlowRateVariable,
         devices,
         reservoirs,
-        D(),
+        D,
     )
 
-    add_variables!(container, ActivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
 
     add_to_expression!(
         container,
@@ -1956,12 +1956,12 @@ function construct_device!(
     S <: AbstractPowerModel,
 }
     devices = get_available_components(model, sys)
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ActivePowerPumpVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ActivePowerPumpVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_market_bid_parameters!(container, devices, model)
@@ -2025,11 +2025,11 @@ function construct_device!(
     S <: AbstractActivePowerModel,
 }
     devices = get_available_components(model, sys)
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ActivePowerPumpVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ActivePowerPumpVariable, devices, D)
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_market_bid_parameters!(container, devices, model)
@@ -2135,13 +2135,13 @@ function construct_device!(
     S <: AbstractPowerModel,
 }
     devices = get_available_components(model, sys)
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ActivePowerPumpVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ActivePowerPumpVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_market_bid_parameters!(container, devices, model)
@@ -2205,12 +2205,12 @@ function construct_device!(
     S <: AbstractActivePowerModel,
 }
     devices = get_available_components(model, sys)
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ActivePowerPumpVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ActivePowerPumpVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_market_bid_parameters!(container, devices, model)

--- a/src/static_injector_models/load_constructor.jl
+++ b/src/static_injector_models/load_constructor.jl
@@ -14,8 +14,8 @@ function construct_device!(
             sys,
         )
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
 
     process_market_bid_parameters!(container, devices, model, false, true)
 
@@ -104,7 +104,7 @@ function construct_device!(
             sys,
         )
 
-    add_variables!(container, ActivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
 
     # Add Variables to expressions
     add_to_expression!(
@@ -173,9 +173,9 @@ function construct_device!(
             sys,
         )
 
-    add_variables!(container, ActivePowerVariable, devices, PowerLoadInterruption())
-    add_variables!(container, ReactivePowerVariable, devices, PowerLoadInterruption())
-    add_variables!(container, OnVariable, devices, PowerLoadInterruption())
+    add_variables!(container, ActivePowerVariable, devices, PowerLoadInterruption)
+    add_variables!(container, ReactivePowerVariable, devices, PowerLoadInterruption)
+    add_variables!(container, OnVariable, devices, PowerLoadInterruption)
 
     # Add Variables to expressions
     add_to_expression!(
@@ -269,8 +269,8 @@ function construct_device!(
             sys,
         )
 
-    add_variables!(container, ActivePowerVariable, devices, PowerLoadInterruption())
-    add_variables!(container, OnVariable, devices, PowerLoadInterruption())
+    add_variables!(container, ActivePowerVariable, devices, PowerLoadInterruption)
+    add_variables!(container, OnVariable, devices, PowerLoadInterruption)
 
     process_market_bid_parameters!(container, devices, model, false, true)
     # Add Variables to expressions

--- a/src/static_injector_models/reactivepower_device.jl
+++ b/src/static_injector_models/reactivepower_device.jl
@@ -1,13 +1,13 @@
 #! format: off
 
 requires_initialization(::AbstractReactivePowerDeviceFormulation) = false
-get_variable_multiplier(::VariableType, ::Type{<:PSY.SynchronousCondenser}, ::AbstractReactivePowerDeviceFormulation) = 1.0
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.SynchronousCondenser}, ::Type{<:AbstractReactivePowerDeviceFormulation}) = 1.0
 
 ############## ReactivePowerVariable, SynchronousCondensers ####################
-get_variable_binary(::ReactivePowerVariable, ::Type{PSY.SynchronousCondenser}, ::AbstractReactivePowerDeviceFormulation) = false
-get_variable_warm_start_value(::ReactivePowerVariable, d::PSY.SynchronousCondenser, ::AbstractReactivePowerDeviceFormulation) = PSY.get_reactive_power(d)
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.SynchronousCondenser, ::AbstractReactivePowerDeviceFormulation) = isnothing(PSY.get_reactive_power_limits(d)) ? nothing : PSY.get_reactive_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.SynchronousCondenser, ::AbstractReactivePowerDeviceFormulation) = isnothing(PSY.get_reactive_power_limits(d)) ? nothing : PSY.get_reactive_power_limits(d).max
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{PSY.SynchronousCondenser}, ::Type{<:AbstractReactivePowerDeviceFormulation}) = false
+get_variable_warm_start_value(::Type{ReactivePowerVariable}, d::PSY.SynchronousCondenser, ::Type{<:AbstractReactivePowerDeviceFormulation}) = PSY.get_reactive_power(d)
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.SynchronousCondenser, ::Type{<:AbstractReactivePowerDeviceFormulation}) = isnothing(PSY.get_reactive_power_limits(d)) ? nothing : PSY.get_reactive_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.SynchronousCondenser, ::Type{<:AbstractReactivePowerDeviceFormulation}) = isnothing(PSY.get_reactive_power_limits(d)) ? nothing : PSY.get_reactive_power_limits(d).max
 
 #! format: on
 function get_initial_conditions_device_model(

--- a/src/static_injector_models/reactivepowerdevice_constructor.jl
+++ b/src/static_injector_models/reactivepowerdevice_constructor.jl
@@ -9,7 +9,7 @@ function construct_device!(
     D <: AbstractReactivePowerDeviceFormulation,
 }
     devices = get_available_components(model, sys)
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ReactivePowerVariable, devices, D)
     add_to_expression!(
         container,
         ReactivePowerBalance,

--- a/src/static_injector_models/renewable_generation.jl
+++ b/src/static_injector_models/renewable_generation.jl
@@ -1,27 +1,27 @@
 #! format: off
-get_variable_multiplier(::VariableType, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = 1.0
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.RenewableGen}, ::Type{<:AbstractRenewableFormulation}) = 1.0
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
 ########################### ActivePowerVariable, RenewableGen #################################
 
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:AbstractRenewableFormulation}) = false
 get_min_max_limits(d::PSY.RenewableGen, ::Type{ActivePowerVariableLimitsConstraint}, ::Type{<:AbstractRenewableFormulation}) = (min = 0.0, max = PSY.get_max_active_power(d))
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = PSY.get_max_active_power(d)
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.RenewableGen, ::Type{<:AbstractRenewableFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.RenewableGen, ::Type{<:AbstractRenewableFormulation}) = PSY.get_max_active_power(d)
 
 ########################### ReactivePowerVariable, RenewableGen #################################
 
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.RenewableGen}, ::AbstractRenewableFormulation) = false
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:AbstractRenewableFormulation}) = false
 
-get_multiplier_value(::TimeSeriesParameter, d::PSY.RenewableGen, ::FixedOutput) = PSY.get_max_active_power(d)
-get_multiplier_value(::TimeSeriesParameter, d::PSY.RenewableGen, ::AbstractRenewableFormulation) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.RenewableGen, ::Type{FixedOutput}) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{<:TimeSeriesParameter}, d::PSY.RenewableGen, ::Type{<:AbstractRenewableFormulation}) = PSY.get_max_active_power(d)
 
 # To avoid ambiguity with default_interface_methods.jl:
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, ::PSY.RenewableGen, ::FixedOutput) = 1.0
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, ::PSY.RenewableGen, ::AbstractRenewableFormulation) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.RenewableGen, ::Type{FixedOutput}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.RenewableGen, ::Type{<:AbstractRenewableFormulation}) = 1.0
 
 ########################Objective Function##################################################
-objective_function_multiplier(::ActivePowerVariable, ::AbstractRenewableDispatchFormulation)=OBJECTIVE_FUNCTION_NEGATIVE
+objective_function_multiplier(::Type{ActivePowerVariable}, ::Type{<:AbstractRenewableDispatchFormulation})=OBJECTIVE_FUNCTION_NEGATIVE
 #! format: on
 
 get_initial_conditions_device_model(
@@ -35,7 +35,7 @@ get_initial_conditions_device_model(
 ) where {T <: PSY.RenewableGen} = DeviceModel(T, FixedOutput)
 
 function get_min_max_limits(
-    device,
+    device::PSY.RenewableGen,
     ::Type{ReactivePowerVariableLimitsConstraint},
     ::Type{<:AbstractRenewableFormulation},
 )
@@ -90,11 +90,11 @@ function add_constraints!(
 }
     names = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
-    p_var = get_variable(container, ActivePowerVariable(), V)
-    q_var = get_variable(container, ReactivePowerVariable(), V)
+    p_var = get_variable(container, ActivePowerVariable, V)
+    q_var = get_variable(container, ReactivePowerVariable, V)
     jump_model = get_jump_model(container)
     constraint =
-        add_constraints_container!(container, EqualityConstraint(), V, names, time_steps)
+        add_constraints_container!(container, EqualityConstraint, V, names, time_steps)
     for t in time_steps, d in devices
         name = PSY.get_name(d)
         pf = sin(acos(PSY.get_power_factor(d)))
@@ -157,6 +157,6 @@ function add_to_objective_function!(
     ::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.RenewableGen, U <: AbstractRenewableDispatchFormulation}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
     return
 end

--- a/src/static_injector_models/renewablegeneration_constructor.jl
+++ b/src/static_injector_models/renewablegeneration_constructor.jl
@@ -10,8 +10,8 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
     if haskey(get_time_series_names(model), ActivePowerTimeSeriesParameter)
         add_parameters!(container, ActivePowerTimeSeriesParameter, devices, model)
     end
@@ -131,7 +131,7 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
     # this is always true!! see get_default_time_series_names in renewable_generation.jl
     # and line 62 of device_model.jl
     if haskey(get_time_series_names(model), ActivePowerTimeSeriesParameter)

--- a/src/static_injector_models/source.jl
+++ b/src/static_injector_models/source.jl
@@ -3,30 +3,30 @@
 requires_initialization(::ImportExportSourceModel) = false
 
 
-get_variable_multiplier(::ActivePowerOutVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = 1.0
-get_variable_multiplier(::ActivePowerInVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = -1.0
-get_variable_multiplier(::ReactivePowerVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = 1.0
+get_variable_multiplier(::Type{ActivePowerOutVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = 1.0
+get_variable_multiplier(::Type{ActivePowerInVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = -1.0
+get_variable_multiplier(::Type{ReactivePowerVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = 1.0
 ############## ActivePowerVariables, Source ####################
-get_variable_binary(::ActivePowerInVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = false
-get_variable_binary(::ActivePowerOutVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = false
-get_variable_lower_bound(::ActivePowerInVariable, d::PSY.Source, ::AbstractSourceFormulation) = 0.0
-get_variable_lower_bound(::ActivePowerOutVariable, d::PSY.Source, ::AbstractSourceFormulation) = 0.0
-get_variable_upper_bound(::ActivePowerInVariable, d::PSY.Source, ::AbstractSourceFormulation) = -PSY.get_active_power_limits(d).min
-get_variable_upper_bound(::ActivePowerOutVariable, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_active_power_limits(d).max
+get_variable_binary(::Type{ActivePowerInVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = false
+get_variable_binary(::Type{ActivePowerOutVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = false
+get_variable_lower_bound(::Type{ActivePowerInVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = 0.0
+get_variable_lower_bound(::Type{ActivePowerOutVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = 0.0
+get_variable_upper_bound(::Type{ActivePowerInVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = -PSY.get_active_power_limits(d).min
+get_variable_upper_bound(::Type{ActivePowerOutVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d).max
 
 ############## ReactivePowerVariable, Source ####################
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.Source}, ::AbstractSourceFormulation) = false
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_reactive_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_reactive_power_limits(d).max
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.Source}, ::Type{<:AbstractSourceFormulation}) = false
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_reactive_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_reactive_power_limits(d).max
 
-get_multiplier_value(::ActivePowerTimeSeriesParameter, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_active_power_limits(d).max
-get_multiplier_value(::ActivePowerOutTimeSeriesParameter, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_active_power_limits(d).max
-get_multiplier_value(::ActivePowerInTimeSeriesParameter, d::PSY.Source, ::AbstractSourceFormulation) = PSY.get_active_power_limits(d).max
+get_multiplier_value(::Type{ActivePowerTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d).max
+get_multiplier_value(::Type{ActivePowerOutTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d).max
+get_multiplier_value(::Type{ActivePowerInTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d).max
 # This additional method definition is used to avoid ambiguity with the method defined in default_interface_methods.jl
-get_multiplier_value(::AbstractPiecewiseLinearBreakpointParameter, d::PSY.Source, ::AbstractSourceFormulation) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = 1.0
 
 ############## ReservationVariable, Source ####################
-get_variable_binary(::ReservationVariable, ::Type{<:PSY.Source}, ::ImportExportSourceModel) = true
+get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.Source}, ::Type{ImportExportSourceModel}) = true
 
 
 #! format: on
@@ -47,7 +47,7 @@ function get_default_attributes(
 end
 
 function get_min_max_limits(
-    device,
+    device::PSY.Source,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{<:AbstractSourceFormulation},
 )
@@ -55,7 +55,7 @@ function get_min_max_limits(
 end
 
 function get_min_max_limits(
-    device,
+    device::PSY.Source,
     ::Type{InputActivePowerVariableLimitsConstraint},
     ::Type{<:AbstractSourceFormulation},
 )
@@ -63,7 +63,7 @@ function get_min_max_limits(
 end
 
 function get_min_max_limits(
-    device,
+    device::PSY.Source,
     ::Type{ReactivePowerVariableLimitsConstraint},
     ::Type{<:AbstractSourceFormulation},
 )
@@ -107,20 +107,16 @@ function add_constraints!(
     resolution = get_resolution(container)
     resolution_in_hours = Dates.Hour(resolution).value
     hours_in_horizon = length(time_steps) * resolution_in_hours
-    p_out = get_variable(container, ActivePowerOutVariable(), U)
-    p_in = get_variable(container, ActivePowerInVariable(), U)
+    p_out = get_variable(container, ActivePowerOutVariable, U)
+    p_in = get_variable(container, ActivePowerInVariable, U)
     names = PSY.get_name.(devices)
     constraint_export =
-        add_constraints_container!(
-            container,
-            ImportExportBudgetConstraint(),
+        add_constraints_container!(container, ImportExportBudgetConstraint,
             U,
             names;
             meta = "export",
         )
-    constraint_import = add_constraints_container!(
-        container,
-        ImportExportBudgetConstraint(),
+    constraint_import = add_constraints_container!(container, ImportExportBudgetConstraint,
         U,
         names;
         meta = "import",
@@ -199,8 +195,8 @@ function add_to_objective_function!(
     ::DeviceModel{T, U},
     ::Type{V},
 ) where {T <: PSY.Source, U <: AbstractSourceFormulation, V <: AbstractPowerModel}
-    add_variable_cost!(container, ActivePowerOutVariable(), devices, U())
-    add_variable_cost!(container, ActivePowerInVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerOutVariable, devices, U)
+    add_variable_cost!(container, ActivePowerInVariable, devices, U)
     return
 end
 

--- a/src/static_injector_models/source_constructor.jl
+++ b/src/static_injector_models/source_constructor.jl
@@ -13,9 +13,9 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerInVariable, devices, D())
-    add_variables!(container, ActivePowerOutVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerInVariable, devices, D)
+    add_variables!(container, ActivePowerOutVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
     add_expressions!(container, NetActivePower, devices, model)
 
     if haskey(get_time_series_names(model), ActivePowerOutTimeSeriesParameter)
@@ -26,7 +26,7 @@ function construct_device!(
     end
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_import_export_parameters!(container, devices, model)
@@ -176,8 +176,8 @@ function construct_device!(
 }
     devices = get_available_components(model, sys)
 
-    add_variables!(container, ActivePowerInVariable, devices, D())
-    add_variables!(container, ActivePowerOutVariable, devices, D())
+    add_variables!(container, ActivePowerInVariable, devices, D)
+    add_variables!(container, ActivePowerOutVariable, devices, D)
     add_expressions!(container, NetActivePower, devices, model)
 
     if haskey(get_time_series_names(model), ActivePowerOutTimeSeriesParameter)
@@ -188,7 +188,7 @@ function construct_device!(
     end
 
     if get_attribute(model, "reservation")
-        add_variables!(container, ReservationVariable, devices, D())
+        add_variables!(container, ReservationVariable, devices, D)
     end
 
     process_import_export_parameters!(container, devices, model)

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -6,75 +6,75 @@ requires_initialization(::ThermalStandardDispatch) = true
 requires_initialization(::ThermalBasicCompactUnitCommitment) = false
 requires_initialization(::ThermalBasicUnitCommitment) = false
 
-get_variable_multiplier(::VariableType, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = 1.0
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = 1.0
 # Per-device P_min multiplier computed inline at add_to_expression! call sites.
-get_variable_multiplier(::OnVariable, ::Type{<:PSY.ThermalGen}, ::Union{AbstractCompactUnitCommitment, ThermalCompactDispatch}) = 1.0
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
-get_expression_type_for_reserve(::ActivePowerReserveVariable, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+get_variable_multiplier(::Type{OnVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:Union{AbstractCompactUnitCommitment, ThermalCompactDispatch}}) = 1.0
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
 
 ############## ActivePowerVariable, ThermalGen ####################
-get_variable_binary(::ActivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_warm_start_value(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power(d)
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_must_run(d) ? PSY.get_active_power_limits(d).min : 0.0
-get_variable_upper_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max
-get_variable_lower_bound(::ActivePowerVariable, d::PSY.ThermalGen, ::ThermalDispatchNoMin) = 0.0
+get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
+get_variable_warm_start_value(::Type{ActivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power(d)
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_must_run(d) ? PSY.get_active_power_limits(d).min : 0.0
+get_variable_upper_bound(::Type{ActivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d).max
+get_variable_lower_bound(::Type{ActivePowerVariable}, d::PSY.ThermalGen, ::Type{ThermalDispatchNoMin}) = 0.0
 
 ############## PowerAboveMinimumVariable, ThermalGen ####################
-get_variable_binary(::PowerAboveMinimumVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_warm_start_value(::PowerAboveMinimumVariable, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = max(0.0, PSY.get_active_power(d) - PSY.get_active_power_limits(d).min)
-get_variable_lower_bound(::PowerAboveMinimumVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
-get_variable_upper_bound(::PowerAboveMinimumVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
+get_variable_binary(::Type{PowerAboveMinimumVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
+get_variable_warm_start_value(::Type{PowerAboveMinimumVariable}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = max(0.0, PSY.get_active_power(d) - PSY.get_active_power_limits(d).min)
+get_variable_lower_bound(::Type{PowerAboveMinimumVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 0.0
+get_variable_upper_bound(::Type{PowerAboveMinimumVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
 
 ############## ReactivePowerVariable, ThermalGen ####################
-get_variable_binary(::ReactivePowerVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_warm_start_value(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_reactive_power(d)
-get_variable_lower_bound(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_reactive_power_limits(d).min
-get_variable_upper_bound(::ReactivePowerVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_reactive_power_limits(d).max
+get_variable_binary(::Type{ReactivePowerVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
+get_variable_warm_start_value(::Type{ReactivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_reactive_power(d)
+get_variable_lower_bound(::Type{ReactivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_reactive_power_limits(d).min
+get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_reactive_power_limits(d).max
 
 ############## OnVariable, ThermalGen ####################
-get_variable_binary(::OnVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
-get_variable_warm_start_value(::OnVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_status(d) ? 1.0 : 0.0
-get_variable_lower_bound(::OnVariable, d::PSY.ThermalGen, ::AbstractThermalUnitCommitment) = PSY.get_must_run(d) ? 1.0 : 0.0
+get_variable_binary(::Type{OnVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = true
+get_variable_warm_start_value(::Type{OnVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_status(d) ? 1.0 : 0.0
+get_variable_lower_bound(::Type{OnVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalUnitCommitment}) = PSY.get_must_run(d) ? 1.0 : 0.0
 
 ############## StopVariable, ThermalGen ####################
-get_variable_binary(::StopVariable, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
-get_variable_lower_bound(::StopVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
-get_variable_upper_bound(::StopVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
+get_variable_binary(::Type{StopVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = true
+get_variable_lower_bound(::Type{StopVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 0.0
+get_variable_upper_bound(::Type{StopVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 
 ############## StartVariable, ThermalGen ####################
-get_variable_binary(::StartVariable, d::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = true
-get_variable_lower_bound(::StartVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
-get_variable_upper_bound(::StartVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
+get_variable_binary(::Type{StartVariable}, d::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = true
+get_variable_lower_bound(::Type{StartVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 0.0
+get_variable_upper_bound(::Type{StartVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 
 ############## ColdStartVariable, WarmStartVariable, HotStartVariable ############
-get_variable_binary(::Union{ColdStartVariable, WarmStartVariable, HotStartVariable}, ::Type{PSY.ThermalMultiStart}, ::AbstractThermalFormulation) = true
+get_variable_binary(::Type{<:Union{ColdStartVariable, WarmStartVariable, HotStartVariable}}, ::Type{PSY.ThermalMultiStart}, ::Type{<:AbstractThermalFormulation}) = true
 
 ############## SlackVariables, ThermalGen ####################
 # LB Slack #
-get_variable_binary(::RateofChangeConstraintSlackDown, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::RateofChangeConstraintSlackDown, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_binary(::Type{RateofChangeConstraintSlackDown}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
+get_variable_lower_bound(::Type{RateofChangeConstraintSlackDown}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 0.0
 # UB Slack #
-get_variable_binary(::RateofChangeConstraintSlackUp, ::Type{<:PSY.ThermalGen}, ::AbstractThermalFormulation) = false
-get_variable_lower_bound(::RateofChangeConstraintSlackUp, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 0.0
+get_variable_binary(::Type{RateofChangeConstraintSlackUp}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
+get_variable_lower_bound(::Type{RateofChangeConstraintSlackUp}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 0.0
 
 ############## PostContingencyActivePowerChangeVariable, ThermalGen ####################
-get_variable_binary(::PostContingencyActivePowerChangeVariable, ::Type{<:PSY.ThermalGen}, ::AbstractSecurityConstrainedUnitCommitment) = false
-get_variable_warm_start_value(::PostContingencyActivePowerChangeVariable, d::PSY.ThermalGen, ::AbstractSecurityConstrainedUnitCommitment) = 0.0
-get_variable_lower_bound(::PostContingencyActivePowerChangeVariable, d::PSY.ThermalGen, ::AbstractSecurityConstrainedUnitCommitment) = -1.0
-get_variable_upper_bound(::PostContingencyActivePowerChangeVariable, d::PSY.ThermalGen, ::AbstractSecurityConstrainedUnitCommitment) = 1.0
+get_variable_binary(::Type{PostContingencyActivePowerChangeVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractSecurityConstrainedUnitCommitment}) = false
+get_variable_warm_start_value(::Type{PostContingencyActivePowerChangeVariable}, d::PSY.ThermalGen, ::Type{<:AbstractSecurityConstrainedUnitCommitment}) = 0.0
+get_variable_lower_bound(::Type{PostContingencyActivePowerChangeVariable}, d::PSY.ThermalGen, ::Type{<:AbstractSecurityConstrainedUnitCommitment}) = -1.0
+get_variable_upper_bound(::Type{PostContingencyActivePowerChangeVariable}, d::PSY.ThermalGen, ::Type{<:AbstractSecurityConstrainedUnitCommitment}) = 1.0
 
 ########################### Parameter related set functions ################################
-get_multiplier_value(::ActivePowerTimeSeriesParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_max_active_power(d)
-get_multiplier_value(::FuelCostParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
-get_parameter_multiplier(::VariableValueParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
-get_initial_parameter_value(::VariableValueParameter, d::PSY.ThermalGen, ::AbstractThermalFormulation) = 1.0
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionUB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).max
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionLB, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).min
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionUB, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionLB, d::PSY.ThermalGen, ::AbstractCompactUnitCommitment) = 0.0
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionUB, d::PSY.ThermalGen, ::ThermalCompactDispatch) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerRangeExpressionLB, d::PSY.ThermalGen, ::ThermalCompactDispatch) = 0.0
-get_expression_multiplier(::OnStatusParameter, ::ActivePowerBalance, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_active_power_limits(d).min
+get_multiplier_value(::Type{ActivePowerTimeSeriesParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_max_active_power(d)
+get_multiplier_value(::Type{FuelCostParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
+get_parameter_multiplier(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
+get_initial_parameter_value(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d).max
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d).min
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = 0.0
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{ThermalCompactDispatch}) = PSY.get_active_power_limits(d).max - PSY.get_active_power_limits(d).min
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{ThermalCompactDispatch}) = 0.0
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerBalance}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d).min
 
 #################### Initial Conditions for models ###############
 initial_condition_default(::DeviceStatus, d::PSY.ThermalGen, ::AbstractThermalFormulation) = PSY.get_status(d) ? 1.0 : 0.0
@@ -91,58 +91,60 @@ initial_condition_variable(::InitialTimeDurationOff, d::PSY.ThermalGen, ::Abstra
 
 ########################Objective Function##################################################
 # TODO: Decide what is the cost for OnVariable, if fixed or constant term in variable
-function proportional_cost(container::OptimizationContainer, cost::PSY.ThermalGenerationCost, S::OnVariable, T::PSY.ThermalGen, U::AbstractThermalFormulation, t::Int)
+function proportional_cost(container::OptimizationContainer, cost::PSY.ThermalGenerationCost, S::Type{OnVariable}, T::PSY.ThermalGen, U::Type{<:AbstractThermalFormulation}, t::Int)
     return onvar_cost(container, cost, S, T, U, t) + PSY.get_constant_term(PSY.get_vom_cost(PSY.get_variable(cost))) + PSY.get_fixed(cost)
 end
-is_time_variant_term(::OptimizationContainer, ::PSY.ThermalGenerationCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation, t::Int) = false
 
-function proportional_cost(container::OptimizationContainer, cost::PSY.MarketBidCost, ::OnVariable, comp::T, ::AbstractThermalFormulation, t::Int) where {T <: PSY.ThermalGen}
+
+is_time_variant_term(::OptimizationContainer, ::PSY.ThermalGenerationCost, ::Type{OnVariable}, ::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}, t::Int) = false
+
+function proportional_cost(container::OptimizationContainer, cost::PSY.MarketBidCost, ::Type{OnVariable}, comp::T, ::Type{<:AbstractThermalFormulation}, t::Int) where {T <: PSY.ThermalGen}
     if is_time_variant(PSY.get_incremental_initial_input(cost))
         name = get_name(comp)
         # inelegant: an iterator wrapping either param_array[name, :] .* param_mult[name, :]
         # (load values lazily) or repeat(constant_value) would be closer to what we want.
-        param_arr = get_parameter_array(container, IncrementalCostAtMinParameter(), T)
-        param_mult = get_parameter_multiplier_array(container, IncrementalCostAtMinParameter(), T)
+        param_arr = get_parameter_array(container, IncrementalCostAtMinParameter, T)
+        param_mult = get_parameter_multiplier_array(container, IncrementalCostAtMinParameter, T)
         return param_arr[name, t] * param_mult[name, t]
     else
         return PSY.get_initial_input(PSY.get_incremental_offer_curves(PSY.get_operation_cost(comp)))
     end
 end
-is_time_variant_term(::OptimizationContainer, cost::PSY.MarketBidCost, ::OnVariable, ::PSY.ThermalGen, ::AbstractThermalFormulation, t::Int) =
+is_time_variant_term(::OptimizationContainer, cost::PSY.MarketBidCost, ::Type{OnVariable}, ::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}, t::Int) =
     is_time_variant(PSY.get_incremental_initial_input(cost))
 
-proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Union{RateofChangeConstraintSlackUp, RateofChangeConstraintSlackDown}, ::PSY.ThermalGen, ::AbstractThermalFormulation) = CONSTRAINT_VIOLATION_SLACK_COST
+proportional_cost(::Union{PSY.MarketBidCost, PSY.ThermalGenerationCost}, ::Type{<:Union{RateofChangeConstraintSlackUp, RateofChangeConstraintSlackDown}}, ::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = CONSTRAINT_VIOLATION_SLACK_COST
 
 
 has_multistart_variables(::PSY.ThermalGen, ::AbstractThermalFormulation)=false
 has_multistart_variables(::PSY.ThermalMultiStart, ::ThermalMultiStartUnitCommitment)=true
 
-objective_function_multiplier(::VariableType, ::AbstractThermalFormulation)=OBJECTIVE_FUNCTION_POSITIVE
+objective_function_multiplier(::Type{<:VariableType}, ::Type{<:AbstractThermalFormulation})=OBJECTIVE_FUNCTION_POSITIVE
 
 # Startup cost interpretations!
 # Validators: check that the types match (formulation is optional) and redirect to the simpler methods
-start_up_cost(cost, ::Type{<:PSY.ThermalGen}, ::T, ::Union{AbstractThermalFormulation, Nothing} = nothing) where {T <: StartVariable} =
-    start_up_cost(cost, T())
-start_up_cost(cost, ::Type{<:PSY.ThermalMultiStart}, ::T, ::ThermalMultiStartUnitCommitment = ThermalMultiStartUnitCommitment()) where {T <: MultiStartVariable} =
-    start_up_cost(cost, T())
+start_up_cost(cost, ::Type{<:PSY.ThermalGen}, ::Type{T}, ::Type{<:Union{AbstractThermalFormulation, Nothing}} = Nothing) where {T <: StartVariable} =
+    start_up_cost(cost, T)
+start_up_cost(cost, ::Type{<:PSY.ThermalMultiStart}, ::Type{T}, ::Type{ThermalMultiStartUnitCommitment} = ThermalMultiStartUnitCommitment) where {T <: MultiStartVariable} =
+    start_up_cost(cost, T)
 
 # Implementations: given a single number, tuple, or StartUpStages and a variable, do the right thing
 # Single number to anything
-start_up_cost(cost::Float64, ::StartVariable) = cost
+start_up_cost(cost::Float64, ::Type{StartVariable}) = cost
 # TODO in the case where we have a single number startup cost and we're modeling a multi-start, do we set all the values to that number?
-start_up_cost(cost::Float64, ::T) where {T <: MultiStartVariable} =
-    start_up_cost((hot = cost, warm = cost, cold = cost), T())
+start_up_cost(cost::Float64, ::Type{T}) where {T <: MultiStartVariable} =
+    start_up_cost((hot = cost, warm = cost, cold = cost), T)
 
 # 3-tuple to anything
-start_up_cost(cost::NTuple{3, Float64}, ::T) where {T <: VariableType} =
-    start_up_cost(StartUpStages(cost), T())
+start_up_cost(cost::NTuple{3, Float64}, ::Type{T}) where {T <: VariableType} =
+    start_up_cost(StartUpStages(cost), T)
 
 # `StartUpStages` to anything
-start_up_cost(cost::StartUpStages, ::ColdStartVariable) = cost.cold
-start_up_cost(cost::StartUpStages, ::WarmStartVariable) = cost.warm
-start_up_cost(cost::StartUpStages, ::HotStartVariable) = cost.hot
+start_up_cost(cost::StartUpStages, ::Type{ColdStartVariable}) = cost.cold
+start_up_cost(cost::StartUpStages, ::Type{WarmStartVariable}) = cost.warm
+start_up_cost(cost::StartUpStages, ::Type{HotStartVariable}) = cost.hot
 # TODO in the opposite case, do we want to get the maximum or the hot?
-start_up_cost(cost::StartUpStages, ::StartVariable) = maximum(cost)
+start_up_cost(cost::StartUpStages, ::Type{StartVariable}) = maximum(cost)
 
 uses_compact_power(::PSY.ThermalGen, ::AbstractThermalFormulation)=false
 uses_compact_power(::PSY.ThermalGen, ::AbstractCompactUnitCommitment )=true
@@ -151,7 +153,7 @@ uses_compact_power(::PSY.ThermalGen, ::ThermalCompactDispatch)=true
 """
 Theoretical Cost at power output zero. Mathematically is the intercept with the y-axis
 """
-function onvar_cost(container::OptimizationContainer, cost::PSY.ThermalGenerationCost, ::OnVariable, d::PSY.ThermalGen, ::AbstractThermalFormulation, t::Int)
+function onvar_cost(container::OptimizationContainer, cost::PSY.ThermalGenerationCost, ::Type{OnVariable}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}, t::Int)
     return _onvar_cost(container, PSY.get_variable(cost), d, t)
 end
 
@@ -176,9 +178,9 @@ function _onvar_cost(container::OptimizationContainer, cost_function::Union{PSY.
     if typeof(fuel_cost) <: Float64
         return constant_term * fuel_cost
     else
-        parameter_array = get_parameter_array(container, FuelCostParameter(), T)
+        parameter_array = get_parameter_array(container, FuelCostParameter, T)
         parameter_multiplier =
-            get_parameter_multiplier_array(container, FuelCostParameter(), T)
+            get_parameter_multiplier_array(container, FuelCostParameter, T)
         name = PSY.get_name(d)
         return constant_term * parameter_array[name, t] * parameter_multiplier[name, t]
     end
@@ -240,7 +242,7 @@ end
 Min and max active power limits of generators for thermal dispatch formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{<:AbstractThermalDispatchFormulation},
 )
@@ -252,7 +254,7 @@ end
 Min and max active power limits of generators for thermal unit commitment formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{<:AbstractThermalUnitCommitment},
 )
@@ -266,7 +268,7 @@ end
 Min and max active power limits of generators for thermal dispatch compact formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{ThermalCompactDispatch},
 )
@@ -281,7 +283,7 @@ end
 Min and max active power limits of generators for thermal dispatch no minimum formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{ThermalDispatchNoMin},
 )
@@ -313,7 +315,7 @@ end
 Min and max active power limits for multi-start unit commitment formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{ThermalMultiStartUnitCommitment},
 ) #  -> Union{Nothing, NamedTuple{(:startup, :shutdown), Tuple{Float64, Float64}}}
@@ -331,20 +333,20 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::U,
-    formulation::AbstractThermalFormulation,
+    ::F,
 ) where {
     T <: Union{OnVariable, StartVariable, StopVariable},
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
+    F <: AbstractThermalFormulation,
 } where {D <: PSY.ThermalGen}
     @assert !isempty(devices)
-    variable_type = T()
     time_steps = get_time_steps(container)
     settings = get_settings(container)
-    binary = get_variable_binary(variable_type, D, formulation)
+    binary = get_variable_binary(T, D, F)
 
     variable = add_variable_container!(
         container,
-        variable_type,
+        T,
         D,
         [PSY.get_name(d) for d in devices if !PSY.get_must_run(d)],
         time_steps,
@@ -362,7 +364,7 @@ function add_variables!(
                 binary = binary
             )
             if get_warm_start(settings)
-                init = get_variable_warm_start_value(variable_type, d, formulation)
+                init = get_variable_warm_start_value(T, d, F)
                 init !== nothing && JuMP.set_start_value(variable[name, t], init)
             end
         end
@@ -415,7 +417,7 @@ end
 Min and Max active power limits for Compact Unit Commitment
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ActivePowerVariableLimitsConstraint},
     ::Type{<:AbstractCompactUnitCommitment},
 ) #  -> Union{Nothing, NamedTuple{(:min, :max), Tuple{Float64, Float64}}}
@@ -503,9 +505,9 @@ function add_constraints!(
     variable_type = U()
     component_type = V
     varp = get_variable(container, variable_type, component_type)
-    varstatus = get_variable(container, OnVariable(), component_type)
-    varon = get_variable(container, StartVariable(), component_type)
-    varoff = get_variable(container, StopVariable(), component_type)
+    varstatus = get_variable(container, OnVariable, component_type)
+    varon = get_variable(container, StartVariable, component_type)
+    varoff = get_variable(container, StopVariable, component_type)
 
     names = [PSY.get_name(x) for x in devices]
     con_on = add_constraints_container!(
@@ -579,16 +581,14 @@ function add_constraints!(
     X <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    constraint_type = T()
-    expression_type = U()
     component_type = V
-    expression_products = get_expression(container, expression_type, component_type)
-    varp = get_variable(container, PowerAboveMinimumVariable(), component_type)
+    expression_products = get_expression(container, U, component_type)
+    varp = get_variable(container, PowerAboveMinimumVariable, component_type)
 
     names = [PSY.get_name(x) for x in devices]
     con_lb = add_constraints_container!(
         container,
-        constraint_type,
+        T,
         component_type,
         names,
         time_steps;
@@ -624,19 +624,17 @@ function add_constraints!(
     X <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    constraint_type = T()
-    expression_type = U()
     component_type = V
-    expression_products = get_expression(container, expression_type, component_type)
-    varstatus = get_variable(container, OnVariable(), component_type)
-    varon = get_variable(container, StartVariable(), component_type)
-    varoff = get_variable(container, StopVariable(), component_type)
-    varp = get_variable(container, PowerAboveMinimumVariable(), component_type)
+    expression_products = get_expression(container, U, component_type)
+    varstatus = get_variable(container, OnVariable, component_type)
+    varon = get_variable(container, StartVariable, component_type)
+    varoff = get_variable(container, StopVariable, component_type)
+    varp = get_variable(container, PowerAboveMinimumVariable, component_type)
 
     names = [PSY.get_name(x) for x in devices]
     con_on = add_constraints_container!(
         container,
-        constraint_type,
+        T,
         component_type,
         names,
         time_steps;
@@ -644,7 +642,7 @@ function add_constraints!(
     )
     con_off = add_constraints_container!(
         container,
-        constraint_type,
+        T,
         component_type,
         names,
         time_steps[1:(end - 1)];
@@ -696,11 +694,9 @@ function add_constraints!(
     ini_conds = _get_data_for_range_ic(initial_conditions_power, initial_conditions_status)
 
     if !isempty(ini_conds)
-        varstop = get_variable(container, StopVariable(), T)
+        varstop = get_variable(container, StopVariable, T)
         device_name_set = PSY.get_name.(devices)
-        con = add_constraints_container!(
-            container,
-            ActiveRangeICConstraint(),
+        con = add_constraints_container!(container, ActiveRangeICConstraint,
             T,
             device_name_set,
         )
@@ -727,7 +723,7 @@ end
 Reactive power limits of generators for all dispatch formulations
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ReactivePowerVariableLimitsConstraint},
     ::Type{<:AbstractThermalDispatchFormulation},
 )
@@ -738,7 +734,7 @@ end
 Reactive power limits of generators when there CommitmentVariables
 """
 function get_min_max_limits(
-    device,
+    device::PSY.ThermalGen,
     ::Type{ReactivePowerVariableLimitsConstraint},
     ::Type{<:AbstractThermalUnitCommitment},
 )
@@ -757,16 +753,14 @@ function add_constraints!(
     X <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    varstart = get_variable(container, StartVariable(), U)
-    varstop = get_variable(container, StopVariable(), U)
-    varon = get_variable(container, OnVariable(), U)
+    varstart = get_variable(container, StartVariable, U)
+    varstop = get_variable(container, StopVariable, U)
+    varon = get_variable(container, OnVariable, U)
     names = axes(varstart, 1)
     initial_conditions = get_initial_condition(container, DeviceStatus(), U)
     constraint =
-        add_constraints_container!(container, CommitmentConstraint(), U, names, time_steps)
-    aux_constraint = add_constraints_container!(
-        container,
-        CommitmentConstraint(),
+        add_constraints_container!(container, CommitmentConstraint, U, names, time_steps)
+    aux_constraint = add_constraints_container!(container, CommitmentConstraint,
         U,
         names,
         time_steps;
@@ -869,8 +863,8 @@ function calculate_aux_variable_value!(
     ::AuxVarKey{TimeDurationOn, T},
     ::PSY.System,
 ) where {T <: PSY.ThermalGen}
-    on_variable_output = get_variable(container, OnVariable(), T)
-    aux_variable_container = get_aux_variable(container, TimeDurationOn(), T)
+    on_variable_output = get_variable(container, OnVariable, T)
+    aux_variable_container = get_aux_variable(container, TimeDurationOn, T)
     ini_cond = get_initial_condition(container, InitialTimeDurationOn(), T)
 
     time_steps = get_time_steps(container)
@@ -916,8 +910,8 @@ function calculate_aux_variable_value!(
     ::AuxVarKey{TimeDurationOff, T},
     ::PSY.System,
 ) where {T <: PSY.ThermalGen}
-    on_variable_output = get_variable(container, OnVariable(), T)
-    aux_variable_container = get_aux_variable(container, TimeDurationOff(), T)
+    on_variable_output = get_variable(container, OnVariable, T)
+    aux_variable_container = get_aux_variable(container, TimeDurationOff, T)
     ini_cond = get_initial_condition(container, InitialTimeDurationOff(), T)
 
     time_steps = get_time_steps(container)
@@ -963,18 +957,18 @@ function calculate_aux_variable_value!(
 ) where {T <: PSY.ThermalGen}
     time_steps = get_time_steps(container)
     if has_container_key(container, OnVariable, T)
-        on_variable_output = get_variable(container, OnVariable(), T)
+        on_variable_output = get_variable(container, OnVariable, T)
     elseif has_container_key(container, OnStatusParameter, T)
-        on_variable_output = get_parameter_array(container, OnStatusParameter(), T)
+        on_variable_output = get_parameter_array(container, OnStatusParameter, T)
     else
         error(
             "$T formulation is NOT supported without a Feedforward for CommitmentDecisions,
       please consider changing your simulation setup or adding a SemiContinuousFeedforward.",
         )
     end
-    p_variable_output = get_variable(container, PowerAboveMinimumVariable(), T)
+    p_variable_output = get_variable(container, PowerAboveMinimumVariable, T)
     device_name = axes(p_variable_output, 1)
-    aux_variable_container = get_aux_variable(container, PowerOutput(), T)
+    aux_variable_container = get_aux_variable(container, PowerOutput, T)
     for d_name in device_name
         d = PSY.get_component(T, system, d_name)
         name = PSY.get_name(d)
@@ -1128,26 +1122,22 @@ function add_constraints!(
     resolution = get_resolution(container)
     time_steps = get_time_steps(container)
     start_vars = [
-        get_variable(container, HotStartVariable(), T),
-        get_variable(container, WarmStartVariable(), T),
+        get_variable(container, HotStartVariable, T),
+        get_variable(container, WarmStartVariable, T),
     ]
-    varstop = get_variable(container, StopVariable(), T)
+    varstop = get_variable(container, StopVariable, T)
 
     names = PSY.get_name.(devices)
 
     con = [
-        add_constraints_container!(
-            container,
-            StartupTimeLimitTemperatureConstraint(),
+        add_constraints_container!(container, StartupTimeLimitTemperatureConstraint,
             T,
             names,
             time_steps;
             sparse = true,
             meta = "hot",
         ),
-        add_constraints_container!(
-            container,
-            StartupTimeLimitTemperatureConstraint(),
+        add_constraints_container!(container, StartupTimeLimitTemperatureConstraint,
             T,
             names,
             time_steps;
@@ -1202,17 +1192,15 @@ function add_constraints!(
     ::NetworkModel{<:AbstractPowerModel},
 ) where {T <: PSY.ThermalMultiStart}
     time_steps = get_time_steps(container)
-    varstart = get_variable(container, StartVariable(), T)
+    varstart = get_variable(container, StartVariable, T)
     start_vars = [
-        get_variable(container, HotStartVariable(), T),
-        get_variable(container, WarmStartVariable(), T),
-        get_variable(container, ColdStartVariable(), T),
+        get_variable(container, HotStartVariable, T),
+        get_variable(container, WarmStartVariable, T),
+        get_variable(container, ColdStartVariable, T),
     ]
 
     device_name_set = PSY.get_name.(devices)
-    con = add_constraints_container!(
-        container,
-        StartTypeConstraint(),
+    con = add_constraints_container!(container, StartTypeConstraint,
         T,
         device_name_set,
         time_steps,
@@ -1258,15 +1246,13 @@ function add_constraints!(
 
     time_steps = get_time_steps(container)
     device_name_set = [get_component_name(ic) for ic in initial_conditions_offtime]
-    varbin = get_variable(container, OnVariable(), T)
+    varbin = get_variable(container, OnVariable, T)
     varstarts = [
-        get_variable(container, HotStartVariable(), T),
-        get_variable(container, WarmStartVariable(), T),
+        get_variable(container, HotStartVariable, T),
+        get_variable(container, WarmStartVariable, T),
     ]
 
-    con_ub = add_constraints_container!(
-        container,
-        StartupInitialConditionConstraint(),
+    con_ub = add_constraints_container!(container, StartupInitialConditionConstraint,
         T,
         device_name_set,
         time_steps,
@@ -1274,9 +1260,7 @@ function add_constraints!(
         sparse = true,
         meta = "ub",
     )
-    con_lb = add_constraints_container!(
-        container,
-        StartupInitialConditionConstraint(),
+    con_lb = add_constraints_container!(container, StartupInitialConditionConstraint,
         T,
         device_name_set,
         time_steps,
@@ -1382,7 +1366,7 @@ function add_constraints!(
                 time_params,
                 ini_conds,
                 DurationConstraint(),
-                (OnVariable(), StartVariable(), StopVariable()),
+                (OnVariable, StartVariable, StopVariable),
                 U,
             )
         else
@@ -1391,7 +1375,7 @@ function add_constraints!(
                 time_params,
                 ini_conds,
                 DurationConstraint(),
-                (OnVariable(), StartVariable(), StopVariable()),
+                (OnVariable, StartVariable, StopVariable),
                 U,
             )
         end
@@ -1421,7 +1405,7 @@ function add_constraints!(
                 time_params,
                 ini_conds,
                 DurationConstraint(),
-                (OnVariable(), StartVariable(), StopVariable()),
+                (OnVariable, StartVariable, StopVariable),
                 U,
             )
         else
@@ -1430,7 +1414,7 @@ function add_constraints!(
                 time_params,
                 ini_conds,
                 DurationConstraint(),
-                (OnVariable(), StartVariable(), StopVariable()),
+                (OnVariable, StartVariable, StopVariable),
                 U,
             )
         end
@@ -1446,15 +1430,15 @@ skip_proportional_cost(d::PSY.ThermalGen) = get_must_run(d)
 
 add_proportional_cost!(
     container::OptimizationContainer,
-    ::U,
+    ::Type{U},
     devices::IS.FlattenIteratorWrapper{T},
-    formulation::AbstractThermalFormulation,
-) where {U <: OnVariable, T <: PSY.ThermalGen} =
+    ::Type{V},
+) where {U <: OnVariable, T <: PSY.ThermalGen, V <: AbstractThermalFormulation} =
     add_proportional_cost_maybe_time_variant!(
         container,
-        U(),
+        U,
         devices,
-        formulation,
+        V,
     )
 
 ########################### Objective Function Calls#############################################
@@ -1466,13 +1450,13 @@ function add_to_objective_function!(
     device_model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalUnitCommitment}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
-    add_start_up_cost!(container, StartVariable(), devices, U())
-    add_shut_down_cost!(container, StopVariable(), devices, U())
-    add_proportional_cost!(container, OnVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
+    add_start_up_cost!(container, StartVariable, devices, U)
+    add_shut_down_cost!(container, StopVariable, devices, U)
+    add_proportional_cost!(container, OnVariable, devices, U)
     if get_use_slacks(device_model)
-        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
-        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp, devices, U)
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown, devices, U)
     end
     return
 end
@@ -1483,13 +1467,13 @@ function add_to_objective_function!(
     device_model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractCompactUnitCommitment}
-    add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
-    add_start_up_cost!(container, StartVariable(), devices, U())
-    add_shut_down_cost!(container, StopVariable(), devices, U())
-    add_proportional_cost!(container, OnVariable(), devices, U())
+    add_variable_cost!(container, PowerAboveMinimumVariable, devices, U)
+    add_start_up_cost!(container, StartVariable, devices, U)
+    add_shut_down_cost!(container, StopVariable, devices, U)
+    add_proportional_cost!(container, OnVariable, devices, U)
     if get_use_slacks(device_model)
-        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
-        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp, devices, U)
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown, devices, U)
     end
     return
 end
@@ -1500,15 +1484,15 @@ function add_to_objective_function!(
     device_model::DeviceModel{PSY.ThermalMultiStart, U},
     ::Type{<:AbstractPowerModel},
 ) where {U <: ThermalMultiStartUnitCommitment}
-    add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
+    add_variable_cost!(container, PowerAboveMinimumVariable, devices, U)
     for var_type in MULTI_START_VARIABLES
-        add_start_up_cost!(container, var_type(), devices, U())
+        add_start_up_cost!(container, var_type, devices, U)
     end
-    add_shut_down_cost!(container, StopVariable(), devices, U())
-    add_proportional_cost!(container, OnVariable(), devices, U())
+    add_shut_down_cost!(container, StopVariable, devices, U)
+    add_proportional_cost!(container, OnVariable, devices, U)
     if get_use_slacks(device_model)
-        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
-        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp, devices, U)
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown, devices, U)
     end
     return
 end
@@ -1519,10 +1503,10 @@ function add_to_objective_function!(
     device_model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: AbstractThermalDispatchFormulation}
-    add_variable_cost!(container, ActivePowerVariable(), devices, U())
+    add_variable_cost!(container, ActivePowerVariable, devices, U)
     if get_use_slacks(device_model)
-        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
-        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp, devices, U)
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown, devices, U)
     end
     return
 end
@@ -1533,10 +1517,10 @@ function add_to_objective_function!(
     device_model::DeviceModel{T, U},
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ThermalGen, U <: ThermalCompactDispatch}
-    add_variable_cost!(container, PowerAboveMinimumVariable(), devices, U())
+    add_variable_cost!(container, PowerAboveMinimumVariable, devices, U)
     if get_use_slacks(device_model)
-        add_proportional_cost!(container, RateofChangeConstraintSlackUp(), devices, U())
-        add_proportional_cost!(container, RateofChangeConstraintSlackDown(), devices, U())
+        add_proportional_cost!(container, RateofChangeConstraintSlackUp, devices, U)
+        add_proportional_cost!(container, RateofChangeConstraintSlackDown, devices, U)
     end
     return
 end
@@ -1622,7 +1606,7 @@ function IOM.add_pwl_term_lambda!(
         IOM.create_temporary_cost_function_in_system_per_unit(cost_function, data)
     for t in time_steps
         IOM.add_pwl_variables_lambda!(container, T, name, t, data)
-        power_var = IOM.get_variable(container, U(), T)[name, t]
+        power_var = IOM.get_variable(container, U, T)[name, t]
         IOM._add_pwl_constraint_standard!(
             container,
             component,

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -333,7 +333,7 @@ function add_variables!(
     container::OptimizationContainer,
     ::Type{T},
     devices::U,
-    ::F,
+    ::Type{F},
 ) where {
     T <: Union{OnVariable, StartVariable, StopVariable},
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -1550,8 +1550,8 @@ function IOM.add_pwl_term_lambda!(
         PSY.CostCurve{PSY.PiecewisePointCurve},
         PSY.FuelCurve{PSY.PiecewisePointCurve},
     },
-    ::U,
-    ::V,
+    ::Type{U},
+    ::Type{V},
 ) where {T <: PSY.ThermalGen, U <: IOM.VariableType, V <: ThermalDispatchNoMin}
     name = PSY.get_name(component)
     value_curve = PSY.get_value_curve(cost_function)
@@ -1621,8 +1621,8 @@ function IOM.add_pwl_term_lambda!(
                 component,
                 t,
                 temp_cost_function,
-                U(),
-                V(),
+                U,
+                V,
             )
         pwl_cost_expressions[t] = pwl_cost
     end

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -1365,8 +1365,7 @@ function add_constraints!(
                 container,
                 time_params,
                 ini_conds,
-                DurationConstraint(),
-                (OnVariable, StartVariable, StopVariable),
+                DurationConstraint,
                 U,
             )
         else
@@ -1374,8 +1373,7 @@ function add_constraints!(
                 container,
                 time_params,
                 ini_conds,
-                DurationConstraint(),
-                (OnVariable, StartVariable, StopVariable),
+                DurationConstraint,
                 U,
             )
         end
@@ -1404,8 +1402,7 @@ function add_constraints!(
                 container,
                 time_params,
                 ini_conds,
-                DurationConstraint(),
-                (OnVariable, StartVariable, StopVariable),
+                DurationConstraint,
                 U,
             )
         else
@@ -1413,8 +1410,7 @@ function add_constraints!(
                 container,
                 time_params,
                 ini_conds,
-                DurationConstraint(),
-                (OnVariable, StartVariable, StopVariable),
+                DurationConstraint,
                 U,
             )
         end

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -485,6 +485,10 @@ function add_constraints!(
     return
 end
 
+# FIXME: untested and possibly dead code. The ThermalMultiStart constructor
+# (thermalgeneration_constructor.jl) calls add_constraints! for
+# ActivePowerVariableLimitsConstraint with expression types
+# (ActivePowerRangeExpressionLB/UB), not variable types.
 """
 This function adds range constraint for the first time period. Constraint (10) from PGLIB formulation
 """
@@ -501,35 +505,32 @@ function add_constraints!(
     X <: AbstractPowerModel,
 }
     time_steps = get_time_steps(container)
-    constraint_type = T()
-    variable_type = U()
-    component_type = V
-    varp = get_variable(container, variable_type, component_type)
-    varstatus = get_variable(container, OnVariable, component_type)
-    varon = get_variable(container, StartVariable, component_type)
-    varoff = get_variable(container, StopVariable, component_type)
+    varp = get_variable(container, U, V)
+    varstatus = get_variable(container, OnVariable, V)
+    varon = get_variable(container, StartVariable, V)
+    varoff = get_variable(container, StopVariable, V)
 
     names = [PSY.get_name(x) for x in devices]
     con_on = add_constraints_container!(
         container,
-        constraint_type,
-        component_type,
+        T,
+        V,
         names,
         time_steps;
         meta = "on",
     )
     con_off = add_constraints_container!(
         container,
-        constraint_type,
-        component_type,
+        T,
+        V,
         names,
         time_steps[1:(end - 1)];
         meta = "off",
     )
     con_lb = add_constraints_container!(
         container,
-        constraint_type,
-        component_type,
+        T,
+        V,
         names,
         time_steps;
         meta = "lb",

--- a/src/static_injector_models/thermalgeneration_constructor.jl
+++ b/src/static_injector_models/thermalgeneration_constructor.jl
@@ -68,14 +68,14 @@ function construct_device!(
 }
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, StartVariable, devices, D())
-    add_variables!(container, StopVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
+    add_variables!(container, StartVariable, devices, D)
+    add_variables!(container, StopVariable, devices, D)
 
-    add_variables!(container, TimeDurationOn, devices, D())
-    add_variables!(container, TimeDurationOff, devices, D())
+    add_variables!(container, TimeDurationOn, devices, D)
+    add_variables!(container, TimeDurationOff, devices, D)
 
     initial_conditions!(container, devices, D())
 
@@ -129,8 +129,8 @@ function construct_device!(
         device_model,
     )
     if get_use_slacks(device_model)
-        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
-        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D)
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D)
     end
     add_feedforward_arguments!(container, device_model, devices)
     add_event_arguments!(container, devices, device_model, network_model)
@@ -228,13 +228,13 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen, D <: AbstractStandardUnitCommitment}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, OnVariable, devices, D())
-    add_variables!(container, StartVariable, devices, D())
-    add_variables!(container, StopVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, OnVariable, devices, D)
+    add_variables!(container, StartVariable, devices, D)
+    add_variables!(container, StopVariable, devices, D)
 
-    add_variables!(container, TimeDurationOn, devices, D())
-    add_variables!(container, TimeDurationOff, devices, D())
+    add_variables!(container, TimeDurationOn, devices, D)
+    add_variables!(container, TimeDurationOff, devices, D)
 
     initial_conditions!(container, devices, D())
 
@@ -280,8 +280,8 @@ function construct_device!(
         device_model,
     )
     if get_use_slacks(device_model)
-        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
-        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D)
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D)
     end
 
     add_feedforward_arguments!(container, device_model, devices)
@@ -356,14 +356,14 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, ReactivePowerVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, OnVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalBasicUnitCommitment())
+    add_variables!(container, ActivePowerVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, ReactivePowerVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, OnVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalBasicUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalBasicUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalBasicUnitCommitment)
     initial_conditions!(container, devices, ThermalBasicUnitCommitment())
 
     if haskey(get_time_series_names(device_model), ActivePowerTimeSeriesParameter)
@@ -420,13 +420,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalBasicUnitCommitment(),
+            ThermalBasicUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalBasicUnitCommitment(),
+            ThermalBasicUnitCommitment,
         )
     end
 
@@ -510,13 +510,13 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, OnVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalBasicUnitCommitment())
+    add_variables!(container, ActivePowerVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, OnVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalBasicUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalBasicUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalBasicUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalBasicUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalBasicUnitCommitment)
     initial_conditions!(container, devices, ThermalBasicUnitCommitment())
 
     if haskey(get_time_series_names(device_model), ActivePowerTimeSeriesParameter)
@@ -565,13 +565,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalBasicUnitCommitment(),
+            ThermalBasicUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalBasicUnitCommitment(),
+            ThermalBasicUnitCommitment,
         )
     end
 
@@ -646,8 +646,8 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, ThermalStandardDispatch())
-    add_variables!(container, ReactivePowerVariable, devices, ThermalStandardDispatch())
+    add_variables!(container, ActivePowerVariable, devices, ThermalStandardDispatch)
+    add_variables!(container, ReactivePowerVariable, devices, ThermalStandardDispatch)
 
     initial_conditions!(container, devices, ThermalStandardDispatch())
 
@@ -701,13 +701,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalStandardDispatch(),
+            ThermalStandardDispatch,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalStandardDispatch(),
+            ThermalStandardDispatch,
         )
     end
 
@@ -780,7 +780,7 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, ThermalStandardDispatch())
+    add_variables!(container, ActivePowerVariable, devices, ThermalStandardDispatch)
 
     initial_conditions!(container, devices, ThermalStandardDispatch())
 
@@ -826,13 +826,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalStandardDispatch(),
+            ThermalStandardDispatch,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalStandardDispatch(),
+            ThermalStandardDispatch,
         )
     end
 
@@ -897,8 +897,8 @@ function construct_device!(
 }
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
-    add_variables!(container, ReactivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
+    add_variables!(container, ReactivePowerVariable, devices, D)
 
     _handle_common_thermal_parameters!(container, devices, device_model)
 
@@ -946,8 +946,8 @@ function construct_device!(
         device_model,
     )
     if get_use_slacks(device_model)
-        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
-        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D)
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D)
     end
 
     add_feedforward_arguments!(container, device_model, devices)
@@ -1015,7 +1015,7 @@ function construct_device!(
 }
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, ActivePowerVariable, devices, D())
+    add_variables!(container, ActivePowerVariable, devices, D)
 
     _handle_common_thermal_parameters!(container, devices, device_model)
 
@@ -1055,8 +1055,8 @@ function construct_device!(
         device_model,
     )
     if get_use_slacks(device_model)
-        add_variables!(container, RateofChangeConstraintSlackUp, devices, D())
-        add_variables!(container, RateofChangeConstraintSlackDown, devices, D())
+        add_variables!(container, RateofChangeConstraintSlackUp, devices, D)
+        add_variables!(container, RateofChangeConstraintSlackDown, devices, D)
     end
 
     add_feedforward_arguments!(container, device_model, devices)
@@ -1115,24 +1115,24 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalMultiStartUnitCommitment(),
+        ThermalMultiStartUnitCommitment,
     )
     add_variables!(
         container,
         ReactivePowerVariable,
         devices,
-        ThermalMultiStartUnitCommitment(),
+        ThermalMultiStartUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, ColdStartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, WarmStartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, HotStartVariable, devices, ThermalMultiStartUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, ColdStartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, WarmStartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, HotStartVariable, devices, ThermalMultiStartUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, PowerOutput, devices, ThermalMultiStartUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, PowerOutput, devices, ThermalMultiStartUnitCommitment)
 
     initial_conditions!(container, devices, ThermalMultiStartUnitCommitment())
 
@@ -1199,13 +1199,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalMultiStartUnitCommitment(),
+            ThermalMultiStartUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalMultiStartUnitCommitment(),
+            ThermalMultiStartUnitCommitment,
         )
     end
 
@@ -1311,18 +1311,18 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalMultiStartUnitCommitment(),
+        ThermalMultiStartUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, ColdStartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, WarmStartVariable, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, HotStartVariable, devices, ThermalMultiStartUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, ColdStartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, WarmStartVariable, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, HotStartVariable, devices, ThermalMultiStartUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalMultiStartUnitCommitment())
-    add_variables!(container, PowerOutput, devices, ThermalMultiStartUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalMultiStartUnitCommitment)
+    add_variables!(container, PowerOutput, devices, ThermalMultiStartUnitCommitment)
 
     if haskey(get_time_series_names(device_model), ActivePowerTimeSeriesParameter)
         add_parameters!(container, ActivePowerTimeSeriesParameter, devices, device_model)
@@ -1379,13 +1379,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalMultiStartUnitCommitment(),
+            ThermalMultiStartUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalMultiStartUnitCommitment(),
+            ThermalMultiStartUnitCommitment,
         )
     end
 
@@ -1485,21 +1485,21 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalCompactUnitCommitment(),
+        ThermalCompactUnitCommitment,
     )
     add_variables!(
         container,
         ReactivePowerVariable,
         devices,
-        ThermalCompactUnitCommitment(),
+        ThermalCompactUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalCompactUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalCompactUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, PowerOutput, devices, ThermalCompactUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, PowerOutput, devices, ThermalCompactUnitCommitment)
 
     initial_conditions!(container, devices, ThermalCompactUnitCommitment())
 
@@ -1557,13 +1557,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalCompactUnitCommitment(),
+            ThermalCompactUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalCompactUnitCommitment(),
+            ThermalCompactUnitCommitment,
         )
     end
 
@@ -1646,15 +1646,15 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalCompactUnitCommitment(),
+        ThermalCompactUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalCompactUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalCompactUnitCommitment)
 
-    add_variables!(container, TimeDurationOn, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalCompactUnitCommitment())
-    add_variables!(container, PowerOutput, devices, ThermalCompactUnitCommitment())
+    add_variables!(container, TimeDurationOn, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalCompactUnitCommitment)
+    add_variables!(container, PowerOutput, devices, ThermalCompactUnitCommitment)
 
     initial_conditions!(container, devices, ThermalCompactUnitCommitment())
 
@@ -1712,13 +1712,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalCompactUnitCommitment(),
+            ThermalCompactUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalCompactUnitCommitment(),
+            ThermalCompactUnitCommitment,
         )
     end
 
@@ -1793,21 +1793,21 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalBasicCompactUnitCommitment(),
+        ThermalBasicCompactUnitCommitment,
     )
     add_variables!(
         container,
         ReactivePowerVariable,
         devices,
-        ThermalBasicCompactUnitCommitment(),
+        ThermalBasicCompactUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalBasicCompactUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalBasicCompactUnitCommitment)
 
-    add_variables!(container, PowerOutput, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, TimeDurationOn, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalBasicCompactUnitCommitment())
+    add_variables!(container, PowerOutput, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, TimeDurationOn, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalBasicCompactUnitCommitment)
 
     initial_conditions!(container, devices, ThermalBasicCompactUnitCommitment())
 
@@ -1865,13 +1865,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalBasicCompactUnitCommitment(),
+            ThermalBasicCompactUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalBasicCompactUnitCommitment(),
+            ThermalBasicCompactUnitCommitment,
         )
     end
 
@@ -1952,15 +1952,15 @@ function construct_device!(
         container,
         PowerAboveMinimumVariable,
         devices,
-        ThermalBasicCompactUnitCommitment(),
+        ThermalBasicCompactUnitCommitment,
     )
-    add_variables!(container, OnVariable, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, StartVariable, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, StopVariable, devices, ThermalBasicCompactUnitCommitment())
+    add_variables!(container, OnVariable, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, StartVariable, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, StopVariable, devices, ThermalBasicCompactUnitCommitment)
 
-    add_variables!(container, PowerOutput, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, TimeDurationOn, devices, ThermalBasicCompactUnitCommitment())
-    add_variables!(container, TimeDurationOff, devices, ThermalBasicCompactUnitCommitment())
+    add_variables!(container, PowerOutput, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, TimeDurationOn, devices, ThermalBasicCompactUnitCommitment)
+    add_variables!(container, TimeDurationOff, devices, ThermalBasicCompactUnitCommitment)
     initial_conditions!(container, devices, ThermalBasicCompactUnitCommitment())
 
     if haskey(get_time_series_names(device_model), ActivePowerTimeSeriesParameter)
@@ -2017,13 +2017,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalBasicCompactUnitCommitment(),
+            ThermalBasicCompactUnitCommitment,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalBasicCompactUnitCommitment(),
+            ThermalBasicCompactUnitCommitment,
         )
     end
     add_feedforward_arguments!(container, device_model, devices)
@@ -2091,10 +2091,10 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, PowerAboveMinimumVariable, devices, ThermalCompactDispatch())
-    add_variables!(container, ReactivePowerVariable, devices, ThermalCompactDispatch())
+    add_variables!(container, PowerAboveMinimumVariable, devices, ThermalCompactDispatch)
+    add_variables!(container, ReactivePowerVariable, devices, ThermalCompactDispatch)
 
-    add_variables!(container, PowerOutput, devices, ThermalCompactDispatch())
+    add_variables!(container, PowerOutput, devices, ThermalCompactDispatch)
 
     add_parameters!(container, OnStatusParameter, devices, device_model)
 
@@ -2160,13 +2160,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalCompactDispatch(),
+            ThermalCompactDispatch,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalCompactDispatch(),
+            ThermalCompactDispatch,
         )
     end
     add_event_arguments!(container, devices, device_model, network_model)
@@ -2231,9 +2231,9 @@ function construct_device!(
 ) where {T <: PSY.ThermalGen}
     devices = get_available_components(device_model, sys)
 
-    add_variables!(container, PowerAboveMinimumVariable, devices, ThermalCompactDispatch())
+    add_variables!(container, PowerAboveMinimumVariable, devices, ThermalCompactDispatch)
 
-    add_variables!(container, PowerOutput, devices, ThermalCompactDispatch())
+    add_variables!(container, PowerOutput, devices, ThermalCompactDispatch)
 
     add_parameters!(container, OnStatusParameter, devices, device_model)
 
@@ -2292,13 +2292,13 @@ function construct_device!(
             container,
             RateofChangeConstraintSlackUp,
             devices,
-            ThermalCompactDispatch(),
+            ThermalCompactDispatch,
         )
         add_variables!(
             container,
             RateofChangeConstraintSlackDown,
             devices,
-            ThermalCompactDispatch(),
+            ThermalCompactDispatch,
         )
     end
     add_event_arguments!(container, devices, device_model, network_model)

--- a/src/twoterminal_hvdc_models/AC_branches.jl
+++ b/src/twoterminal_hvdc_models/AC_branches.jl
@@ -69,10 +69,11 @@ function add_variables!(
     ::Type{T},
     network_model::NetworkModel{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::AbstractBranchFormulation,
+    ::Type{F},
 ) where {
     T <: AbstractACActivePowerFlow,
-    U <: PSY.ACTransmission}
+    U <: PSY.ACTransmission,
+    F <: AbstractBranchFormulation}
     time_steps = get_time_steps(container)
     net_reduction_data = network_model.network_reduction
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
@@ -97,8 +98,8 @@ function add_variables!(
         if has_entry
             @assert !isempty(tracker_container) name arc reduction
         end
-        ub = get_variable_upper_bound(T, reduction_entry, formulation)
-        lb = get_variable_lower_bound(T, reduction_entry, formulation)
+        ub = get_variable_upper_bound(T, reduction_entry, F)
+        lb = get_variable_lower_bound(T, reduction_entry, F)
         for t in time_steps
             if !has_entry
                 tracker_container[t] = JuMP.@variable(
@@ -119,7 +120,7 @@ function add_variables!(
     ::Type{T},
     network_model::NetworkModel{<:AbstractPTDFModel},
     devices::IS.FlattenIteratorWrapper{U},
-    formulation::StaticBranchUnbounded,
+    ::Type{StaticBranchUnbounded},
 ) where {
     T <: AbstractACActivePowerFlow,
     U <: PSY.ACTransmission}
@@ -173,7 +174,7 @@ function add_variables!(
     ::Type{S},
     network_model::NetworkModel{CopperPlatePowerModel},
     devices::IS.FlattenIteratorWrapper{T},
-    formulation::U,
+    ::Type{U},
 ) where {
     S <: AbstractACActivePowerFlow,
     T <: PSY.ACTransmission,

--- a/src/twoterminal_hvdc_models/AC_branches.jl
+++ b/src/twoterminal_hvdc_models/AC_branches.jl
@@ -18,35 +18,35 @@
 # for the branch flows either in AC or DC.
 
 #! format: off
-get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
-get_variable_binary(::PhaseShifterAngle, ::Type{PSY.PhaseShiftingTransformer}, ::AbstractBranchFormulation,) = false
+get_variable_binary(::Type{FlowActivePowerVariable}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_binary(::Type{PhaseShifterAngle}, ::Type{PSY.PhaseShiftingTransformer}, ::Type{<:AbstractBranchFormulation}) = false
 
-get_parameter_multiplier(::FixValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::LowerBoundValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
-get_parameter_multiplier(::UpperBoundValueParameter, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 1.0
+get_parameter_multiplier(::Type{FixValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{LowerBoundValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
+get_parameter_multiplier(::Type{UpperBoundValueParameter}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 1.0
 
 # Per-device reactance multiplier (1/get_x(d)) computed inline at add_to_expression! call sites.
-get_variable_multiplier(::PhaseShifterAngle, ::Type{<:PSY.PhaseShiftingTransformer}, ::PhaseAngleControl) = 1.0
+get_variable_multiplier(::Type{PhaseShifterAngle}, ::Type{<:PSY.PhaseShiftingTransformer}, ::Type{PhaseAngleControl}) = 1.0
 
-get_multiplier_value(::AbstractDynamicBranchRatingTimeSeriesParameter, d::PSY.ACTransmission, ::StaticBranch) = 1.0/PSY.get_base_power(d)
+get_multiplier_value(::Type{<:AbstractDynamicBranchRatingTimeSeriesParameter}, d::PSY.ACTransmission, ::Type{StaticBranch}) = 1.0/PSY.get_base_power(d)
 
 
 get_initial_conditions_device_model(::OperationModel, ::DeviceModel{T, U}) where {T <: PSY.ACTransmission, U <: AbstractBranchFormulation} = DeviceModel(T, U)
 
 #### Properties of slack variables
-get_variable_binary(::FlowActivePowerSlackUpperBound, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
-get_variable_binary(::FlowActivePowerSlackLowerBound, ::Type{<:PSY.ACTransmission}, ::AbstractBranchFormulation,) = false
+get_variable_binary(::Type{FlowActivePowerSlackUpperBound}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
+get_variable_binary(::Type{FlowActivePowerSlackLowerBound}, ::Type{<:PSY.ACTransmission}, ::Type{<:AbstractBranchFormulation}) = false
 # These two methods are defined to avoid ambiguities
-get_variable_upper_bound(::FlowActivePowerSlackUpperBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerSlackUpperBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 0.0
-get_variable_upper_bound(::FlowActivePowerSlackLowerBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerSlackLowerBound, ::PSY.ACTransmission, ::AbstractBranchFormulation) = 0.0
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.BranchesSeries, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.BranchesSeries, ::AbstractBranchFormulation) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.BranchesParallel, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.BranchesParallel, ::AbstractBranchFormulation) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, ::PNM.ThreeWindingTransformerWinding, ::AbstractBranchFormulation) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, ::PNM.ThreeWindingTransformerWinding, ::AbstractBranchFormulation) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerSlackUpperBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerSlackUpperBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 0.0
+get_variable_upper_bound(::Type{FlowActivePowerSlackLowerBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerSlackLowerBound}, ::PSY.ACTransmission, ::Type{<:AbstractBranchFormulation}) = 0.0
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesSeries, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesSeries, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesParallel, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.BranchesParallel, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, ::PNM.ThreeWindingTransformerWinding, ::Type{<:AbstractBranchFormulation}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, ::PNM.ThreeWindingTransformerWinding, ::Type{<:AbstractBranchFormulation}) = nothing
 
 #! format: on
 function get_default_time_series_names(
@@ -79,9 +79,7 @@ function add_variables!(
     reduced_branch_tracker = get_reduced_branch_tracker(network_model)
     all_branch_maps_by_type = PNM.get_all_branch_maps_by_type(net_reduction_data)
 
-    variable_container = add_variable_container!(
-        container,
-        T(),
+    variable_container = add_variable_container!(container, T,
         U,
         branch_names,
         time_steps,
@@ -99,8 +97,8 @@ function add_variables!(
         if has_entry
             @assert !isempty(tracker_container) name arc reduction
         end
-        ub = get_variable_upper_bound(T(), reduction_entry, formulation)
-        lb = get_variable_lower_bound(T(), reduction_entry, formulation)
+        ub = get_variable_upper_bound(T, reduction_entry, formulation)
+        lb = get_variable_lower_bound(T, reduction_entry, formulation)
         for t in time_steps
             if !has_entry
                 tracker_container[t] = JuMP.@variable(
@@ -190,7 +188,7 @@ function _get_flow_variable_vector(
     ::NetworkModel{<:AbstractDCPModel},
     ::Type{B},
 ) where {B <: PSY.ACTransmission}
-    return [get_variable(container, FlowActivePowerVariable(), B)]
+    return [get_variable(container, FlowActivePowerVariable, B)]
 end
 
 function _get_flow_variable_vector(
@@ -199,8 +197,8 @@ function _get_flow_variable_vector(
     ::Type{B},
 ) where {B <: PSY.ACTransmission}
     return [
-        get_variable(container, FlowActivePowerFromToVariable(), B),
-        get_variable(container, FlowActivePowerToFromVariable(), B),
+        get_variable(container, FlowActivePowerFromToVariable, B),
+        get_variable(container, FlowActivePowerToFromVariable, B),
     ]
 end
 
@@ -399,7 +397,7 @@ function add_constraints!(
     con_lb =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
@@ -408,19 +406,19 @@ function add_constraints!(
     con_ub =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
             meta = "ub",
         )
 
-    array = get_variable(container, FlowActivePowerVariable(), T)
+    array = get_variable(container, FlowActivePowerVariable, T)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraint][T]
@@ -469,7 +467,7 @@ function add_constraints!(
     con_lb =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
@@ -478,19 +476,19 @@ function add_constraints!(
     con_ub =
         add_constraints_container!(
             container,
-            cons_type(),
+            cons_type,
             T,
             branch_names,
             time_steps;
             meta = "ub",
         )
 
-    array = get_expression(container, PTDFBranchFlow(), T)
+    array = get_expression(container, PTDFBranchFlow, T)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraint][T]
@@ -534,20 +532,20 @@ function add_constraints!(
         cons_type,
     )
     time_steps = get_time_steps(container)
-    var1 = get_variable(container, FlowActivePowerFromToVariable(), B)
-    var2 = get_variable(container, FlowReactivePowerFromToVariable(), B)
+    var1 = get_variable(container, FlowActivePowerFromToVariable, B)
+    var2 = get_variable(container, FlowReactivePowerFromToVariable, B)
     add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         B,
         device_names,
         time_steps,
     )
-    constraint = get_constraint(container, cons_type(), B)
+    constraint = get_constraint(container, cons_type, B)
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), B)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, B)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraintFromTo][B]
@@ -586,19 +584,19 @@ function add_constraints!(
         devices,
         cons_type,
     )
-    var1 = get_variable(container, FlowActivePowerToFromVariable(), B)
-    var2 = get_variable(container, FlowReactivePowerToFromVariable(), B)
+    var1 = get_variable(container, FlowActivePowerToFromVariable, B)
+    var2 = get_variable(container, FlowReactivePowerToFromVariable, B)
     add_constraints_container!(
         container,
-        cons_type(),
+        cons_type,
         B,
         device_names,
         time_steps,
     )
-    constraint = get_constraint(container, cons_type(), B)
+    constraint = get_constraint(container, cons_type, B)
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), B)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, B)
     end
     for (name, (arc, reduction)) in
         get_constraint_map_by_type(reduced_branch_tracker)[FlowRateConstraintToFrom][B]
@@ -726,14 +724,11 @@ function add_expressions!(
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
     # Needs to be a vector to use multi-threading
     name_to_arc_map = collect(PNM.get_name_to_arc_map(net_reduction_data, B))
-    nodal_balance_expressions = get_expression(
-        container,
-        ActivePowerBalance(),
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance,
         PSY.ACBus,
     )
 
-    branch_flow_expr = add_expression_container!(container,
-        PTDFBranchFlow(),
+    branch_flow_expr = add_expression_container!(container, PTDFBranchFlow,
         B,
         branch_names,
         time_steps,
@@ -789,8 +784,8 @@ function add_constraints!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.ACTransmission}
     time_steps = get_time_steps(container)
-    branch_flow_expr = get_expression(container, PTDFBranchFlow(), T)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
+    branch_flow_expr = get_expression(container, PTDFBranchFlow, T)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
     net_reduction_data = network_model.network_reduction
     reduced_branch_tracker = get_reduced_branch_tracker(network_model)
     branches = get_branch_argument_constraint_axis(
@@ -799,9 +794,7 @@ function add_constraints!(
         devices,
         cons_type,
     )
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         branches,
         time_steps,
@@ -810,8 +803,8 @@ function add_constraints!(
 
     use_slacks = get_use_slacks(device_model)
     if use_slacks
-        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        slack_ub = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        slack_lb = get_variable(container, FlowActivePowerSlackLowerBound, T)
     end
 
     for name in branches
@@ -852,16 +845,14 @@ function add_constraints!(
     ptdf = get_PTDF_matrix(network_model)
     branches = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         branches,
         time_steps,
     )
-    nodal_balance_expressions = get_expression(container, ActivePowerBalance(), PSY.ACBus)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
-    angle_variables = get_variable(container, PhaseShifterAngle(), T)
+    nodal_balance_expressions = get_expression(container, ActivePowerBalance, PSY.ACBus)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
+    angle_variables = get_variable(container, PhaseShifterAngle, T)
     jump_model = get_jump_model(container)
     for br in devices
         arc = PNM.get_arc_tuple(br)
@@ -1033,13 +1024,11 @@ function add_constraints!(
     ::NetworkModel{DCPPowerModel},
 ) where {T <: PSY.PhaseShiftingTransformer}
     time_steps = get_time_steps(container)
-    flow_variables = get_variable(container, FlowActivePowerVariable(), T)
-    ps_angle_variables = get_variable(container, PhaseShifterAngle(), T)
-    bus_angle_variables = get_variable(container, VoltageAngle(), PSY.ACBus)
+    flow_variables = get_variable(container, FlowActivePowerVariable, T)
+    ps_angle_variables = get_variable(container, PhaseShifterAngle, T)
+    bus_angle_variables = get_variable(container, VoltageAngle, PSY.ACBus)
     jump_model = get_jump_model(container)
-    branch_flow = add_constraints_container!(
-        container,
-        NetworkFlowConstraint(),
+    branch_flow = add_constraints_container!(container, NetworkFlowConstraint,
         T,
         axes(flow_variables)[1],
         time_steps,
@@ -1073,7 +1062,7 @@ function add_to_objective_function!(
     ::Type{<:AbstractPowerModel},
 ) where {T <: PSY.ACTransmission}
     if get_use_slacks(device_model)
-        variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
+        variable_up = get_variable(container, FlowActivePowerSlackUpperBound, T)
         # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)
@@ -1094,8 +1083,8 @@ function add_to_objective_function!(
     ::Type{<:AbstractActivePowerModel},
 ) where {T <: PSY.ACTransmission}
     if get_use_slacks(device_model)
-        variable_up = get_variable(container, FlowActivePowerSlackUpperBound(), T)
-        variable_dn = get_variable(container, FlowActivePowerSlackLowerBound(), T)
+        variable_up = get_variable(container, FlowActivePowerSlackUpperBound, T)
+        variable_dn = get_variable(container, FlowActivePowerSlackLowerBound, T)
         # Use device names because there might be a network reduction
         for name in axes(variable_up, 1)
             for t in get_time_steps(container)

--- a/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
+++ b/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
@@ -1,48 +1,48 @@
 #################################### Branch Variables ##################################################
 #! format: off
-get_variable_binary(::FlowActivePowerSlackUpperBound, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = false
-get_variable_binary(::FlowActivePowerSlackLowerBound, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = false
-get_variable_binary(::HVDCPiecewiseLossVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = false
-get_variable_binary(::HVDCActivePowerReceivedFromVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = false
-get_variable_binary(::HVDCActivePowerReceivedToVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = false
-get_variable_binary(::HVDCPiecewiseBinaryLossVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation,) = true
-get_variable_binary(::VariableType, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = false
-get_variable_binary(::FlowActivePowerVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = false
-get_variable_binary(::HVDCFlowDirectionVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = true
-get_variable_multiplier(::FlowActivePowerVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = NaN
-get_parameter_multiplier(::FixValueParameter, ::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = 1.0
-get_variable_multiplier(::FlowActivePowerFromToVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = -1.0
-get_variable_multiplier(::FlowActivePowerToFromVariable, ::Type{<:PSY.TwoTerminalHVDC}, ::AbstractTwoTerminalDCLineFormulation) = -1.0
-get_variable_multiplier(::HVDCLosses, ::Type{<:PSY.TwoTerminalHVDC}, ::HVDCTwoTerminalDispatch) = -1.0
+get_variable_binary(::Type{FlowActivePowerSlackUpperBound}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{FlowActivePowerSlackLowerBound}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{HVDCPiecewiseLossVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{HVDCActivePowerReceivedFromVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{HVDCActivePowerReceivedToVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{HVDCPiecewiseBinaryLossVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = true
+get_variable_binary(::Type{<:VariableType}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{FlowActivePowerVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = false
+get_variable_binary(::Type{HVDCFlowDirectionVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = true
+get_variable_multiplier(::Type{FlowActivePowerVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = NaN
+get_parameter_multiplier(::Type{FixValueParameter}, ::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = 1.0
+get_variable_multiplier(::Type{FlowActivePowerFromToVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = -1.0
+get_variable_multiplier(::Type{FlowActivePowerToFromVariable}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = -1.0
+get_variable_multiplier(::Type{HVDCLosses}, ::Type{<:PSY.TwoTerminalHVDC}, ::Type{HVDCTwoTerminalDispatch}) = -1.0
 #= Per-device loss check (l1 == l0 == 0 → 0.0, else -1.0) should be computed inline
    at the call site if this distinction is needed.
 function get_variable_multiplier(
-    ::HVDCLosses,
+    ::Type{HVDCLosses},
     ::Type{<:PSY.TwoTerminalHVDC},
-    ::HVDCTwoTerminalDispatch,
+    ::Type{HVDCTwoTerminalDispatch},
 )
     return -1.0
 end
 =#
 
-get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalUnbounded) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalUnbounded) = nothing
-get_variable_lower_bound(::FlowActivePowerVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = nothing
-get_variable_upper_bound(::FlowActivePowerVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = nothing
-get_variable_lower_bound(::HVDCLosses, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalDispatch) = 0.0
-get_variable_upper_bound(::FlowActivePowerFromToVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalDispatch) = PSY.get_active_power_limits_from(d).max
-get_variable_lower_bound(::FlowActivePowerFromToVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalDispatch) = PSY.get_active_power_limits_from(d).min
-get_variable_upper_bound(::FlowActivePowerToFromVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalDispatch) = PSY.get_active_power_limits_to(d).max
-get_variable_lower_bound(::FlowActivePowerToFromVariable, d::PSY.TwoTerminalHVDC, ::HVDCTwoTerminalDispatch) = PSY.get_active_power_limits_to(d).min
-get_variable_upper_bound(::HVDCActivePowerReceivedFromVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = PSY.get_active_power_limits_from(d).max
-get_variable_lower_bound(::HVDCActivePowerReceivedFromVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = PSY.get_active_power_limits_from(d).min
-get_variable_upper_bound(::HVDCActivePowerReceivedToVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = PSY.get_active_power_limits_to(d).max
-get_variable_lower_bound(::HVDCActivePowerReceivedToVariable, d::PSY.TwoTerminalHVDC, ::AbstractTwoTerminalDCLineFormulation) = PSY.get_active_power_limits_to(d).min
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalUnbounded}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalUnbounded}) = nothing
+get_variable_lower_bound(::Type{FlowActivePowerVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = nothing
+get_variable_upper_bound(::Type{FlowActivePowerVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = nothing
+get_variable_lower_bound(::Type{HVDCLosses}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalDispatch}) = 0.0
+get_variable_upper_bound(::Type{FlowActivePowerFromToVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalDispatch}) = PSY.get_active_power_limits_from(d).max
+get_variable_lower_bound(::Type{FlowActivePowerFromToVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalDispatch}) = PSY.get_active_power_limits_from(d).min
+get_variable_upper_bound(::Type{FlowActivePowerToFromVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalDispatch}) = PSY.get_active_power_limits_to(d).max
+get_variable_lower_bound(::Type{FlowActivePowerToFromVariable}, d::PSY.TwoTerminalHVDC, ::Type{HVDCTwoTerminalDispatch}) = PSY.get_active_power_limits_to(d).min
+get_variable_upper_bound(::Type{HVDCActivePowerReceivedFromVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = PSY.get_active_power_limits_from(d).max
+get_variable_lower_bound(::Type{HVDCActivePowerReceivedFromVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = PSY.get_active_power_limits_from(d).min
+get_variable_upper_bound(::Type{HVDCActivePowerReceivedToVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = PSY.get_active_power_limits_to(d).max
+get_variable_lower_bound(::Type{HVDCActivePowerReceivedToVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:AbstractTwoTerminalDCLineFormulation}) = PSY.get_active_power_limits_to(d).min
 
 function get_variable_upper_bound(
-    ::HVDCLosses,
+    ::Type{HVDCLosses},
     d::PSY.TwoTerminalHVDC,
-    ::HVDCTwoTerminalDispatch,
+    ::Type{HVDCTwoTerminalDispatch},
 )
     loss = PSY.get_loss(d)
     if !isa(loss, PSY.LinearCurve)
@@ -59,35 +59,36 @@ function get_variable_upper_bound(
     end
 end
 
-get_variable_upper_bound(::HVDCPiecewiseLossVariable, d::PSY.TwoTerminalHVDC, ::Union{HVDCTwoTerminalDispatch, HVDCTwoTerminalPiecewiseLoss}) = 1.0
-get_variable_lower_bound(::HVDCPiecewiseLossVariable, d::PSY.TwoTerminalHVDC, ::Union{HVDCTwoTerminalDispatch, HVDCTwoTerminalPiecewiseLoss}) = 0.0
+get_variable_upper_bound(::Type{HVDCPiecewiseLossVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:Union{HVDCTwoTerminalDispatch, HVDCTwoTerminalPiecewiseLoss}}) = 1.0
+get_variable_lower_bound(::Type{HVDCPiecewiseLossVariable}, d::PSY.TwoTerminalHVDC, ::Type{<:Union{HVDCTwoTerminalDispatch, HVDCTwoTerminalPiecewiseLoss}}) = 0.0
 
 #################################### LCC ##################################################
-get_variable_binary(::HVDCActivePowerReceivedFromVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCActivePowerReceivedToVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCReactivePowerReceivedFromVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCReactivePowerReceivedToVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierDelayAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterExtinctionAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierPowerFactorAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterPowerFactorAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierOverlapAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterOverlapAngleVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierDCVoltageVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterDCVoltageVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierACCurrentVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterACCurrentVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::DCLineCurrentFlowVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCRectifierTapSettingVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_binary(::HVDCInverterTapSettingVariable, ::Type{PSY.TwoTerminalLCCLine}, ::HVDCTwoTerminalLCC) = false
-get_variable_upper_bound(::HVDCRectifierDelayAngleVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_rectifier_delay_angle_limits(d).max
-get_variable_lower_bound(::HVDCRectifierDelayAngleVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_rectifier_delay_angle_limits(d).min
-get_variable_upper_bound(::HVDCInverterExtinctionAngleVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_inverter_extinction_angle_limits(d).max
-get_variable_lower_bound(::HVDCInverterExtinctionAngleVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_inverter_extinction_angle_limits(d).min
-get_variable_upper_bound(::HVDCRectifierTapSettingVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_rectifier_tap_limits(d).max
-get_variable_lower_bound(::HVDCRectifierTapSettingVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_rectifier_tap_limits(d).min
-get_variable_upper_bound(::HVDCInverterTapSettingVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_inverter_tap_limits(d).max
-get_variable_lower_bound(::HVDCInverterTapSettingVariable, d::PSY.TwoTerminalLCCLine, ::HVDCTwoTerminalLCC) = PSY.get_inverter_tap_limits(d).min
+# FIXME consolidate to one definition on supertype.
+get_variable_binary(::Type{HVDCActivePowerReceivedFromVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCActivePowerReceivedToVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCReactivePowerReceivedFromVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCReactivePowerReceivedToVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierDelayAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterExtinctionAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierPowerFactorAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterPowerFactorAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierOverlapAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterOverlapAngleVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierDCVoltageVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterDCVoltageVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierACCurrentVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterACCurrentVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{DCLineCurrentFlowVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCRectifierTapSettingVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_binary(::Type{HVDCInverterTapSettingVariable}, ::Type{PSY.TwoTerminalLCCLine}, ::Type{HVDCTwoTerminalLCC}) = false
+get_variable_upper_bound(::Type{HVDCRectifierDelayAngleVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_rectifier_delay_angle_limits(d).max
+get_variable_lower_bound(::Type{HVDCRectifierDelayAngleVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_rectifier_delay_angle_limits(d).min
+get_variable_upper_bound(::Type{HVDCInverterExtinctionAngleVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_inverter_extinction_angle_limits(d).max
+get_variable_lower_bound(::Type{HVDCInverterExtinctionAngleVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_inverter_extinction_angle_limits(d).min
+get_variable_upper_bound(::Type{HVDCRectifierTapSettingVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_rectifier_tap_limits(d).max
+get_variable_lower_bound(::Type{HVDCRectifierTapSettingVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_rectifier_tap_limits(d).min
+get_variable_upper_bound(::Type{HVDCInverterTapSettingVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_inverter_tap_limits(d).max
+get_variable_lower_bound(::Type{HVDCInverterTapSettingVariable}, d::PSY.TwoTerminalLCCLine, ::Type{HVDCTwoTerminalLCC}) = PSY.get_inverter_tap_limits(d).min
 #! format: on
 ##########################################################
 function get_default_time_series_names(
@@ -135,9 +136,9 @@ function _add_dense_pwl_loss_variables!(
     # Create Variables
     time_steps = get_time_steps(container)
     settings = get_settings(container)
-    formulation = HVDCTwoTerminalPiecewiseLoss()
+    formulation = HVDCTwoTerminalPiecewiseLoss
     T = HVDCPiecewiseLossVariable
-    binary = get_variable_binary(T(), D, formulation)
+    binary = get_variable_binary(T, D, formulation)
     first_loss = PSY.get_loss(first(devices))
     if isa(first_loss, PSY.LinearCurve)
         len_segments = 4 # 2*1 + 2
@@ -149,9 +150,7 @@ function _add_dense_pwl_loss_variables!(
 
     segments = ["pwl_$i" for i in 1:len_segments]
     T = HVDCPiecewiseLossVariable
-    variable = add_variable_container!(
-        container,
-        T(),
+    variable = add_variable_container!(container, T,
         D,
         PSY.get_name.(devices),
         segments,
@@ -165,14 +164,14 @@ function _add_dense_pwl_loss_variables!(
             base_name = "$(T)_$(D)_{$(name), $(s), $(t)}",
             binary = binary
         )
-        ub = get_variable_upper_bound(T(), d, formulation)
+        ub = get_variable_upper_bound(T, d, formulation)
         ub !== nothing && JuMP.set_upper_bound(variable[name, s, t], ub)
 
-        lb = get_variable_lower_bound(T(), d, formulation)
+        lb = get_variable_lower_bound(T, d, formulation)
         lb !== nothing && JuMP.set_lower_bound(variable[name, s, t], lb)
 
         if get_warm_start(settings)
-            init = get_variable_warm_start_value(T(), d, formulation)
+            init = get_variable_warm_start_value(T, d, formulation)
             init !== nothing && JuMP.set_start_value(variable[name, s, t], init)
         end
     end
@@ -192,9 +191,9 @@ function _add_sparse_pwl_loss_variables!(
     settings = get_settings(container)
     formulation = HVDCTwoTerminalPiecewiseLoss()
     T = HVDCPiecewiseLossVariable
-    binary_T = get_variable_binary(T(), D, formulation)
+    binary_T = get_variable_binary(T, D, formulation)
     U = HVDCPiecewiseBinaryLossVariable
-    binary_U = get_variable_binary(U(), D, formulation)
+    binary_U = get_variable_binary(U, D, formulation)
     first_loss = PSY.get_loss(first(devices))
     if isa(first_loss, PSY.LinearCurve)
         len_segments = 3 # 2*1 + 1
@@ -204,8 +203,8 @@ function _add_sparse_pwl_loss_variables!(
         error("Should not be here")
     end
 
-    var_container = lazy_container_addition!(container, T(), D)
-    var_container_binary = lazy_container_addition!(container, U(), D)
+    var_container = lazy_container_addition!(container, T, D)
+    var_container_binary = lazy_container_addition!(container, U, D)
 
     for d in devices
         name = PSY.get_name(d)
@@ -219,10 +218,10 @@ function _add_sparse_pwl_loss_variables!(
                         base_name = "$(T)_$(name)_{pwl_$(i), $(t)}",
                         binary = binary_T
                     )
-                ub = get_variable_upper_bound(T(), d, formulation)
+                ub = get_variable_upper_bound(T, d, formulation)
                 ub !== nothing && JuMP.set_upper_bound(var_container[name, i, t], ub)
 
-                lb = get_variable_lower_bound(T(), d, formulation)
+                lb = get_variable_lower_bound(T, d, formulation)
                 lb !== nothing && JuMP.set_lower_bound(var_container[name, i, t], lb)
 
                 pwlvars_bin[i] =
@@ -339,19 +338,19 @@ function add_constraints!(
     ::DeviceModel{U, HVDCTwoTerminalPiecewiseLoss},
     ::NetworkModel{<:AbstractPowerModel},
 ) where {T <: HVDCFlowCalculationConstraint, U <: PSY.TwoTerminalHVDC}
-    var_pwl = get_variable(container, HVDCPiecewiseLossVariable(), U)
-    var_pwl_bin = get_variable(container, HVDCPiecewiseBinaryLossVariable(), U)
+    var_pwl = get_variable(container, HVDCPiecewiseLossVariable, U)
+    var_pwl_bin = get_variable(container, HVDCPiecewiseBinaryLossVariable, U)
     names = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
-    flow_ft = get_variable(container, HVDCActivePowerReceivedFromVariable(), U)
-    flow_tf = get_variable(container, HVDCActivePowerReceivedToVariable(), U)
+    flow_ft = get_variable(container, HVDCActivePowerReceivedFromVariable, U)
+    flow_tf = get_variable(container, HVDCActivePowerReceivedToVariable, U)
 
     constraint_from_to =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "ft")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "ft")
     constraint_to_from =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "tf")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "tf")
     constraint_binary =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "bin")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "bin")
     for d in devices
         name = PSY.get_name(d)
         loss = PSY.get_loss(d)
@@ -458,11 +457,11 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
 
-    var = get_variable(container, FlowActivePowerVariable(), U)
+    var = get_variable(container, FlowActivePowerVariable, U)
     constraint_ub =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "ub")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "ub")
     constraint_lb =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "lb")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "lb")
     for d in devices
         min_rate, max_rate = _get_flow_bounds(d)
         for t in time_steps
@@ -499,11 +498,11 @@ function add_constraints!(
         end
     end
 
-    var = get_variable(container, FlowActivePowerVariable(), U)
+    var = get_variable(container, FlowActivePowerVariable, U)
     constraint_ub =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "ub")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "ub")
     constraint_lb =
-        add_constraints_container!(container, T(), U, names, time_steps; meta = "lb")
+        add_constraints_container!(container, T, U, names, time_steps; meta = "lb")
     for d in modeled_devices
         min_rate, max_rate = _get_flow_bounds(d)
         for t in time_steps
@@ -546,6 +545,7 @@ function _add_hvdc_flow_constraints!(
     )
 end
 
+# FIXME typeof(var), typeof(constraint) are runtime. Add function barrier and dispatch.
 function _add_hvdc_flow_constraints!(
     container::OptimizationContainer,
     devices::Union{Vector{T}, IS.FlattenIteratorWrapper{T}},
@@ -560,15 +560,29 @@ function _add_hvdc_flow_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
 
-    variable = get_variable(container, var, T)
+    variable = get_variable(container, typeof(var), T)
     constraint_ub =
-        add_constraints_container!(container, constraint, T, names, time_steps; meta = "ub")
+        add_constraints_container!(
+            container,
+            typeof(constraint),
+            T,
+            names,
+            time_steps;
+            meta = "ub",
+        )
     constraint_lb =
-        add_constraints_container!(container, constraint, T, names, time_steps; meta = "lb")
+        add_constraints_container!(
+            container,
+            typeof(constraint),
+            T,
+            names,
+            time_steps;
+            meta = "lb",
+        )
     for d in devices
         check_hvdc_line_limits_consistency(d)
-        max_rate = get_variable_upper_bound(var, d, HVDCTwoTerminalDispatch())
-        min_rate = get_variable_lower_bound(var, d, HVDCTwoTerminalDispatch())
+        max_rate = get_variable_upper_bound(typeof(var), d, HVDCTwoTerminalDispatch)
+        min_rate = get_variable_lower_bound(typeof(var), d, HVDCTwoTerminalDispatch)
         name = PSY.get_name(d)
         for t in time_steps
             constraint_ub[name, t] = JuMP.@constraint(
@@ -713,78 +727,60 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalHVDC}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    tf_var = get_variable(container, FlowActivePowerToFromVariable(), T)
-    ft_var = get_variable(container, FlowActivePowerFromToVariable(), T)
-    direction_var = get_variable(container, HVDCFlowDirectionVariable(), T)
-    losses = get_variable(container, HVDCLosses(), T)
+    tf_var = get_variable(container, FlowActivePowerToFromVariable, T)
+    ft_var = get_variable(container, FlowActivePowerFromToVariable, T)
+    direction_var = get_variable(container, HVDCFlowDirectionVariable, T)
+    losses = get_variable(container, HVDCLosses, T)
 
-    constraint_ft_ub = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_ft_ub = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "ft_ub",
     )
-    constraint_tf_ub = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_tf_ub = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "tf_ub",
     )
-    constraint_ft_lb = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_ft_lb = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "tf_lb",
     )
-    constraint_tf_lb = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_tf_lb = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "ft_lb",
     )
-    constraint_loss = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_loss = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "loss",
     )
-    constraint_loss_aux1 = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_loss_aux1 = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "loss_aux1",
     )
-    constraint_loss_aux2 = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_loss_aux2 = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "loss_aux2",
     )
-    constraint_loss_aux3 = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_loss_aux3 = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
         meta = "loss_aux3",
     )
-    constraint_loss_aux4 = add_constraints_container!(
-        container,
-        HVDCPowerBalance(),
+    constraint_loss_aux4 = add_constraints_container!(container, HVDCPowerBalance,
         T,
         names,
         time_steps;
@@ -855,19 +851,18 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_dc_voltage_var = get_variable(container, HVDCRectifierDCVoltageVariable(), T)
-    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
-    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable(), T)
-    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+    rect_dc_voltage_var = get_variable(container, HVDCRectifierDCVoltageVariable, T)
+    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
+    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable, T)
+    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_rect_dc_volt = add_constraints_container!(
-        container,
-        HVDCRectifierDCLineVoltageConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_rect_dc_volt =
+        add_constraints_container!(container, HVDCRectifierDCLineVoltageConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -904,20 +899,19 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    inv_dc_voltage_var = get_variable(container, HVDCInverterDCVoltageVariable(), T)
-    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
+    inv_dc_voltage_var = get_variable(container, HVDCInverterDCVoltageVariable, T)
+    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
     inv_extinction_angle_var =
-        get_variable(container, HVDCInverterExtinctionAngleVariable(), T)
-    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+        get_variable(container, HVDCInverterExtinctionAngleVariable, T)
+    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_inv_dc_volt = add_constraints_container!(
-        container,
-        HVDCInverterDCLineVoltageConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_inv_dc_volt =
+        add_constraints_container!(container, HVDCInverterDCLineVoltageConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -954,19 +948,18 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
-    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable(), T)
-    rect_overlap_angle_var = get_variable(container, HVDCRectifierOverlapAngleVariable(), T)
-    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
+    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable, T)
+    rect_overlap_angle_var = get_variable(container, HVDCRectifierOverlapAngleVariable, T)
+    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_rect_over_ang = add_constraints_container!(
-        container,
-        HVDCRectifierOverlapAngleConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_rect_over_ang =
+        add_constraints_container!(container, HVDCRectifierOverlapAngleConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1013,20 +1006,19 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
+    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
     inv_extinction_angle_var =
-        get_variable(container, HVDCInverterExtinctionAngleVariable(), T)
-    inv_overlap_angle_var = get_variable(container, HVDCInverterOverlapAngleVariable(), T)
-    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+        get_variable(container, HVDCInverterExtinctionAngleVariable, T)
+    inv_overlap_angle_var = get_variable(container, HVDCInverterOverlapAngleVariable, T)
+    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_inv_over_ang = add_constraints_container!(
-        container,
-        HVDCInverterOverlapAngleConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_inv_over_ang =
+        add_constraints_container!(container, HVDCInverterOverlapAngleConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1073,18 +1065,17 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable(), T)
-    rect_overlap_angle_var = get_variable(container, HVDCRectifierOverlapAngleVariable(), T)
+    rect_delay_angle_var = get_variable(container, HVDCRectifierDelayAngleVariable, T)
+    rect_overlap_angle_var = get_variable(container, HVDCRectifierOverlapAngleVariable, T)
     rect_power_factor_var =
-        get_variable(container, HVDCRectifierPowerFactorAngleVariable(), T)
+        get_variable(container, HVDCRectifierPowerFactorAngleVariable, T)
 
-    constraint_rect_power_factor_ang = add_constraints_container!(
-        container,
-        HVDCRectifierPowerFactorAngleConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_rect_power_factor_ang =
+        add_constraints_container!(container, HVDCRectifierPowerFactorAngleConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1136,18 +1127,17 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
     inv_extinction_angle_var =
-        get_variable(container, HVDCInverterExtinctionAngleVariable(), T)
-    inv_overlap_angle_var = get_variable(container, HVDCInverterOverlapAngleVariable(), T)
+        get_variable(container, HVDCInverterExtinctionAngleVariable, T)
+    inv_overlap_angle_var = get_variable(container, HVDCInverterOverlapAngleVariable, T)
     inv_power_factor_var =
-        get_variable(container, HVDCInverterPowerFactorAngleVariable(), T)
+        get_variable(container, HVDCInverterPowerFactorAngleVariable, T)
 
-    constraint_inv_power_factor_ang = add_constraints_container!(
-        container,
-        HVDCInverterPowerFactorAngleConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_inv_power_factor_ang =
+        add_constraints_container!(container, HVDCInverterPowerFactorAngleConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1198,16 +1188,15 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_ac_current_var = get_variable(container, HVDCRectifierACCurrentVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+    rect_ac_current_var = get_variable(container, HVDCRectifierACCurrentVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_rect_ac_current = add_constraints_container!(
-        container,
-        HVDCRectifierACCurrentFlowConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_rect_ac_current =
+        add_constraints_container!(container, HVDCRectifierACCurrentFlowConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1233,16 +1222,15 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    inv_ac_current_var = get_variable(container, HVDCInverterACCurrentVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+    inv_ac_current_var = get_variable(container, HVDCInverterACCurrentVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_inv_ac_current = add_constraints_container!(
-        container,
-        HVDCInverterACCurrentFlowConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_inv_ac_current =
+        add_constraints_container!(container, HVDCInverterACCurrentFlowConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1268,30 +1256,28 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_ac_ppower_var = get_variable(container, HVDCActivePowerReceivedFromVariable(), T)
-    rect_ac_qpower_var = get_variable(container, HVDCReactivePowerReceivedFromVariable(), T)
-    rect_ac_current_var = get_variable(container, HVDCRectifierACCurrentVariable(), T)
-    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
+    rect_ac_ppower_var = get_variable(container, HVDCActivePowerReceivedFromVariable, T)
+    rect_ac_qpower_var = get_variable(container, HVDCReactivePowerReceivedFromVariable, T)
+    rect_ac_current_var = get_variable(container, HVDCRectifierACCurrentVariable, T)
+    rect_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
     rect_power_factor_var =
-        get_variable(container, HVDCRectifierPowerFactorAngleVariable(), T)
-    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable(), T)
+        get_variable(container, HVDCRectifierPowerFactorAngleVariable, T)
+    rect_tap_setting_var = get_variable(container, HVDCRectifierTapSettingVariable, T)
 
-    constraint_ft_p = add_constraints_container!(
-        container,
-        HVDCRectifierPowerCalculationConstraint(),
-        T,
-        names,
-        time_steps;
-        meta = "active",
-    )
-    constraint_ft_q = add_constraints_container!(
-        container,
-        HVDCRectifierPowerCalculationConstraint(),
-        T,
-        names,
-        time_steps;
-        meta = "reactive",
-    )
+    constraint_ft_p =
+        add_constraints_container!(container, HVDCRectifierPowerCalculationConstraint,
+            T,
+            names,
+            time_steps;
+            meta = "active",
+        )
+    constraint_ft_q =
+        add_constraints_container!(container, HVDCRectifierPowerCalculationConstraint,
+            T,
+            names,
+            time_steps;
+            meta = "reactive",
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1332,30 +1318,28 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    inv_ac_ppower_var = get_variable(container, HVDCActivePowerReceivedToVariable(), T)
-    inv_ac_qpower_var = get_variable(container, HVDCReactivePowerReceivedToVariable(), T)
-    inv_ac_current_var = get_variable(container, HVDCInverterACCurrentVariable(), T)
-    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude(), PSY.ACBus)
+    inv_ac_ppower_var = get_variable(container, HVDCActivePowerReceivedToVariable, T)
+    inv_ac_qpower_var = get_variable(container, HVDCReactivePowerReceivedToVariable, T)
+    inv_ac_current_var = get_variable(container, HVDCInverterACCurrentVariable, T)
+    inv_ac_voltage_bus_var = get_variable(container, VoltageMagnitude, PSY.ACBus)
     inv_power_factor_var =
-        get_variable(container, HVDCInverterPowerFactorAngleVariable(), T)
-    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable(), T)
+        get_variable(container, HVDCInverterPowerFactorAngleVariable, T)
+    inv_tap_setting_var = get_variable(container, HVDCInverterTapSettingVariable, T)
 
-    constraint_ft_p = add_constraints_container!(
-        container,
-        HVDCInverterPowerCalculationConstraint(),
-        T,
-        names,
-        time_steps;
-        meta = "active",
-    )
-    constraint_ft_q = add_constraints_container!(
-        container,
-        HVDCInverterPowerCalculationConstraint(),
-        T,
-        names,
-        time_steps;
-        meta = "reactive",
-    )
+    constraint_ft_p =
+        add_constraints_container!(container, HVDCInverterPowerCalculationConstraint,
+            T,
+            names,
+            time_steps;
+            meta = "active",
+        )
+    constraint_ft_q =
+        add_constraints_container!(container, HVDCInverterPowerCalculationConstraint,
+            T,
+            names,
+            time_steps;
+            meta = "reactive",
+        )
 
     for d in devices
         name = PSY.get_name(d)
@@ -1396,17 +1380,16 @@ function add_constraints!(
 ) where {T <: PSY.TwoTerminalLCCLine}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
-    rect_dc_voltage_var = get_variable(container, HVDCRectifierDCVoltageVariable(), T)
-    inv_dc_voltage_var = get_variable(container, HVDCInverterDCVoltageVariable(), T)
-    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable(), T)
+    rect_dc_voltage_var = get_variable(container, HVDCRectifierDCVoltageVariable, T)
+    inv_dc_voltage_var = get_variable(container, HVDCInverterDCVoltageVariable, T)
+    dc_line_current_var = get_variable(container, DCLineCurrentFlowVariable, T)
 
-    constraint_tl_c = add_constraints_container!(
-        container,
-        HVDCTransmissionDCLineConstraint(),
-        T,
-        names,
-        time_steps;
-    )
+    constraint_tl_c =
+        add_constraints_container!(container, HVDCTransmissionDCLineConstraint,
+            T,
+            names,
+            time_steps;
+        )
 
     for d in devices
         name = PSY.get_name(d)

--- a/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
+++ b/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
@@ -189,7 +189,7 @@ function _add_sparse_pwl_loss_variables!(
     # Create Variables
     time_steps = get_time_steps(container)
     settings = get_settings(container)
-    formulation = HVDCTwoTerminalPiecewiseLoss()
+    formulation = HVDCTwoTerminalPiecewiseLoss
     T = HVDCPiecewiseLossVariable
     binary_T = get_variable_binary(T, D, formulation)
     U = HVDCPiecewiseBinaryLossVariable
@@ -522,49 +522,52 @@ end
 function _add_hvdc_flow_constraints!(
     container::OptimizationContainer,
     devices::Union{Vector{T}, IS.FlattenIteratorWrapper{T}},
-    constraint::FlowRateConstraintFromTo,
+    ::Type{FlowRateConstraintFromTo},
 ) where {T <: PSY.TwoTerminalHVDC}
     _add_hvdc_flow_constraints!(
         container,
         devices,
-        FlowActivePowerFromToVariable(),
-        constraint,
+        FlowActivePowerFromToVariable,
+        FlowRateConstraintFromTo,
     )
 end
 
 function _add_hvdc_flow_constraints!(
     container::OptimizationContainer,
     devices::Union{Vector{T}, IS.FlattenIteratorWrapper{T}},
-    constraint::FlowRateConstraintToFrom,
+    ::Type{FlowRateConstraintToFrom},
 ) where {T <: PSY.TwoTerminalHVDC}
     _add_hvdc_flow_constraints!(
         container,
         devices,
-        FlowActivePowerToFromVariable(),
-        constraint,
+        FlowActivePowerToFromVariable,
+        FlowRateConstraintToFrom,
     )
 end
 
-# FIXME typeof(var), typeof(constraint) are runtime. Add function barrier and dispatch.
 function _add_hvdc_flow_constraints!(
     container::OptimizationContainer,
     devices::Union{Vector{T}, IS.FlattenIteratorWrapper{T}},
-    var::Union{
+    ::Type{V},
+    ::Type{C},
+) where {
+    T <: PSY.TwoTerminalHVDC,
+    V <: Union{
         FlowActivePowerFromToVariable,
         FlowActivePowerToFromVariable,
         HVDCActivePowerReceivedFromVariable,
         HVDCActivePowerReceivedToVariable,
     },
-    constraint::Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom},
-) where {T <: PSY.TwoTerminalHVDC}
+    C <: Union{FlowRateConstraintFromTo, FlowRateConstraintToFrom},
+}
     time_steps = get_time_steps(container)
     names = PSY.get_name.(devices)
 
-    variable = get_variable(container, typeof(var), T)
+    variable = get_variable(container, V, T)
     constraint_ub =
         add_constraints_container!(
             container,
-            typeof(constraint),
+            C,
             T,
             names,
             time_steps;
@@ -573,7 +576,7 @@ function _add_hvdc_flow_constraints!(
     constraint_lb =
         add_constraints_container!(
             container,
-            typeof(constraint),
+            C,
             T,
             names,
             time_steps;
@@ -581,8 +584,8 @@ function _add_hvdc_flow_constraints!(
         )
     for d in devices
         check_hvdc_line_limits_consistency(d)
-        max_rate = get_variable_upper_bound(typeof(var), d, HVDCTwoTerminalDispatch)
-        min_rate = get_variable_lower_bound(typeof(var), d, HVDCTwoTerminalDispatch)
+        max_rate = get_variable_upper_bound(V, d, HVDCTwoTerminalDispatch)
+        min_rate = get_variable_lower_bound(V, d, HVDCTwoTerminalDispatch)
         name = PSY.get_name(d)
         for t in time_steps
             constraint_ub[name, t] = JuMP.@constraint(
@@ -617,7 +620,7 @@ function add_constraints!(
         end
     end
     if !isempty(inter_network_branches)
-        _add_hvdc_flow_constraints!(container, devices, T())
+        _add_hvdc_flow_constraints!(container, devices, T)
     end
     return
 end
@@ -632,7 +635,7 @@ function add_constraints!(
     T <: Union{FlowRateConstraintToFrom, FlowRateConstraintFromTo},
     U <: PSY.TwoTerminalHVDC,
 }
-    _add_hvdc_flow_constraints!(container, devices, T())
+    _add_hvdc_flow_constraints!(container, devices, T)
     return
 end
 
@@ -646,7 +649,7 @@ function add_constraints!(
     T <: Union{FlowRateConstraintToFrom, FlowRateConstraintFromTo},
     U <: PSY.TwoTerminalHVDC,
 }
-    _add_hvdc_flow_constraints!(container, devices, T())
+    _add_hvdc_flow_constraints!(container, devices, T)
     return
 end
 
@@ -674,15 +677,15 @@ function add_constraints!(
             _add_hvdc_flow_constraints!(
                 container,
                 devices,
-                HVDCActivePowerReceivedFromVariable(),
-                T(),
+                HVDCActivePowerReceivedFromVariable,
+                T,
             )
         else
             _add_hvdc_flow_constraints!(
                 container,
                 devices,
-                HVDCActivePowerReceivedToVariable(),
-                T(),
+                HVDCActivePowerReceivedToVariable,
+                T,
             )
         end
     end
@@ -704,15 +707,15 @@ function add_constraints!(
         _add_hvdc_flow_constraints!(
             container,
             devices,
-            HVDCActivePowerReceivedFromVariable(),
-            T(),
+            HVDCActivePowerReceivedFromVariable,
+            T,
         )
     else
         _add_hvdc_flow_constraints!(
             container,
             devices,
-            HVDCActivePowerReceivedToVariable(),
-            T(),
+            HVDCActivePowerReceivedToVariable,
+            T,
         )
     end
     return

--- a/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
+++ b/src/twoterminal_hvdc_models/TwoTerminalDC_branches.jl
@@ -311,7 +311,7 @@ function add_variables!(
     ::Type{FlowActivePowerVariable},
     network_model::NetworkModel{CopperPlatePowerModel},
     devices::IS.FlattenIteratorWrapper{T},
-    formulation::U,
+    ::Type{U},
 ) where {T <: PSY.TwoTerminalHVDC, U <: AbstractBranchFormulation}
     inter_network_branches = T[]
     for d in devices
@@ -326,7 +326,7 @@ function add_variables!(
         end
     end
     if !isempty(inter_network_branches)
-        add_variables!(container, FlowActivePowerVariable, inter_network_branches, U())
+        add_variables!(container, FlowActivePowerVariable, inter_network_branches, U)
     end
     return
 end

--- a/src/twoterminal_hvdc_models/branch_constructor.jl
+++ b/src/twoterminal_hvdc_models/branch_constructor.jl
@@ -90,13 +90,13 @@ function construct_device!(
             container,
             FlowActivePowerSlackUpperBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
     add_feedforward_arguments!(container, device_model, devices)
@@ -136,14 +136,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
 
@@ -276,7 +276,7 @@ function construct_device!(
         FlowActivePowerVariable,
         network_model,
         devices,
-        StaticBranchBounds(),
+        StaticBranchBounds,
     )
 
     if get_use_slacks(device_model)
@@ -285,14 +285,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
 
@@ -375,7 +375,7 @@ function construct_device!(
             container,
             FlowActivePowerSlackUpperBound,
             devices,
-            StaticBranch(),
+            StaticBranch,
         )
     end
     add_feedforward_arguments!(container, device_model, devices)
@@ -485,7 +485,7 @@ function construct_device!(
             FlowActivePowerVariable,
             network_model,
             devices,
-            HVDCTwoTerminalLossless(),
+            HVDCTwoTerminalLossless,
         )
         add_to_expression!(
             container,
@@ -556,7 +556,7 @@ function construct_device!(
     network_model::NetworkModel{CopperPlatePowerModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -659,7 +659,7 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalUnbounded)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -721,7 +721,7 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.TwoTerminalHVDC}
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalLossless())
+    add_variables!(container, FlowActivePowerVariable, devices, HVDCTwoTerminalLossless)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -763,16 +763,16 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch())
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch)
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -841,16 +841,16 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
-    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
+    add_variables!(container, HVDCLosses, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -914,13 +914,13 @@ function construct_device!(
         container,
         HVDCActivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalPiecewiseLoss(),
+        HVDCTwoTerminalPiecewiseLoss,
     )
     add_variables!(
         container,
         HVDCActivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalPiecewiseLoss(),
+        HVDCTwoTerminalPiecewiseLoss,
     )
     _add_sparse_pwl_loss_variables!(container, devices, device_model)
     add_to_expression!(
@@ -994,15 +994,15 @@ function construct_device!(
         container,
         FlowActivePowerToFromVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
     add_variables!(
         container,
         FlowActivePowerFromToVariable,
         devices,
-        HVDCTwoTerminalDispatch(),
+        HVDCTwoTerminalDispatch,
     )
-    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch())
+    add_variables!(container, HVDCFlowDirectionVariable, devices, HVDCTwoTerminalDispatch)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1084,103 +1084,103 @@ function construct_device!(
         container,
         HVDCActivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCActivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCReactivePowerReceivedFromVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCReactivePowerReceivedToVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierDelayAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterExtinctionAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierPowerFactorAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterPowerFactorAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierOverlapAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterOverlapAngleVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierDCVoltageVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterDCVoltageVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierACCurrentVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterACCurrentVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         DCLineCurrentFlowVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCRectifierTapSettingVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
     add_variables!(
         container,
         HVDCInverterTapSettingVariable,
         devices,
-        HVDCTwoTerminalLCC(),
+        HVDCTwoTerminalLCC,
     )
 
     # Expressions
@@ -1319,8 +1319,8 @@ function construct_device!(
     network_model::NetworkModel{DCPPowerModel},
 )
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl())
-    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl())
+    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl)
+    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1341,8 +1341,8 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 )
     devices = get_available_components(device_model, sys)
-    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl())
-    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl())
+    add_variables!(container, FlowActivePowerVariable, devices, PhaseAngleControl)
+    add_variables!(container, PhaseShifterAngle, devices, PhaseAngleControl)
     add_to_expression!(
         container,
         ActivePowerBalance,
@@ -1442,14 +1442,14 @@ function construct_device!(
             FlowActivePowerSlackUpperBound,
             network_model,
             devices,
-            T(),
+            T,
         )
         add_variables!(
             container,
             FlowActivePowerSlackLowerBound,
             network_model,
             devices,
-            T(),
+            T,
         )
     end
     if any(has_ts) && !all(has_ts)
@@ -1462,7 +1462,7 @@ function construct_device!(
         FlowActivePowerVariable,
         network_model,
         devices,
-        T(),
+        T,
     )
     add_to_expression!(
         container,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -31,9 +31,6 @@ TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/NREL-Sienna/InfrastructureSystems.jl"}
-
 [compat]
 HiGHS = "1"
 Ipopt = "=1.4.0"

--- a/test/test_initialization_problem.jl
+++ b/test/test_initialization_problem.jl
@@ -31,38 +31,38 @@ sys_rts = PSB.build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
     check_active_power_initial_condition_values(model, ThermalStandard)
     check_status_initial_conditions_values(model, ThermalStandard)
     ####### Check variables
-    check_variable_count(model, ActivePowerVariable(), ThermalStandard)
-    check_variable_count(model, StopVariable(), ThermalStandard)
-    check_variable_count(model, OnVariable(), ThermalStandard)
-    check_variable_count(model, StartVariable(), ThermalStandard)
-    check_variable_count(model, ActivePowerVariable(), RenewableDispatch)
-    check_variable_count(model, ActivePowerVariable(), HydroDispatch)
+    check_variable_count(model, ActivePowerVariable, ThermalStandard)
+    check_variable_count(model, StopVariable, ThermalStandard)
+    check_variable_count(model, OnVariable, ThermalStandard)
+    check_variable_count(model, StartVariable, ThermalStandard)
+    check_variable_count(model, ActivePowerVariable, RenewableDispatch)
+    check_variable_count(model, ActivePowerVariable, HydroDispatch)
     ####### Check constraints
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "lb",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "ub",
     )
-    check_constraint_count(model, DurationConstraint(), ThermalStandard)
-    check_constraint_count(model, RampConstraint(), ThermalStandard)
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard)
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard; meta = "aux")
+    check_constraint_count(model, DurationConstraint, ThermalStandard)
+    check_constraint_count(model, RampConstraint, ThermalStandard)
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard)
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard; meta = "aux")
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         RenewableDispatch;
         meta = "ub",
     )
@@ -96,50 +96,50 @@ end
     check_status_initial_conditions_values(model, ThermalStandard)
 
     ####### Check variables
-    check_variable_count(model, ActivePowerVariable(), ThermalStandard)
-    check_variable_count(model, StopVariable(), ThermalStandard)
-    check_variable_count(model, OnVariable(), ThermalStandard)
-    check_variable_count(model, StartVariable(), ThermalStandard)
-    check_variable_count(model, ActivePowerVariable(), RenewableDispatch)
-    check_variable_count(model, ActivePowerVariable(), HydroDispatch)
-    check_variable_count(model, OnVariable(), HydroDispatch)
+    check_variable_count(model, ActivePowerVariable, ThermalStandard)
+    check_variable_count(model, StopVariable, ThermalStandard)
+    check_variable_count(model, OnVariable, ThermalStandard)
+    check_variable_count(model, StartVariable, ThermalStandard)
+    check_variable_count(model, ActivePowerVariable, RenewableDispatch)
+    check_variable_count(model, ActivePowerVariable, HydroDispatch)
+    check_variable_count(model, OnVariable, HydroDispatch)
     ####### Check constraints
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "lb",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "ub",
     )
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard)
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard; meta = "aux")
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard)
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard; meta = "aux")
 
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         RenewableDispatch;
         meta = "ub",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "lb",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
@@ -167,48 +167,48 @@ end
     ####### Check initialization problem constraints #####
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "lb",
     )
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "ub",
     )
     check_initialization_constraint_count(
         model,
-        CommitmentConstraint(),
+        CommitmentConstraint,
         ThermalStandard,
     )
     check_initialization_constraint_count(
         model,
-        CommitmentConstraint(),
+        CommitmentConstraint,
         ThermalStandard;
         meta = "aux",
     )
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         RenewableDispatch;
         meta = "ub",
     )
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "lb",
     )
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
     check_initialization_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
@@ -235,51 +235,51 @@ end
     check_status_initial_conditions_values(model, ThermalStandard)
 
     ####### Check variables
-    check_variable_count(model, PowerAboveMinimumVariable(), ThermalStandard)
-    check_variable_count(model, OnVariable(), ThermalStandard)
-    check_variable_count(model, StopVariable(), ThermalStandard)
-    check_variable_count(model, StartVariable(), ThermalStandard)
-    check_variable_count(model, ActivePowerVariable(), RenewableDispatch)
-    check_variable_count(model, ActivePowerVariable(), HydroDispatch)
+    check_variable_count(model, PowerAboveMinimumVariable, ThermalStandard)
+    check_variable_count(model, OnVariable, ThermalStandard)
+    check_variable_count(model, StopVariable, ThermalStandard)
+    check_variable_count(model, StartVariable, ThermalStandard)
+    check_variable_count(model, ActivePowerVariable, RenewableDispatch)
+    check_variable_count(model, ActivePowerVariable, HydroDispatch)
 
     ####### Check constraints
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "lb",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         ThermalStandard;
         meta = "ub",
     )
-    check_constraint_count(model, RampConstraint(), ThermalStandard)
-    check_constraint_count(model, DurationConstraint(), ThermalStandard)
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard)
-    check_constraint_count(model, CommitmentConstraint(), ThermalStandard; meta = "aux")
+    check_constraint_count(model, RampConstraint, ThermalStandard)
+    check_constraint_count(model, DurationConstraint, ThermalStandard)
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard)
+    check_constraint_count(model, CommitmentConstraint, ThermalStandard; meta = "aux")
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         RenewableDispatch;
         meta = "ub",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableTimeSeriesLimitsConstraint(),
+        ActivePowerVariableTimeSeriesLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "lb",
     )
     check_constraint_count(
         model,
-        ActivePowerVariableLimitsConstraint(),
+        ActivePowerVariableLimitsConstraint,
         HydroDispatch;
         meta = "ub",
     )

--- a/test/test_initialization_problem.jl
+++ b/test/test_initialization_problem.jl
@@ -13,7 +13,7 @@ sys_rts = PSB.build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
         sys_rts;
         optimizer = HiGHS_optimizer,
         initial_time = DateTime("2020-01-01T00:00:00"),
-        horizon = Hour(48),
+        horizon = Hour(4),
     )
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -82,7 +82,7 @@ end
         sys_rts;
         optimizer = HiGHS_optimizer,
         initial_time = DateTime("2020-01-01T00:00:00"),
-        horizon = Hour(48),
+        horizon = Hour(4),
     )
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -159,7 +159,7 @@ end
         sys_rts;
         optimizer = HiGHS_optimizer,
         initial_time = DateTime("2020-01-01T00:00:00"),
-        horizon = Hour(48),
+        horizon = Hour(4),
     )
     POM.instantiate_network_model!(model)
     POM.build_pre_step!(model)

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -627,7 +627,7 @@ end
     # We only test this field because most free solvers don't support detailed stats
     p_variable = IOM.get_variable(
         IOM.get_optimization_container(UC),
-        ActivePowerVariable(),
+        ActivePowerVariable,
         ThermalStandard,
     )
     @test "Alta" ∉ axes(p_variable, 1)

--- a/test/test_network_constructors_with_dlr.jl
+++ b/test/test_network_constructors_with_dlr.jl
@@ -26,7 +26,7 @@ function check_dlr_branch_flows!(
 
         static_rating = PSY.get_rating(branch) * PSY.get_base_power(sys)
         branch_type = typeof(branch)
-        flow_expr = IOM.get_expression(container, PTDFBranchFlow(), branch_type)
+        flow_expr = IOM.get_expression(container, PTDFBranchFlow, branch_type)
         n_dlr = length(dlr_factors)
         for (i, t) in enumerate(axes(flow_expr, 2))
             f = IOM.jump_value(flow_expr[col_key, t])

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -514,7 +514,7 @@ end
 
 function check_constraint_count(
     model,
-    ::POM.RampConstraint,
+    ::Type{POM.RampConstraint},
     ::Type{T},
 ) where {T <: PSY.Component}
     container = IOM.get_optimization_container(model)
@@ -527,14 +527,14 @@ function check_constraint_count(
         )
     check_constraint_count(
         model,
-        POM.RampConstraint(),
+        POM.RampConstraint,
         T;
         meta = "up",
         filter_func = x -> x.name in device_name_set,
     )
     check_constraint_count(
         model,
-        POM.RampConstraint(),
+        POM.RampConstraint,
         T;
         meta = "dn",
         filter_func = x -> x.name in device_name_set,
@@ -544,7 +544,7 @@ end
 
 function check_constraint_count(
     model,
-    ::POM.DurationConstraint,
+    ::Type{POM.DurationConstraint},
     ::Type{T},
 ) where {T <: PSY.Component}
     container = IOM.get_optimization_container(model)
@@ -561,14 +561,14 @@ function check_constraint_count(
     device_name_set = PSY.get_name.(duration_devices)
     check_constraint_count(
         model,
-        POM.DurationConstraint(),
+        POM.DurationConstraint,
         T;
         meta = "up",
         filter_func = x -> x.name in device_name_set,
     )
     return check_constraint_count(
         model,
-        POM.DurationConstraint(),
+        POM.DurationConstraint,
         T;
         meta = "dn",
         filter_func = x -> x.name in device_name_set,

--- a/test/test_utils/model_checks.jl
+++ b/test/test_utils/model_checks.jl
@@ -170,7 +170,7 @@ function check_flow_variable_values(
     limit::Float64,
 ) where {T <: IOM.VariableType, U <: PSY.Component}
     psi_cont = IOM.get_optimization_container(model)
-    variable = IOM.get_variable(psi_cont, T(), U)
+    variable = IOM.get_variable(psi_cont, T, U)
     for var in variable[device_name, :]
         if !(IOM.jump_value(var) <= (limit + 1e-2))
             @error "$device_name out of bounds $(IOM.jump_value(var))"
@@ -194,9 +194,9 @@ function check_flow_variable_values(
     net_formulation = IOM.get_network_formulation(template)
     if dev_formulation <: Union{StaticBranch, StaticBranchUnbounded} &&
        net_formulation <: PTDFPowerModel
-        variable = IOM.get_expression(psi_cont, PTDFBranchFlow(), U)
+        variable = IOM.get_expression(psi_cont, PTDFBranchFlow, U)
     else
-        variable = IOM.get_variable(psi_cont, T(), U)
+        variable = IOM.get_variable(psi_cont, T, U)
     end
     for var in variable[device_name, :]
         if !(IOM.jump_value(var) <= (limit + 1e-2))
@@ -216,7 +216,7 @@ function check_flow_variable_values(
     limit_max::Float64,
 ) where {T <: IOM.VariableType, U <: PSY.Component}
     psi_cont = IOM.get_optimization_container(model)
-    variable = IOM.get_variable(psi_cont, T(), U)
+    variable = IOM.get_variable(psi_cont, T, U)
     for var in variable[device_name, :]
         if !(IOM.jump_value(var) <= (limit_max + 1e-2)) ||
            !(IOM.jump_value(var) >= (limit_min - 1e-2))
@@ -241,9 +241,9 @@ function check_flow_variable_values(
     net_formulation = IOM.get_network_formulation(template)
     if dev_formulation <: Union{StaticBranch, StaticBranchUnbounded} &&
        net_formulation <: PTDFPowerModel
-        variable = IOM.get_expression(psi_cont, PTDFBranchFlow(), U)
+        variable = IOM.get_expression(psi_cont, PTDFBranchFlow, U)
     else
-        variable = IOM.get_variable(psi_cont, T(), U)
+        variable = IOM.get_variable(psi_cont, T, U)
     end
     for var in variable[device_name, :]
         if !(IOM.jump_value(var) <= (limit_max + 1e-2)) ||
@@ -265,8 +265,8 @@ function check_flow_variable_values(
 ) where {T <: IOM.VariableType, U <: IOM.VariableType, V <: PSY.Component}
     psi_cont = IOM.get_optimization_container(model)
     time_steps = IOM.get_time_steps(psi_cont)
-    pvariable = IOM.get_variable(psi_cont, T(), V)
-    qvariable = IOM.get_variable(psi_cont, U(), V)
+    pvariable = IOM.get_variable(psi_cont, T, V)
+    qvariable = IOM.get_variable(psi_cont, U, V)
     for t in time_steps
         fp = IOM.jump_value(pvariable[device_name, t])
         fq = IOM.jump_value(qvariable[device_name, t])
@@ -288,8 +288,8 @@ function check_flow_variable_values(
 ) where {T <: IOM.VariableType, U <: IOM.VariableType, V <: PSY.Component}
     psi_cont = IOM.get_optimization_container(model)
     time_steps = IOM.get_time_steps(psi_cont)
-    pvariable = IOM.get_variable(psi_cont, T(), V)
-    qvariable = IOM.get_variable(psi_cont, U(), V)
+    pvariable = IOM.get_variable(psi_cont, T, V)
+    qvariable = IOM.get_variable(psi_cont, U, V)
     for t in time_steps
         fp = IOM.jump_value(pvariable[device_name, t])
         fq = IOM.jump_value(qvariable[device_name, t])
@@ -475,18 +475,18 @@ end
 
 function check_variable_count(
     model,
-    ::S,
+    ::Type{S},
     ::Type{T},
 ) where {S <: IOM.VariableType, T <: PSY.Component}
     no_component = length(PSY.get_components(PSY.get_available, T, model.sys))
     time_steps = IOM.get_time_steps(IOM.get_optimization_container(model))[end]
-    variable = IOM.get_variable(IOM.get_optimization_container(model), S(), T)
+    variable = IOM.get_variable(IOM.get_optimization_container(model), S, T)
     @test length(variable) == no_component * time_steps
 end
 
 function check_initialization_constraint_count(
     model,
-    ::S,
+    ::Type{S},
     ::Type{T};
     filter_func = PSY.get_available,
     meta = IOM.CONTAINER_KEY_EMPTY_META,
@@ -495,20 +495,20 @@ function check_initialization_constraint_count(
         get_initial_conditions_model_container(IOM.get_internal(model))
     no_component = length(PSY.get_components(filter_func, T, model.sys))
     time_steps = IOM.get_time_steps(container)[end]
-    constraint = IOM.get_constraint(container, S(), T, meta)
+    constraint = IOM.get_constraint(container, S, T, meta)
     @test length(constraint) == no_component * time_steps
 end
 
 function check_constraint_count(
     model,
-    ::S,
+    ::Type{S},
     ::Type{T};
     filter_func = PSY.get_available,
     meta = IOM.CONTAINER_KEY_EMPTY_META,
 ) where {S <: IOM.ConstraintType, T <: PSY.Component}
     no_component = length(PSY.get_components(filter_func, T, model.sys))
     time_steps = IOM.get_time_steps(IOM.get_optimization_container(model))[end]
-    constraint = IOM.get_constraint(IOM.get_optimization_container(model), S(), T, meta)
+    constraint = IOM.get_constraint(IOM.get_optimization_container(model), S, T, meta)
     @test length(constraint) == no_component * time_steps
 end
 


### PR DESCRIPTION
> IOM PR 71 changed interface functions from instance dispatch (::T) to type dispatch (::Type{T}) for VariableType, ConstraintType, ExpressionType, ParameterType, and formulation subtypes. This commit updates POM accordingly:
> 
> - Convert ~800+ call sites from SomeKey() to SomeKey for get_variable, get_expression, get_parameter, add_*_container!, lazy_container_addition!
> - Convert all get_variable_binary/upper_bound/lower_bound/warm_start_value definitions to use ::Type{X} for variable and formulation args
> - Convert objective function interfaces (proportional_cost, objective_function_multiplier, variable_cost, start_up_cost, etc.)
> - Fix POM-local add_variables! overrides to extract formulation type via ::F where F pattern
> - Add device type annotations to get_min_max_limits to resolve ambiguities with IOM default
> - Update test helpers and test call sites

All except for ~10 tests are passing, with IOM on `main` (last commit: PR 71 merge),  PSY on `jd/mbc_iec_refactor` (last commit: `18198590c0`), IS on `jd/namedtuple_time_series` (last commit: `9731128b0f9`).

I'll look at those last dozen tests, fix the merge conflicts, and reconcile with further upstream changes (e.g. compatibility with IS's `IS4` and PSY's `psy6`) tomorrow. Note to self: there's also a handful of runtime calls to fix, `typeof(x)`.