### PR TITLE
Fix a scoping issue in _get_irreducible_buses_due_to_dlrs

### DIFF
--- a/src/network_models/instantiate_network_model.jl
+++ b/src/network_models/instantiate_network_model.jl
@@ -75,7 +75,7 @@ function _get_irreducible_buses_due_to_dlrs(
     irreducible_buses = Set{Int64}()
     for branch_type in network_model.modeled_branch_types
         branch_type <: PSY.ACTransmission || continue
-        device_model = branch_models[Symbol(branch_type)]
+        device_model = branch_models[nameof(branch_type)]
         if !haskey(
             get_time_series_names(device_model),
             DynamicBranchRatingTimeSeriesParameter,


### PR DESCRIPTION
This threw me for a loop. I'm using 
```Julia
import Dates
import HiGHS
import PowerOperationsModels as POM
import PowerSystems as PSY
sys = PSY.System(joinpath(@__DIR__, "performance", "CATS_Sienna.json"))
PSY.transform_single_time_series!(sys, Dates.Hour(1), Dates.Hour(1))
template = POM.OperationsProblemTemplate(
    POM.NetworkModel(
        POM.PTDFPowerModel;
        use_slacks = true,
        duals = [POM.CopperPlateBalanceConstraint],
    ),
);
POM.set_device_model!(template, PSY.ThermalStandard, POM.ThermalBasicUnitCommitment)
POM.set_device_model!(template, PSY.RenewableDispatch, POM.RenewableFullDispatch)
POM.set_device_model!(template, PSY.HydroDispatch, POM.HydroDispatchRunOfRiver)
POM.set_device_model!(template, PSY.PowerLoad, POM.StaticPowerLoad)
POM.set_device_model!(template, PSY.Line, POM.StaticBranch)
POM.set_device_model!(template, PSY.Transformer2W, POM.StaticBranch)
model = POM.DecisionModel(
    template,
    sys;
    name = "CATS_UC2",
    optimizer = HiGHS.Optimizer,
);
POM.build!(model; output_dir = mktempdir(; cleanup = true))
```
as a script. And I had it working. Then restarted Julia and had a cryptic error message about a missing symbol `"PowerSystems.Line"`.

The issue is that in the guts of `set_device_model!` we call `nameof(D)` to set the key:

https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl/blob/9ccee6240f9b07ee16bf5a23b144e2a9e4fc4459/src/core/device_model.jl#L112-L116

but in POM we use `Symbol(D)`. These differ depending on whether `D` is in the current scope:
```julia
julia> import PowerSystems as PSY

julia> nameof(PSY.Line)
:Line

julia> Symbol(PSY.Line)
Symbol("PowerSystems.Line")

julia> using PowerSystems

julia> Symbol(PSY.Line)
:Line

julia> Symbol(PSY.Line)
:Line
```

I must have had `using PowerSystems` in the first REPL and not the second.