### PR TITLE
Fix stray `end` breaking parse of hybrid_systems.jl

### DIFF
--- a/src/hybrid_system_models/hybrid_systems.jl
+++ b/src/hybrid_system_models/hybrid_systems.jl
@@ -1616,7 +1616,6 @@ function _emit_coverage_constraint!(
             )
         end
     end
-    end
     return
 end
 


### PR DESCRIPTION
`src/hybrid_system_models/hybrid_systems.jl` currently fails to parse on `main`, breaking precompilation of `PowerOperationsModels`.

The ReserveUp `_emit_coverage_constraint!` method has an extra `end`: the `if/else` already closes (line 1618) and the function closes (line 1621), leaving a stray `end` at line 1619.

```
        end      # closes `for`
    end          # closes `if/else`
    end          # ← stray, breaks parse
    return
end              # closes function
```

Introduced by the hybrid systems port (#104, merged via #105). Removing the stray `end` makes the file parse and the package precompile again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)