### PR TITLE
Fix show(::DecisionModel) by extending IOM._show_method instead of shadowing it

### DIFF
--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -89,6 +89,9 @@ const IOM = InfrastructureOptimizationModels
 import InfrastructureOptimizationModels:
     should_write_resulting_value,
     convert_output_to_natural_units,
+    # Printing dispatch shared with IOM (POM adds the template method in utils/print.jl);
+    # without this import POM would shadow IOM._show_method and break show(::DecisionModel).
+    _show_method,
     # Network model compatibility checks (extended in core/network_formulations.jl)
     requires_all_branch_models,
     supports_branch_filtering,

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -783,3 +783,22 @@ end
     @test solve!(model; export_optimization_problem = false) ==
           IOM.RunStatus.SUCCESSFULLY_FINALIZED
 end
+
+@testset "show(::DecisionModel) renders the template" begin
+    # Regression test: show(::AbstractOptimizationModel) delegates to
+    # _show_method(io, model.template, ...). The template method lives in POM
+    # (utils/print.jl) and must extend IOM._show_method, not shadow it - otherwise
+    # printing any DecisionModel throws MethodError. See the `_show_method` import
+    # in src/PowerOperationsModels.jl.
+    c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
+    template = get_thermal_standard_uc_template()
+    model = DecisionModel(template, c_sys5; optimizer = HiGHS_optimizer)
+
+    out_plain = sprint(show, MIME("text/plain"), model)
+    @test occursin("Network Model", out_plain)
+    @test occursin("Device Models", out_plain)
+
+    # The text/html show path delegates the same way; exercise it too.
+    out_html = sprint(show, MIME("text/html"), model)
+    @test occursin("Network Model", out_html)
+end


### PR DESCRIPTION
## Problem

Printing any `DecisionModel` throws:

```
MethodError: no method matching _show_method(::IO, ::PowerOperationsProblemTemplate, ::Symbol)
```

## Root cause

The print path for a `DecisionModel` is:

1. `show(io, MIME"text/plain", ::DecisionModel)` resolves to the `AbstractOptimizationModel` method in IOM (`utils/print_pt_v3.jl`).
2. That calls `_show_method(io, model, :auto)`, which delegates to `_show_method(io, model.template, backend)`.
3. `model.template` is a `PowerOperationsProblemTemplate`, whose `_show_method` lives here in `src/utils/print.jl`.

The bug: POM never imported `_show_method` from IOM. So when `print.jl` writes `function _show_method(...)`, Julia created a brand-new `PowerOperationsModels._show_method` separate from `InfrastructureOptimizationModels._show_method`. The template method was attached to POM's copy, but IOM's delegation calls IOM's copy — which has no method for `PowerOperationsProblemTemplate` → `MethodError`.

`show` on a bare template worked on its own only because POM's own `show` methods run in the POM module and resolve to the POM-local function. That asymmetry hid the bug until something printed a full model.

## Fix

Add `_show_method` to the existing `import InfrastructureOptimizationModels:` block so POM's definition **extends** the shared function instead of shadowing it — the same pattern POM already uses for every other IOM function it specializes. One line; no change needed in `print.jl` itself.

## Test

Adds a regression testset in `test/test_model_decision.jl` that constructs a `DecisionModel` and asserts `show` renders the template for both the `text/plain` and `text/html` paths. This class of bug (cross-package function shadowing) is invisible until something prints, so the test guards both paths against future regressions.

## Verification

- Reproduced the `MethodError` against the delegation in IOM (identical in registered IOM 0.1.0 and the dev branch).
- Verified the fix end-to-end against the live dev stack (psy6 / IS4 / dev IOM + this branch): `show(model)` now renders the Network Model and Device Models tables correctly.
- Note: the new regression testset was not run in POM's standalone test environment locally because that env pins git-rev sibling sources (psy6 / IS4 / ac-ordc) whose resolution conflicts with the registered PowerSystems in my local registry — a pre-existing env-resolution issue unrelated to this change. CI exercises the test.