### PR TITLE
Use FunctionData get_domain sugar (closes #33)

### DIFF
--- a/src/common_models/market_bid_plumbing.jl
+++ b/src/common_models/market_bid_plumbing.jl
@@ -234,7 +234,7 @@ function _validate_occ_subtype(
         ),
     )
     fd = IS.get_function_data(IS.get_value_curve(curve))
-    if !iszero(first(IS.get_x_coords(fd)))
+    if !iszero(first(IS.get_domain(fd)))
         throw(
             ArgumentError(
                 "For ImportExportCost, the first breakpoint must be zero.",

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -192,7 +192,7 @@ end
 function _onvar_cost(container::OptimizationContainer, cost_function::Union{PSY.FuelCurve{PSY.LinearCurve}, PSY.FuelCurve{PSY.QuadraticCurve}}, d::T, t::Int) where {T <: PSY.ThermalGen}
     value_curve = PSY.get_value_curve(cost_function)
     cost_component = PSY.get_function_data(value_curve)
-    # In Unit/h
+    # Cost at zero output (y-intercept), in Unit/h.
     constant_term = PSY.get_constant_term(cost_component)
     fuel_cost = PSY.get_fuel_cost(cost_function)
     if typeof(fuel_cost) <: Float64


### PR DESCRIPTION
Closes #33.

Adopts the `FunctionData` sugar from [InfrastructureSystems PR #492](https://github.com/Sienna-Platform/InfrastructureSystems.jl/pull/492):

- `_validate_occ_subtype` (ImportExportCost validation) now uses `IS.get_domain` instead of `first(IS.get_x_coords(...))`.
- Clarifies the `_onvar_cost` comment (the constant term is the cost at zero output, i.e. the y-intercept).

### Scope note

The realistic surface for this sugar is narrow. Most `get_proportional_term` / `get_constant_term` / `get_quadratic_term` calls can't use the new helpers because they either (a) build JuMP expressions over **variables** — the evaluation functor only accepts numbers — or (b) do **unit-aware per-axis scaling**, where `c*fd` (which scales y uniformly) doesn't apply since x and y convert by different ratios. The `get_domain` substitutions here are the clean, behavior-preserving wins.

We considered replacing the two `_onvar_cost` "cost at zero output" reads with the evaluation functor `cost_component(0.0)`, but kept `get_constant_term` for efficiency and consistency (it's a plain field read; the functor would compute `a·0² + b·0 + c`).

Linked with InfrastructureOptimizationModels PR #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)