### PR TITLE
Reparent network formulation hierarchy onto IOM.AbstractNetworkModel

### DIFF
--- a/src/PowerModels/PowerModels.jl
+++ b/src/PowerModels/PowerModels.jl
@@ -3,15 +3,18 @@ module PowerModels
 import ..InfrastructureModels as _IM
 import ..InfrastructureModels: @im_fields, nw_id_default
 import InfrastructureSystems
+import InfrastructureOptimizationModels
 import JuMP
 import LinearAlgebra
 import Logging
 import SparseArrays
 
-# Shared types — const aliases so PM.Foo === IS.Optimization.Foo
-const AbstractPowerModel = InfrastructureSystems.Optimization.AbstractPowerModel
-const AbstractActivePowerModel = InfrastructureSystems.Optimization.AbstractActivePowerModel
-const AbstractACPModel = InfrastructureSystems.Optimization.AbstractACPModel
+# Formulation-marker hierarchy, rooted on IOM's neutral network-model anchor rather than
+# IS.Optimization.AbstractPowerModel (no longer the NetworkModel{T} bound — see IOM ADR
+# 0001, "IOM network vocabulary neutralization").
+abstract type AbstractPowerModel <: InfrastructureOptimizationModels.AbstractNetworkModel end
+abstract type AbstractActivePowerModel <: AbstractPowerModel end
+abstract type AbstractACPModel <: AbstractPowerModel end
 
 const _pm_global_keys = Set(["time_series", "per_unit"])
 const pm_it_name = "pm"

--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -34,6 +34,7 @@ const PM = PowerModels
 
 # Import PM types into module namespace for re-export
 using .PowerModels:
+    AbstractPowerModel,
     AbstractDCPModel,
     AbstractACPModel,
     AbstractActivePowerModel,
@@ -67,7 +68,9 @@ import InfrastructureSystems.Optimization:
 
 # Import formulation abstract types from InfrastructureSystems.Optimization
 # Note: AbstractPTDFModel is defined in this package (network_formulations.jl)
-# as a subtype of AbstractDCPModel.
+# as a subtype of AbstractDCPModel. AbstractPowerModel itself is imported from the
+# embedded PowerModels submodule above, rooted on IOM.AbstractNetworkModel rather than
+# IS.Optimization.AbstractPowerModel (see IOM ADR 0001).
 import InfrastructureSystems.Optimization:
     AbstractDeviceFormulation,
     AbstractThermalFormulation,
@@ -75,7 +78,6 @@ import InfrastructureSystems.Optimization:
     AbstractRenewableFormulation,
     AbstractServiceFormulation,
     AbstractReservesFormulation,
-    AbstractPowerModel,
     AbstractHVDCNetworkModel
 
 #################################################################################

--- a/src/ac_transmission_models/AC_branches.jl
+++ b/src/ac_transmission_models/AC_branches.jl
@@ -1049,7 +1049,7 @@ function add_expressions!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {B <: PSY.ACTransmission}
     time_steps = get_time_steps(container)
-    ptdf = get_PTDF_matrix(network_model)
+    ptdf = get_network_matrix(network_model)
     net_reduction_data = network_model.network_reduction
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
     # `collect` to a Vector so the spawn loop below can index it for multi-threading.
@@ -1161,7 +1161,7 @@ function add_constraints!(
     model::DeviceModel{T, PhaseAngleControl},
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.PhaseShiftingTransformer}
-    ptdf = get_PTDF_matrix(network_model)
+    ptdf = get_network_matrix(network_model)
     branches = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
     branch_flow = add_constraints_container!(container, NetworkFlowConstraint,

--- a/src/ac_transmission_models/security_constrained_branch.jl
+++ b/src/ac_transmission_models/security_constrained_branch.jl
@@ -593,7 +593,7 @@ function add_post_contingency_flow_expressions!(
     N <: AbstractPTDFModel,
 }
     time_steps = get_time_steps(container)
-    modf_matrix = get_MODF_matrix(network_model)
+    modf_matrix = get_contingency_matrix(network_model)
     registered_contingencies = PNM.get_registered_contingencies(modf_matrix)
 
     net_reduction_data = network_model.network_reduction

--- a/src/initial_conditions/initialization.jl
+++ b/src/initial_conditions/initialization.jl
@@ -8,12 +8,12 @@ function get_initial_conditions_template(
     network_model = NetworkModel(
         get_network_formulation(model.template);
         use_slacks = get_use_slacks(get_network_model(model.template)),
-        PTDF_matrix = get_PTDF_matrix(get_network_model(model.template)),
+        network_matrix = get_network_matrix(get_network_model(model.template)),
         # Carry the MODF matrix forward so security-constrained branch models
         # (which read the registered contingencies off the network model's MODF)
         # can build inside the initial-conditions sub-model. Without this the IC
         # build hits `get_registered_contingencies(nothing)`.
-        MODF_matrix = get_MODF_matrix(get_network_model(model.template)),
+        contingency_matrix = get_contingency_matrix(get_network_model(model.template)),
         reduce_radial_branches = get_reduce_radial_branches(
             get_network_model(model.template),
         ),

--- a/src/initial_conditions/initialization.jl
+++ b/src/initial_conditions/initialization.jl
@@ -9,10 +9,10 @@ function get_initial_conditions_template(
         get_network_formulation(model.template);
         use_slacks = get_use_slacks(get_network_model(model.template)),
         network_matrix = get_network_matrix(get_network_model(model.template)),
-        # Carry the MODF matrix forward so security-constrained branch models
-        # (which read the registered contingencies off the network model's MODF)
-        # can build inside the initial-conditions sub-model. Without this the IC
-        # build hits `get_registered_contingencies(nothing)`.
+        # Carry the contingency matrix forward so security-constrained branch models
+        # (which read the registered contingencies off the network model's
+        # contingency matrix) can build inside the initial-conditions sub-model.
+        # Without this the IC build hits `get_registered_contingencies(nothing)`.
         contingency_matrix = get_contingency_matrix(get_network_model(model.template)),
         reduce_radial_branches = get_reduce_radial_branches(
             get_network_model(model.template),

--- a/src/network_models/instantiate_network_model.jl
+++ b/src/network_models/instantiate_network_model.jl
@@ -450,8 +450,8 @@ function IOM.instantiate_network_model!(
         branch_models,
     )
     _validate_network_and_branches(model, branch_models, sys)
-    if IOM.get_PTDF_matrix(model) === nothing || !isempty(irreducible_buses)
-        if IOM.get_PTDF_matrix(model) !== nothing
+    if IOM.get_network_matrix(model) === nothing || !isempty(irreducible_buses)
+        if IOM.get_network_matrix(model) !== nothing
             @warn "Provided PTDF Matrix is being ignored since irreducible buses were identified because of DLRs. Recalculating PTDF Matrix with PowerNetworkMatrices.PTDF and the identified irreducible buses."
         else
             @info "No PTDF Matrix provided. Calculating using PowerNetworkMatrices.PTDF"
@@ -498,14 +498,14 @@ function IOM.instantiate_network_model!(
                 irreducible_buses = irreducible_buses,
             )
         end
-        model.PTDF_matrix = ptdf
+        model.network_matrix = ptdf
         model.network_reduction = deepcopy(ptdf.network_reduction_data)
     else
-        model.network_reduction = deepcopy(model.PTDF_matrix.network_reduction_data)
+        model.network_reduction = deepcopy(model.network_matrix.network_reduction_data)
     end
 
     if !model.reduce_radial_branches && PNM.has_radial_reduction(
-        PNM.get_reductions(model.PTDF_matrix.network_reduction_data),
+        PNM.get_reductions(model.network_matrix.network_reduction_data),
     )
         throw(
             IS.ConflictingInputsError(
@@ -515,7 +515,7 @@ function IOM.instantiate_network_model!(
         )
     end
     if !model.reduce_degree_two_branches && PNM.has_degree_two_reduction(
-        PNM.get_reductions(model.PTDF_matrix.network_reduction_data),
+        PNM.get_reductions(model.network_matrix.network_reduction_data),
     )
         throw(
             IS.ConflictingInputsError(
@@ -525,7 +525,9 @@ function IOM.instantiate_network_model!(
         )
     end
     if model.reduce_radial_branches &&
-       PNM.has_ward_reduction(PNM.get_reductions(model.PTDF_matrix.network_reduction_data))
+       PNM.has_ward_reduction(
+        PNM.get_reductions(model.network_matrix.network_reduction_data),
+    )
         throw(
             IS.ConflictingInputsError(
                 "The provided PTDF Matrix has  a ward reduction specified and the keyword argument \
@@ -535,9 +537,9 @@ function IOM.instantiate_network_model!(
     end
 
     if model.reduce_radial_branches
-        @assert !isempty(model.PTDF_matrix.network_reduction_data)
+        @assert !isempty(model.network_matrix.network_reduction_data)
     end
-    model.subnetworks = _make_subnetworks_from_subnetwork_axes(model.PTDF_matrix)
+    model.subnetworks = _make_subnetworks_from_subnetwork_axes(model.network_matrix)
     if length(model.subnetworks) > 1
         @debug "System Contains Multiple Subnetworks. Assigning buses to subnetworks."
         _assign_subnetworks_to_buses(model, sys)
@@ -592,8 +594,8 @@ function _reconcile_ptdf_modf_reduction!(
     model::NetworkModel{<:AbstractPTDFModel},
     sys::PSY.System,
 )
-    ptdf_nrd = PNM.get_network_reduction_data(model.PTDF_matrix)
-    modf_nrd = PNM.get_network_reduction_data(IOM.get_MODF_matrix(model))
+    ptdf_nrd = PNM.get_network_reduction_data(model.network_matrix)
+    modf_nrd = PNM.get_network_reduction_data(IOM.get_contingency_matrix(model))
     retained_ptdf = _retained_buses(ptdf_nrd)
     retained_modf = _retained_buses(modf_nrd)
     retained_ptdf == retained_modf && return false
@@ -605,21 +607,21 @@ function _reconcile_ptdf_modf_reduction!(
            post-contingency dimensions agree."
     cohesive = collect(union(retained_ptdf, retained_modf))
     reductions = _model_network_reductions(model)
-    model.PTDF_matrix = PNM.VirtualPTDF(
+    model.network_matrix = PNM.VirtualPTDF(
         sys;
         tol = PTDF_ZERO_TOL,
         network_reductions = reductions,
         irreducible_buses = cohesive,
     )
-    model.MODF_matrix = PNM.VirtualMODF(
+    model.contingency_matrix = PNM.VirtualMODF(
         sys;
         tol = PTDF_ZERO_TOL,
         network_reductions = reductions,
         irreducible_buses = cohesive,
     )
 
-    if _retained_buses(PNM.get_network_reduction_data(model.PTDF_matrix)) !=
-       _retained_buses(PNM.get_network_reduction_data(IOM.get_MODF_matrix(model)))
+    if _retained_buses(PNM.get_network_reduction_data(model.network_matrix)) !=
+       _retained_buses(PNM.get_network_reduction_data(IOM.get_contingency_matrix(model)))
         throw(
             IS.ConflictingInputsError(
                 "PTDF and MODF reductions remain dimensionally inconsistent \
@@ -643,7 +645,7 @@ function _maybe_build_modf_matrix!(
     irreducible_buses::Vector{Int64},
 )
     IOM._template_has_outage_aware_branch(branch_models) || return
-    if IOM.get_MODF_matrix(model) === nothing
+    if IOM.get_contingency_matrix(model) === nothing
         @info "MODF Matrix not provided. Calculating using PowerNetworkMatrices.VirtualMODF"
         reductions = PNM.NetworkReduction[]
         if model.reduce_radial_branches
@@ -652,7 +654,7 @@ function _maybe_build_modf_matrix!(
         if model.reduce_degree_two_branches
             push!(reductions, PNM.DegreeTwoReduction())
         end
-        model.MODF_matrix = PNM.VirtualMODF(
+        model.contingency_matrix = PNM.VirtualMODF(
             sys;
             tol = PTDF_ZERO_TOL,
             network_reductions = reductions,
@@ -664,15 +666,15 @@ function _maybe_build_modf_matrix!(
     # and subnetworks from the rebuilt PTDF so all downstream axes agree.
     if _reconcile_ptdf_modf_reduction!(model, sys)
         model.network_reduction =
-            deepcopy(PNM.get_network_reduction_data(model.PTDF_matrix))
-        model.subnetworks = _make_subnetworks_from_subnetwork_axes(model.PTDF_matrix)
+            deepcopy(PNM.get_network_reduction_data(model.network_matrix))
+        model.subnetworks = _make_subnetworks_from_subnetwork_axes(model.network_matrix)
         if length(model.subnetworks) > 1
             _assign_subnetworks_to_buses(model, sys)
         end
     end
     _consolidate_device_model_outages_with_modf!(
         branch_models,
-        IOM.get_MODF_matrix(model),
+        IOM.get_contingency_matrix(model),
     )
     return
 end

--- a/src/twoterminal_hvdc_models/AC_branches.jl
+++ b/src/twoterminal_hvdc_models/AC_branches.jl
@@ -704,7 +704,7 @@ function add_expressions!(
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {B <: PSY.ACTransmission}
     time_steps = get_time_steps(container)
-    ptdf = get_PTDF_matrix(network_model)
+    ptdf = get_network_matrix(network_model)
     net_reduction_data = network_model.network_reduction
     # This might need to be changed to something else
     branch_names = get_branch_argument_variable_axis(net_reduction_data, devices)
@@ -828,7 +828,7 @@ function add_constraints!(
     model::DeviceModel{T, PhaseAngleControl},
     network_model::NetworkModel{<:AbstractPTDFModel},
 ) where {T <: PSY.PhaseShiftingTransformer}
-    ptdf = get_PTDF_matrix(network_model)
+    ptdf = get_network_matrix(network_model)
     branches = PSY.get_name.(devices)
     time_steps = get_time_steps(container)
     branch_flow = add_constraints_container!(container, NetworkFlowConstraint,

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -16,7 +16,7 @@ function _show_method(
     table = [
         "Network Model" string(get_network_formulation(network_model))
         "Slacks" get_use_slacks(network_model)
-        "PTDF" !isnothing(get_PTDF_matrix(network_model))
+        "PTDF" !isnothing(get_network_matrix(network_model))
         "Duals" isempty(get_duals(network_model)) ? "None" : string.(get_duals(network_model))
         "HVDC Network Model" isnothing(get_hvdc_network_model(network_model)) ? "None" : replace(string(get_hvdc_network_model(network_model)), r"[()]" => "")
     ]

--- a/test/test_ac_transmission_security_constrained_models.jl
+++ b/test/test_ac_transmission_security_constrained_models.jl
@@ -43,7 +43,7 @@ end
     template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PNM.VirtualPTDF(c_sys5),
+            network_matrix = PNM.VirtualPTDF(c_sys5),
         ),
     )
     set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -56,7 +56,7 @@ end
 
     container = IOM.get_optimization_container(ps_model)
     network_model = IOM.get_network_model(IOM.get_template(ps_model))
-    @test IOM.get_MODF_matrix(network_model) isa PNM.VirtualMODF
+    @test IOM.get_contingency_matrix(network_model) isa PNM.VirtualMODF
 
     # Fresh VirtualMODF for the ground-truth column (independent solver pool so
     # a build-time race cannot pass the test by being read identically). The
@@ -150,7 +150,7 @@ end
 # MOI-count / objective-value magic numbers, which differ under POM/PS6.
 
 @testset "Security Constrained branch formulation Network DC-PF with VirtualPTDF + auto-MODF" begin
-    # Exercises the VirtualPTDF + auto-constructed MODF code path: MODF_matrix
+    # Exercises the VirtualPTDF + auto-constructed MODF code path: contingency_matrix
     # is intentionally omitted so it must be auto-built during instantiate.
     c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
     all_branches = collect(get_components(PSY.ACTransmission, c_sys5))
@@ -166,8 +166,8 @@ end
     template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PNM.VirtualPTDF(c_sys5),
-            # MODF_matrix intentionally omitted — exercises auto-construction
+            network_matrix = PNM.VirtualPTDF(c_sys5),
+            # contingency_matrix intentionally omitted — exercises auto-construction
         ),
     )
     set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -180,7 +180,7 @@ end
 
     # MODF should have been auto-populated during build
     nm = IOM.get_network_model(IOM.get_template(ps_model))
-    @test !isnothing(IOM.get_MODF_matrix(nm))
+    @test !isnothing(IOM.get_contingency_matrix(nm))
 
     constraint_keys = [
         IOM.ConstraintKey(POM.PostContingencyFlowRateConstraint, PSY.Line, "lb"),
@@ -195,7 +195,7 @@ end
     c_sys14 = PSB.build_system(PSB.PSITestSystems, "c_sys14")
 
     template = get_thermal_dispatch_template_network(
-        NetworkModel(PTDFPowerModel; PTDF_matrix = PNM.VirtualPTDF(c_sys14)),
+        NetworkModel(PTDFPowerModel; network_matrix = PNM.VirtualPTDF(c_sys14)),
     )
     set_device_model!(template, PSY.Line, POM.StaticBranch)
     set_device_model!(template, PSY.Transformer2W, POM.StaticBranch)
@@ -207,7 +207,7 @@ end
 
     container = IOM.get_optimization_container(ps_model)
     network_model = IOM.get_network_model(IOM.get_template(ps_model))
-    @test IOM.get_PTDF_matrix(network_model) isa PNM.VirtualPTDF
+    @test IOM.get_network_matrix(network_model) isa PNM.VirtualPTDF
 
     ground_truth_ptdf = PNM.VirtualPTDF(c_sys14)
 
@@ -283,8 +283,8 @@ end
     template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PNM.VirtualPTDF(c_sys14),
-            MODF_matrix = PNM.VirtualMODF(c_sys14),
+            network_matrix = PNM.VirtualPTDF(c_sys14),
+            contingency_matrix = PNM.VirtualMODF(c_sys14),
         ),
     )
     set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -297,7 +297,7 @@ end
 
     container = IOM.get_optimization_container(ps_model)
     network_model = IOM.get_network_model(IOM.get_template(ps_model))
-    @test IOM.get_MODF_matrix(network_model) isa PNM.VirtualMODF
+    @test IOM.get_contingency_matrix(network_model) isa PNM.VirtualMODF
 
     ground_truth_modf = PNM.VirtualMODF(c_sys14)
     ground_truth_registered = PNM.get_registered_contingencies(ground_truth_modf)
@@ -370,8 +370,8 @@ end
     auto_template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PNM.PTDF(c_sys5),
-            MODF_matrix = PNM.VirtualMODF(c_sys5),
+            network_matrix = PNM.PTDF(c_sys5),
+            contingency_matrix = PNM.VirtualMODF(c_sys5),
         ),
     )
     set_device_model!(auto_template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -436,7 +436,7 @@ end
     outage_uuid_str = string(outage_uuid)
 
     template = get_thermal_dispatch_template_network(
-        NetworkModel(PTDFPowerModel; MODF_matrix = PNM.VirtualMODF(sys)),
+        NetworkModel(PTDFPowerModel; contingency_matrix = PNM.VirtualMODF(sys)),
     )
     set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
     set_device_model!(template, PSY.Transformer2W, POM.SecurityConstrainedStaticBranch)
@@ -516,7 +516,7 @@ end
     outage_uuid = string(IS.get_uuid(outage))
 
     template = get_thermal_dispatch_template_network(
-        NetworkModel(PTDFPowerModel; MODF_matrix = PNM.VirtualMODF(sys)),
+        NetworkModel(PTDFPowerModel; contingency_matrix = PNM.VirtualMODF(sys)),
     )
     set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
     ps_model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
@@ -591,7 +591,7 @@ end
     ]
         @testset "$label" begin
             template = get_thermal_dispatch_template_network(
-                NetworkModel(NetFormulation; MODF_matrix = PNM.VirtualMODF(sys)),
+                NetworkModel(NetFormulation; contingency_matrix = PNM.VirtualMODF(sys)),
             )
             set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
             set_device_model!(
@@ -674,8 +674,8 @@ end
         template = get_thermal_dispatch_template_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = PNM.PTDF(sys),
-                MODF_matrix = PNM.VirtualMODF(sys),
+                network_matrix = PNM.PTDF(sys),
+                contingency_matrix = PNM.VirtualMODF(sys),
             ),
         )
         set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -745,8 +745,8 @@ end
         template = get_thermal_dispatch_template_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = PNM.PTDF(sys),
-                MODF_matrix = PNM.VirtualMODF(sys),
+                network_matrix = PNM.PTDF(sys),
+                contingency_matrix = PNM.VirtualMODF(sys),
             ),
         )
         set_device_model!(template, PSY.Line, POM.SecurityConstrainedStaticBranch)
@@ -817,8 +817,8 @@ end
         template = get_thermal_dispatch_template_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = ptdf,
-                MODF_matrix = modf,
+                network_matrix = ptdf,
+                contingency_matrix = modf,
                 reduce_degree_two_branches = PNM.has_degree_two_reduction(
                     ptdf.network_reduction_data,
                 ),
@@ -930,8 +930,8 @@ end
         template = get_thermal_dispatch_template_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = ptdf,
-                MODF_matrix = modf,
+                network_matrix = ptdf,
+                contingency_matrix = modf,
                 reduce_degree_two_branches = PNM.has_degree_two_reduction(
                     ptdf.network_reduction_data,
                 ),
@@ -1048,7 +1048,7 @@ end
     # HiGHS returns the dual values directly.
     c_sys5 = _attach_all_branch_outages!(PSB.build_system(PSITestSystems, "c_sys5"))
     template = get_thermal_dispatch_template_network(
-        NetworkModel(PTDFPowerModel; PTDF_matrix = PNM.PTDF(c_sys5)),
+        NetworkModel(PTDFPowerModel; network_matrix = PNM.PTDF(c_sys5)),
     )
     set_device_model!(
         template,
@@ -1076,7 +1076,7 @@ end
     c_sys5 = _attach_all_branch_outages!(PSB.build_system(PSITestSystems, "c_sys5"))
     template =
         PowerOperationsProblemTemplate(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PNM.PTDF(c_sys5)),
+            NetworkModel(PTDFPowerModel; network_matrix = PNM.PTDF(c_sys5)),
         )
     set_device_model!(template, PSY.PowerLoad, StaticPowerLoad)
     set_device_model!(template, PSY.ThermalStandard, ThermalStandardUnitCommitment)
@@ -1133,8 +1133,8 @@ _sc_retained_buses(nrd) = Set(keys(PNM.get_bus_reduction_map(nrd)))
     template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = ptdf,
-            MODF_matrix = modf,
+            network_matrix = ptdf,
+            contingency_matrix = modf,
             reduce_radial_branches = true,
             reduce_degree_two_branches = true,
         ),
@@ -1147,10 +1147,10 @@ _sc_retained_buses(nrd) = Set(keys(PNM.get_bus_reduction_map(nrd)))
 
     nm = IOM.get_network_model(IOM.get_template(model))
     ptdf_retained = _sc_retained_buses(
-        PNM.get_network_reduction_data(IOM.get_PTDF_matrix(nm)),
+        PNM.get_network_reduction_data(IOM.get_network_matrix(nm)),
     )
     modf_retained = _sc_retained_buses(
-        PNM.get_network_reduction_data(IOM.get_MODF_matrix(nm)),
+        PNM.get_network_reduction_data(IOM.get_contingency_matrix(nm)),
     )
     @test ptdf_retained == modf_retained
     @test _sc_retained_buses(IOM.get_network_reduction(nm)) == modf_retained
@@ -1172,7 +1172,7 @@ end
 
     function _build_sc_slack_model(use_slacks)
         template = get_thermal_dispatch_template_network(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PNM.PTDF(c_sys5)),
+            NetworkModel(PTDFPowerModel; network_matrix = PNM.PTDF(c_sys5)),
         )
         set_device_model!(
             template,
@@ -1301,7 +1301,7 @@ end
 
     function _build_sc(use_slacks)
         template = get_thermal_dispatch_template_network(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PNM.PTDF(c_sys5)),
+            NetworkModel(PTDFPowerModel; network_matrix = PNM.PTDF(c_sys5)),
         )
         set_device_model!(
             template,
@@ -1406,8 +1406,8 @@ end
     template = get_thermal_dispatch_template_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PNM.VirtualPTDF(c_sys14),
-            MODF_matrix = PNM.VirtualMODF(c_sys14),
+            network_matrix = PNM.VirtualPTDF(c_sys14),
+            contingency_matrix = PNM.VirtualMODF(c_sys14),
         ),
     )
     set_device_model!(

--- a/test/test_device_branch_constructors.jl
+++ b/test/test_device_branch_constructors.jl
@@ -7,7 +7,7 @@ const DC_NETWORK_MODELS_FOR_TESTING = [PTDFPowerModel]
     limits = PSY.get_flow_limits(PSY.get_component(MonitoredLine, system, "1"), PSY.SU)
     for model in DC_NETWORK_MODELS_FOR_TESTING
         template = get_thermal_dispatch_template_network(
-            NetworkModel(model; PTDF_matrix = PTDF(system)),
+            NetworkModel(model; network_matrix = PTDF(system)),
         )
         model_m = DecisionModel(template, system; optimizer = HiGHS_optimizer)
         @test build!(model_m; output_dir = mktempdir(; cleanup = true)) ==
@@ -53,7 +53,7 @@ end
     set_rating!(PSY.get_component(Line, system, "2"), 1.5 * PSY.SU)
     for model in DC_NETWORK_MODELS_FOR_TESTING
         template = get_thermal_dispatch_template_network(
-            NetworkModel(model; PTDF_matrix = PTDF(system)),
+            NetworkModel(model; network_matrix = PTDF(system)),
         )
         set_device_model!(template, DeviceModel(Line, StaticBranch))
         set_device_model!(template, DeviceModel(MonitoredLine, StaticBranchUnbounded))
@@ -183,7 +183,7 @@ end
 
     for model in DC_NETWORK_MODELS_FOR_TESTING
         template = get_template_dispatch_with_network(
-            NetworkModel(model; PTDF_matrix = PTDF(system)),
+            NetworkModel(model; network_matrix = PTDF(system)),
         )
         set_device_model!(
             template,
@@ -556,7 +556,7 @@ end
     remove_component!(system, line)
 
     template = get_template_dispatch_with_network(
-        NetworkModel(PTDFPowerModel; PTDF_matrix = PTDF(system)),
+        NetworkModel(PTDFPowerModel; network_matrix = PTDF(system)),
     )
     set_device_model!(template, DeviceModel(PhaseShiftingTransformer, PhaseAngleControl))
     model_m = DecisionModel(template, system; optimizer = HiGHS_optimizer)
@@ -867,7 +867,7 @@ end
     # Test with DC Power Flow Model
     for net_model in DC_NETWORK_MODELS_FOR_TESTING
         template = get_template_dispatch_with_network(
-            NetworkModel(net_model; PTDF_matrix = PTDF(system)),
+            NetworkModel(net_model; network_matrix = PTDF(system)),
         )
         # Set device model for Transformer3W
         set_device_model!(template, DeviceModel(Transformer3W, StaticBranch))
@@ -916,7 +916,7 @@ _bus_merged_away(nrd, b) = any(b in s for s in values(PNM.get_bus_reduction_map(
         ml = PSY.get_component(MonitoredLine, sys, "1")
         PSY.set_r!(ml, 0.0 * PSY.SU)
         PSY.set_x!(ml, 1e-5 * PSY.SU)
-        # No `PTDF_matrix` provided, so a VirtualPTDF is built and the reduction runs.
+        # No `network_matrix` provided, so a VirtualPTDF is built and the reduction runs.
         template = get_thermal_dispatch_template_network(NetworkModel(PTDFPowerModel))
         set_device_model!(
             template,
@@ -944,7 +944,7 @@ _bus_merged_away(nrd, b) = any(b in s for s in values(PNM.get_bus_reduction_map(
     from_bus = PSY.get_number(PSY.get_from(arc))
     to_bus = PSY.get_number(PSY.get_to(arc))
     nm = IOM.get_network_model(IOM.get_template(model))
-    nrd = IOM.get_PTDF_matrix(nm).network_reduction_data
+    nrd = IOM.get_network_matrix(nm).network_reduction_data
     @test !_bus_merged_away(nrd, from_bus)
     @test !_bus_merged_away(nrd, to_bus)
     @test haskey(IOM.get_branch_models(IOM.get_template(model)), :MonitoredLine)
@@ -956,7 +956,7 @@ _bus_merged_away(nrd, b) = any(b in s for s in values(PNM.get_bus_reduction_map(
     model_default, ml_default, status_default = _build_zib_monitored_line(false)
     @test status_default == IOM.ModelBuildStatus.BUILT
     nm_d = IOM.get_network_model(IOM.get_template(model_default))
-    nrd_d = IOM.get_PTDF_matrix(nm_d).network_reduction_data
+    nrd_d = IOM.get_network_matrix(nm_d).network_reduction_data
     @test _bus_merged_away(nrd_d, PSY.get_number(PSY.get_to(PSY.get_arc(ml_default))))
     @test !haskey(IOM.get_branch_models(IOM.get_template(model_default)), :MonitoredLine)
     container_default = IOM.get_optimization_container(model_default)

--- a/test/test_device_hvdc.jl
+++ b/test/test_device_hvdc.jl
@@ -3,7 +3,7 @@
     template_uc = PowerOperationsProblemTemplate(NetworkModel(
         DCPPowerModel,
         #use_slacks=true,
-        #PTDF_matrix=PTDF(sys_5),
+        #network_matrix =PTDF(sys_5),
         #duals=[CopperPlateBalanceConstraint],
     ))
 
@@ -23,7 +23,7 @@
         NetworkModel(
             PTDFPowerModel;
             #use_slacks=true,
-            PTDF_matrix = PTDF(sys_5),
+            network_matrix = PTDF(sys_5),
             #duals=[CopperPlateBalanceConstraint],
         ),
     )

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -205,7 +205,7 @@ end
     networks = [PTDFPowerModel, DCPPowerModel, ACPPowerModel]
     for network in networks
         template = get_thermal_dispatch_template_network(
-            NetworkModel(network; use_slacks = true, PTDF_matrix = PTDF(c_sys5_re)),
+            NetworkModel(network; use_slacks = true, network_matrix = PTDF(c_sys5_re)),
         )
         model = DecisionModel(template, c_sys5_re; optimizer = ipopt_optimizer)
         @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
@@ -223,7 +223,7 @@ end
     LMPs = []
     for (ix, network) in enumerate(networks)
         template = get_template_dispatch_with_network(
-            NetworkModel(network; PTDF_matrix = ptdf, duals = dual_constraint[ix]),
+            NetworkModel(network; network_matrix = ptdf, duals = dual_constraint[ix]),
         )
         if network == PTDFPowerModel
             set_device_model!(

--- a/test/test_network_constructors.jl
+++ b/test/test_network_constructors.jl
@@ -30,7 +30,7 @@ end
 
     template = PowerOperationsProblemTemplate(
         NetworkModel(PTDFPowerModel;
-            PTDF_matrix = ptdf,
+            network_matrix = ptdf,
             duals = [CopperPlateBalanceConstraint],
             reduce_radial_branches = PNM.has_radial_reduction(ptdf.network_reduction_data),
             reduce_degree_two_branches = PNM.has_degree_two_reduction(

--- a/test/test_network_constructors_with_branch_rating_time_series.jl
+++ b/test/test_network_constructors_with_branch_rating_time_series.jl
@@ -102,7 +102,7 @@ end
         template = get_thermal_dispatch_template_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = PTDF_ref[sys],
+                network_matrix = PTDF_ref[sys],
             ),
         )
 
@@ -192,7 +192,7 @@ end
             template = get_thermal_dispatch_template_network(
                 NetworkModel(
                     PTDFPowerModel;
-                    PTDF_matrix = PTDF(sys),
+                    network_matrix = PTDF(sys),
                 ),
             )
             set_device_model!(template, line_device_model)
@@ -279,7 +279,7 @@ end
             template = get_thermal_dispatch_template_network(
                 NetworkModel(
                     PTDFPowerModel;
-                    PTDF_matrix = PTDF(sys),
+                    network_matrix = PTDF(sys),
                 ),
             )
             set_device_model!(template, line_device_model)
@@ -365,7 +365,7 @@ end
             template = get_thermal_dispatch_template_network(
                 NetworkModel(
                     PTDFPowerModel;
-                    PTDF_matrix = PTDF(sys),
+                    network_matrix = PTDF(sys),
                 ),
             )
             set_device_model!(template, line_device_model)
@@ -458,7 +458,7 @@ end
             template = get_thermal_dispatch_template_network(
                 NetworkModel(
                     PTDFPowerModel;
-                    #PTDF_matrix = ptdf,
+                    #network_matrix = ptdf,
                     reduce_degree_two_branches = PNM.has_degree_two_reduction(
                         ptdf.network_reduction_data,
                     ),

--- a/test/test_parallel_branch_parameter_multipliers.jl
+++ b/test/test_parallel_branch_parameter_multipliers.jl
@@ -31,7 +31,7 @@
         )
 
         template = get_thermal_dispatch_template_network(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PTDF(sys)),
+            NetworkModel(PTDFPowerModel; network_matrix = PTDF(sys)),
         )
         set_device_model!(template, line_device_model)
         ps_model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
@@ -87,7 +87,7 @@ end
         )
 
         template = get_thermal_dispatch_template_network(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PTDF(sys)),
+            NetworkModel(PTDFPowerModel; network_matrix = PTDF(sys)),
         )
         set_device_model!(template, line_device_model)
         ps_model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
@@ -129,7 +129,7 @@ end
             Dict{String, Any}(POM.PARALLEL_BRANCH_MAX_RATING_KEY => method)
         end
         template = get_thermal_dispatch_template_network(
-            NetworkModel(PTDFPowerModel; PTDF_matrix = PTDF(sys)),
+            NetworkModel(PTDFPowerModel; network_matrix = PTDF(sys)),
         )
         set_device_model!(template, DeviceModel(Line, StaticBranch; attributes = attrs))
         ps_model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)

--- a/test/test_postcontingency_mixed_outage_axes.jl
+++ b/test/test_postcontingency_mixed_outage_axes.jl
@@ -55,7 +55,7 @@
             NetworkModel(
                 PTDFPowerModel;
                 use_slacks = false,
-                MODF_matrix = PNM.VirtualMODF(sys),
+                contingency_matrix = PNM.VirtualMODF(sys),
             ),
         )
         set_device_model!(

--- a/test/test_power_flow_in_the_loop.jl
+++ b/test/test_power_flow_in_the_loop.jl
@@ -4,7 +4,7 @@
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             evaluations = power_flow_evaluations(
                 ACPowerFlow(;
                     distribute_slack_proportional_to_headroom = true,
@@ -87,7 +87,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             use_slacks = true,
             evaluations = power_flow_evaluations(
                 ACPowerFlow(;
@@ -133,7 +133,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             use_slacks = true,
             evaluations = power_flow_evaluations(
                 ACPowerFlow(;
@@ -221,7 +221,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             evaluations = power_flow_evaluations(ACPowerFlow()),
         ),
     )
@@ -285,7 +285,7 @@ end
         template = get_template_dispatch_with_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = PTDF(system),
+                network_matrix = PTDF(system),
                 evaluations = power_flow_evaluations(ACPowerFlow()),
             ),
         )
@@ -340,7 +340,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             evaluations = power_flow_evaluations(ACPowerFlow()),
         ),
     )
@@ -378,7 +378,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             evaluations = power_flow_evaluations(ACPowerFlow()),
         ),
     )
@@ -409,7 +409,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             evaluations = power_flow_evaluations(ACPowerFlow()),
         ),
     )
@@ -448,7 +448,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             use_slacks = true,
             evaluations = power_flow_evaluations(DCPowerFlow()),
         ),
@@ -484,7 +484,7 @@ end
     template = get_template_dispatch_with_network(
         NetworkModel(
             PTDFPowerModel;
-            PTDF_matrix = PTDF(system),
+            network_matrix = PTDF(system),
             use_slacks = true,
             evaluations = power_flow_evaluations(ACPowerFlow()),
         ),
@@ -704,7 +704,7 @@ end
         template = get_template_dispatch_with_network(
             NetworkModel(
                 PTDFPowerModel;
-                PTDF_matrix = PTDF(system),
+                network_matrix = PTDF(system),
                 evaluations = power_flow_evaluations(pf_eval),
             ),
         )


### PR DESCRIPTION
## Summary
- Fixes the CI precompile failure on `main` ([run](https://github.com/Sienna-Platform/PowerOperationsModels.jl/actions/runs/28660839260/job/86156308775)): `TypeError: in NetworkModel, in T, expected T<:InfrastructureOptimizationModels.AbstractNetworkModel, got Type{PowerOperationsModels.AreaPTDFPowerModel}`.
- Root cause: IOM's `main` branch landed [ADR 0001 "IOM network vocabulary neutralization"](https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl/blob/main/docs/adr/0001-iom-network-vocabulary-neutralization.md), moving `NetworkModel{T}`'s bound off `IS.Optimization.AbstractPowerModel` onto a new IOM-owned `AbstractNetworkModel`, and renaming the `NetworkModel` matrix fields/getters `PTDF_matrix`/`MODF_matrix` → `network_matrix`/`contingency_matrix`. POM (pinned to IOM `main` per `[sources]`) hadn't been updated to match.
- Reparents the embedded PowerModels submodule's `AbstractPowerModel`/`AbstractActivePowerModel`/`AbstractACPModel` hierarchy (and transitively every concrete network formulation: `DCPPowerModel`, `ACPPowerModel`, `PTDFPowerModel`, `AreaPTDFPowerModel`, `CopperPlatePowerModel`, `AreaBalancePowerModel`, …) onto `IOM.AbstractNetworkModel` instead of `IS.Optimization.AbstractPowerModel`.
- Renames `PTDF_matrix`/`MODF_matrix` (kwargs, field accesses, getters) to `network_matrix`/`contingency_matrix` throughout `src/`, `ext/`, and `test/` to match IOM's renamed `NetworkModel` API.

## Test plan
- [x] `julia --project=test -e 'using PowerOperationsModels'` precompiles cleanly (previously failed with the `TypeError` above).
- [x] `julia --project=test -e 'using PowerFlows; using PowerOperationsModels'` — `PowerFlowsExt` also precompiles cleanly (it hit the same error in CI).
- [x] Formatter run (no diffs).
- [x] `julia --project=test test/runtests.jl test_network_constructors test_device_hvdc test_parallel_branch_parameter_multipliers` — 4237/4237 pass on this branch.
- [x] Also validated a superset of network-model-touching test files (`test_static_injection_security_constrained_models`, `test_device_branch_constructors`, `test_ac_transmission_security_constrained_models`, `test_network_constructors_with_branch_rating_time_series`, `test_postcontingency_mixed_outage_axes`, `test_model_decision`) on a working branch with the same fix — all pass, aside from one pre-existing, unrelated `HydroReservoir`/`LinearCurve→FunctionData` failure in `test_model_decision.jl` that's also present in the `main` CI run and stems from `PowerSystems`/`PowerSystemCaseBuilder` test-data generation, not this change.

Note: the `PowerSystemCaseBuilder` `CaseData` artifact-download failure visible in the linked CI run (404 / hash mismatch) is a separate, transient CI-infra issue unrelated to this fix — the artifact is already cached locally and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)