### PR TITLE
Fix 1D container creation ahead of IOM issue #15 assertion

### DIFF
--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -1308,12 +1308,13 @@ function add_constraints!(
         add_constraints_container!(container, StateofChargeTargetConstraint,
             V,
             device_names,
+            [time_steps[end]],
         )
 
     for d in devices
         name = PSY.get_name(d)
         target = PSY.get_storage_target(d)
-        constraint_container[name] = JuMP.@constraint(
+        constraint_container[name, time_steps[end]] = JuMP.@constraint(
             get_jump_model(container),
             energy_var[name, time_steps[end]] - surplus_var[name, time_steps[end]] +
             shortfall_var[name, time_steps[end]] == target
@@ -1338,7 +1339,8 @@ function add_cycling_charge_without_reserves!(
     powerin_var = get_variable(container, ActivePowerInVariable, V)
     slack_var = get_variable(container, StorageChargeCyclingSlackVariable, V)
 
-    constraint = add_constraints_container!(container, StorageCyclingCharge, V, names)
+    constraint = add_constraints_container!(
+        container, StorageCyclingCharge, V, names, [time_steps[end]])
 
     for d in devices
         name = PSY.get_name(d)
@@ -1378,7 +1380,8 @@ function add_cycling_charge_with_reserves!(
         V,
     )
 
-    constraint = add_constraints_container!(container, StorageCyclingCharge, V, names)
+    constraint = add_constraints_container!(
+        container, StorageCyclingCharge, V, names, [time_steps[end]])
 
     for d in devices
         name = PSY.get_name(d)
@@ -1431,7 +1434,8 @@ function add_cycling_discharge_without_reserves!(
     slack_var = get_variable(container, StorageDischargeCyclingSlackVariable, V)
 
     constraint =
-        add_constraints_container!(container, StorageCyclingDischarge, V, names)
+        add_constraints_container!(
+            container, StorageCyclingDischarge, V, names, [time_steps[end]])
 
     for d in devices
         name = PSY.get_name(d)
@@ -1472,7 +1476,8 @@ function add_cycling_discharge_with_reserves!(
     )
 
     constraint =
-        add_constraints_container!(container, StorageCyclingDischarge, V, names)
+        add_constraints_container!(
+            container, StorageCyclingDischarge, V, names, [time_steps[end]])
 
     for d in devices
         name = PSY.get_name(d)

--- a/src/services_models/agc.jl
+++ b/src/services_models/agc.jl
@@ -68,9 +68,10 @@ function add_agc_variables!(
     ::Type{T},
 ) where {T <: SteadyStateFrequencyDeviation}
     time_steps = get_time_steps(container)
-    variable = add_variable_container!(container, T, PSY.AGC, time_steps)
+    variable = add_variable_container!(container, T, PSY.AGC, ["System"], time_steps)
     for t in time_steps
-        variable[t] = JuMP.@variable(container.JuMPmodel, base_name = "ΔF_{$(t)}")
+        variable["System", t] =
+            JuMP.@variable(container.JuMPmodel, base_name = "ΔF_{$(t)}")
     end
 end
 
@@ -152,7 +153,8 @@ function add_constraints!(
     R_dn_emergency =
         get_variable(container, AdditionalDeltaActivePowerUpVariable, PSY.Area)
 
-    const_container = add_constraints_container!(container, T, PSY.System, time_steps)
+    const_container =
+        add_constraints_container!(container, T, PSY.System, ["System"], time_steps)
 
     for t in time_steps
         system_balance = sum(area_balance.data[:, t])
@@ -164,9 +166,9 @@ function add_constraints!(
             JuMP.add_to_expression!(system_balance, R_up_emergency[area_name, t])
             JuMP.add_to_expression!(system_balance, -1.0, R_dn_emergency[area_name, t])
         end
-        const_container[t] = JuMP.@constraint(
+        const_container["System", t] = JuMP.@constraint(
             container.JuMPmodel,
-            frequency[t] == -inv_frequency_response * system_balance
+            frequency["System", t] == -inv_frequency_response * system_balance
         )
     end
     return

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -1275,7 +1275,8 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
+        add_constraints_container!(
+            container, EnergyBudgetConstraint, V, set_name, ["horizon"])
 
     variable_out = get_variable(container, ActivePowerVariable, V)
     param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
@@ -1284,7 +1285,7 @@ function add_constraints!(
     for d in devices
         name = PSY.get_name(d)
         param = get_parameter_column_values(param_container, name)
-        constraint[name] = JuMP.@constraint(
+        constraint[name, "horizon"] = JuMP.@constraint(
             container.JuMPmodel,
             sum([variable_out[name, t] for t in time_steps]) <=
             sum([multiplier[name, t] * param[t] for t in time_steps])
@@ -1307,7 +1308,8 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
+        add_constraints_container!(
+            container, EnergyBudgetConstraint, V, set_name, ["horizon"])
     variable_out = get_variable(container, ActivePowerVariable, V)
     param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
     multiplier = get_multiplier_array(param_container)
@@ -1320,7 +1322,7 @@ function add_constraints!(
             slack_var = 0.0
         end
         param = get_parameter_column_values(param_container, name)
-        constraint[name] = JuMP.@constraint(
+        constraint[name, "horizon"] = JuMP.@constraint(
             container.JuMPmodel,
             sum([variable_out[name, t] for t in time_steps]) <=
             sum([multiplier[name, t] * param[t] for t in time_steps]) + slack_var
@@ -1330,7 +1332,8 @@ function add_constraints!(
     if !isnothing(hydro_budget_interval)
         constraint_aux = add_constraints_container!(container, EnergyBudgetConstraint,
             V,
-            set_name;
+            set_name,
+            ["horizon"];
             meta = "interval",
         )
         resolution = get_resolution(container)
@@ -1340,7 +1343,7 @@ function add_constraints!(
         for d in devices
             name = PSY.get_name(d)
             param = get_parameter_column_values(param_container, name)
-            constraint_aux[name] = JuMP.@constraint(
+            constraint_aux[name, "horizon"] = JuMP.@constraint(
                 container.JuMPmodel,
                 sum([variable_out[name, t] for t in 1:interval_length]) <=
                 sum([multiplier[name, t] * param[t] for t in 1:interval_length])
@@ -1370,7 +1373,8 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, EnergyBudgetConstraint, V, set_name)
+        add_constraints_container!(
+            container, EnergyBudgetConstraint, V, set_name, ["horizon"])
 
     total_power_out = get_expression(container, TotalHydroPowerReservoirOutgoing, V)
     param_container = get_parameter(container, EnergyBudgetTimeSeriesParameter, V)
@@ -1385,7 +1389,7 @@ function add_constraints!(
             slack_var = 0.0
         end
         param = get_parameter_column_values(param_container, name)
-        constraint[name] = JuMP.@constraint(
+        constraint[name, "horizon"] = JuMP.@constraint(
             container.JuMPmodel,
             sum([total_power_out[name, t] for t in time_steps]) <=
             sum([multiplier[name, t] * param[t] for t in time_steps]) + slack_var
@@ -1414,7 +1418,8 @@ function add_constraints!(
     time_steps = get_time_steps(container)
     set_name = [PSY.get_name(d) for d in devices]
     constraint =
-        add_constraints_container!(container, WaterBudgetConstraint, V, set_name)
+        add_constraints_container!(
+            container, WaterBudgetConstraint, V, set_name, ["horizon"])
 
     total_flow_out = get_expression(container, TotalHydroFlowRateReservoirOutgoing, V)
     param_container = get_parameter(container, WaterBudgetTimeSeriesParameter, V)
@@ -1423,7 +1428,7 @@ function add_constraints!(
     for d in devices
         name = PSY.get_name(d)
         param = get_parameter_column_values(param_container, name)
-        constraint[name] = JuMP.@constraint(
+        constraint[name, "horizon"] = JuMP.@constraint(
             container.JuMPmodel,
             sum([total_flow_out[name, t] for t in time_steps]) <=
             sum([multiplier[name, t] * param[t] for t in time_steps])
@@ -1615,6 +1620,7 @@ function add_constraints!(
         add_constraints_container!(container, ReservoirLevelTargetConstraint,
             V,
             names,
+            [time_steps[end]],
         )
 
     for d in devices
@@ -1627,7 +1633,7 @@ function add_constraints!(
             var = get_variable(container, HydroReservoirHeadVariable, V)
         end
 
-        constraint[name] = JuMP.@constraint(
+        constraint[name, time_steps[end]] = JuMP.@constraint(
             container.JuMPmodel,
             var[name, time_steps[end]] >= level_targets
         )
@@ -1655,6 +1661,7 @@ function add_constraints!(
         add_constraints_container!(container, ReservoirLevelTargetConstraint,
             V,
             names,
+            [time_steps[end]],
         )
 
     for d in devices
@@ -1674,7 +1681,7 @@ function add_constraints!(
                 get_variable(container, HydroReservoirVolumeVariable, V) / h2v_factor
         end
 
-        constraint[name] = JuMP.@constraint(
+        constraint[name, time_steps[end]] = JuMP.@constraint(
             container.JuMPmodel,
             level_targets <= var[name, time_steps[end]] <=
             PSY.get_storage_level_limits(d).max

--- a/src/static_injector_models/source.jl
+++ b/src/static_injector_models/source.jl
@@ -113,12 +113,14 @@ function add_constraints!(
     constraint_export =
         add_constraints_container!(container, ImportExportBudgetConstraint,
             U,
-            names;
+            names,
+            ["horizon"];
             meta = "export",
         )
     constraint_import = add_constraints_container!(container, ImportExportBudgetConstraint,
         U,
-        names;
+        names,
+        ["horizon"];
         meta = "import",
     )
 
@@ -127,12 +129,12 @@ function add_constraints!(
         op_cost = PSY.get_operation_cost(d)
         week_import_limit = PSY.get_energy_import_weekly_limit(op_cost)
         week_export_limit = PSY.get_energy_export_weekly_limit(op_cost)
-        constraint_import[name] = JuMP.@constraint(
+        constraint_import[name, "horizon"] = JuMP.@constraint(
             get_jump_model(container),
             resolution_in_hours * sum(p_out[name, t] for t in time_steps) <=
             week_import_limit * (hours_in_horizon / HOURS_IN_WEEK)
         )
-        constraint_export[name] = JuMP.@constraint(
+        constraint_export[name, "horizon"] = JuMP.@constraint(
             get_jump_model(container),
             resolution_in_hours * sum(p_in[name, t] for t in time_steps) <=
             week_export_limit * (hours_in_horizon / HOURS_IN_WEEK)

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -721,6 +721,7 @@ function add_constraints!(
         con = add_constraints_container!(container, ActiveRangeICConstraint,
             T,
             device_name_set,
+            [1],
         )
 
         for (ix, ic) in enumerate(ini_conds[:, 1])
@@ -729,7 +730,7 @@ function add_constraints!(
             limits = PSY.get_active_power_limits(device, PSY.SU)
             lag_ramp_limits = PSY.get_power_trajectory(device, PSY.SU)
             val = max(limits.max - lag_ramp_limits.shutdown, 0)
-            con[name] = JuMP.@constraint(
+            con[name, 1] = JuMP.@constraint(
                 get_jump_model(container),
                 val * varstop[name, 1] <=
                 ini_conds[ix, 2].value * (limits.max - limits.min) - get_value(ic)


### PR DESCRIPTION
## Summary
IOM is adding a runtime assertion (Sienna-Platform/InfrastructureOptimizationModels.jl#137, tracking Sienna-Platform/InfrastructureOptimizationModels.jl#15) that rejects any variable/constraint/expression/dual/parameter container built with only one index axis — containers must always be indexable as `x[i, j]`. This proactively fixes every call site in POM that currently builds such a 1D container, so nothing breaks once that assertion lands.

Three patterns, fixed consistently:
- **End-of-horizon / initial-condition snapshots** (`thermal_generation.jl` `ActiveRangeICConstraint`, `hydro_generation.jl` `ReservoirLevelTargetConstraint`, `storage_models.jl` `StateofChargeTargetConstraint`): built with just a `names` axis but indexed with an extra time key downstream. Added the matching singleton time axis (`[time_steps[end]]` / `[1]`).
- **Whole-horizon budget constraints** (`hydro_generation.jl` `EnergyBudgetConstraint`/`WaterBudgetConstraint`, `source.jl` `ImportExportBudgetConstraint`): aggregate over the entire horizon with no time axis by design. Added a `["horizon"]` singleton axis, consistent across all budget sites.
- **Genuinely system-wide scalars** (`agc.jl` `SteadyStateFrequencyDeviation` variable + `FrequencyResponseConstraint`): added a `["System"]` singleton axis.

Also fixes 4 latent bugs in `storage_models.jl` (`StorageCyclingCharge`/`StorageCyclingDischarge`, marked `# no test coverage`) that built a 1D container but were already being indexed with 2 keys (`constraint[name, time_steps[end]]`) downstream — that would already error today against a 1D `DenseAxisArray`.

## Test plan
- [x] All 5 changed files parse cleanly (`Meta.parseall`)
- [x] Formatter clean
- [ ] Full test suite — **could not run**: `main` currently fails to precompile (`TypeError` in `NetworkModel`/`AbstractNetworkModel`, `common_models/add_expressions.jl:10`), a pre-existing, unrelated breakage someone else is already fixing. Confirmed by reproducing the identical failure with these changes fully reverted. Recommend re-running CI on this branch once that's resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)