### PR TITLE
Fix thermal min-up/down rounding and improve parallel-branch interface error messages

### DIFF
--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -2331,7 +2331,8 @@ function _reduced_entry_in_interface(
     ]
 
     if !allequal(in_interface)
-        throw(ArgumentError(_error_msg(T)))
+        branch_names = [PSY.get_name(x) for x in reduction_entry]
+        throw(ArgumentError(_error_msg(T) * " Offending branches: $(branch_names)."))
     end
     return first(in_interface)
 end


### PR DESCRIPTION
Two small fixes ported from PSI:

- **Thermal min-up/down rounding** — drop the stray `Float64` positional argument in `round(..., RoundUp)` in `_get_data_for_tdc` (`thermal_generation.jl`), which is incompatible with the `RoundingMode` argument.
- **Parallel-branch interface error message** — when a transmission interface names only part of a reduced double-circuit / degree-two chain, list the offending branch names in the `ArgumentError` (re-ported onto `main`'s `_error_msg(T)` helper).

### Ported from PSI
- Sienna-Platform/PowerSimulations.jl#1527 (thermal rounding)
- Sienna-Platform/PowerSimulations.jl#1587 (parallel-branch error message)

The HVDC area-balance fix (#1519) originally bundled with this work is already present on `main`, so it is not included here.

---
Part of splitting the former #154 into focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)