### PR TITLE
Add FixedOutput formulation for Source devices

### DIFF
--- a/src/core/parameters.jl
+++ b/src/core/parameters.jl
@@ -256,6 +256,8 @@ convert_output_to_natural_units(
     ::Type{PostContingencyBranchRatingTimeSeriesParameter},
 ) = true
 convert_output_to_natural_units(::Type{ActivePowerTimeSeriesParameter}) = true
+convert_output_to_natural_units(::Type{ActivePowerOutTimeSeriesParameter}) = true
+convert_output_to_natural_units(::Type{ActivePowerInTimeSeriesParameter}) = true
 convert_output_to_natural_units(::Type{ReactivePowerTimeSeriesParameter}) = true
 convert_output_to_natural_units(::Type{RequirementTimeSeriesParameter}) = true
 convert_output_to_natural_units(::Type{UpperBoundValueParameter}) = true

--- a/src/static_injector_models/source.jl
+++ b/src/static_injector_models/source.jl
@@ -22,6 +22,9 @@ get_variable_upper_bound(::Type{ReactivePowerVariable}, d::PSY.Source, ::Type{<:
 get_multiplier_value(::Type{ActivePowerTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
 get_multiplier_value(::Type{ActivePowerOutTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
 get_multiplier_value(::Type{ActivePowerInTimeSeriesParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
+get_multiplier_value(::Type{ActivePowerTimeSeriesParameter}, d::PSY.Source, ::Type{FixedOutput}) = PSY.get_active_power_limits(d, PSY.SU).max
+get_multiplier_value(::Type{ActivePowerOutTimeSeriesParameter}, d::PSY.Source, ::Type{FixedOutput}) = PSY.get_active_power_limits(d, PSY.SU).max
+get_multiplier_value(::Type{ActivePowerInTimeSeriesParameter}, d::PSY.Source, ::Type{FixedOutput}) = PSY.get_active_power_limits(d, PSY.SU).min
 # This additional method definition is used to avoid ambiguity with the method defined in default_interface_methods.jl
 get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, d::PSY.Source, ::Type{<:AbstractSourceFormulation}) = 1.0
 
@@ -33,14 +36,17 @@ get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.Source}, ::Type{Im
 function get_default_time_series_names(
     ::Type{U},
     ::Type{V},
-) where {U <: PSY.Source, V <: AbstractSourceFormulation}
-    return Dict{Any, String}()
+) where {U <: PSY.Source, V <: Union{FixedOutput, AbstractSourceFormulation}}
+    return Dict{Type{<:TimeSeriesParameter}, String}(
+        ActivePowerOutTimeSeriesParameter => "max_active_power_out",
+        ActivePowerInTimeSeriesParameter => "max_active_power_in",
+    )
 end
 
 function get_default_attributes(
     ::Type{U},
     ::Type{V},
-) where {U <: PSY.Source, V <: AbstractSourceFormulation}
+) where {U <: PSY.Source, V <: Union{FixedOutput, AbstractSourceFormulation}}
     return Dict{String, Any}(
         "reservation" => true,
     )

--- a/src/static_injector_models/source_constructor.jl
+++ b/src/static_injector_models/source_constructor.jl
@@ -322,3 +322,57 @@ function construct_device!(
     add_constraint_dual!(container, sys, model)
     return
 end
+
+"""
+This function creates the arguments for the model for a FixedOutput formulation for Source devices
+"""
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ArgumentConstructStage,
+    model::DeviceModel{T, D},
+    network_model::NetworkModel{<:AbstractActivePowerModel},
+) where {
+    T <: PSY.Source,
+    D <: FixedOutput,
+}
+    devices = get_available_components(model, sys)
+    add_parameters!(container, ActivePowerInTimeSeriesParameter, devices, model)
+    add_parameters!(container, ActivePowerOutTimeSeriesParameter, devices, model)
+
+    add_to_expression!(
+        container,
+        ActivePowerBalance,
+        ActivePowerInTimeSeriesParameter,
+        devices,
+        model,
+        network_model,
+    )
+    add_to_expression!(
+        container,
+        ActivePowerBalance,
+        ActivePowerOutTimeSeriesParameter,
+        devices,
+        model,
+        network_model,
+    )
+    add_event_arguments!(container, devices, model, network_model)
+    return
+end
+
+"""
+This function creates the constraints for the model for a FixedOutput formulation for Source devices (no constraints added for FixedOutput)
+"""
+function construct_device!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    model::DeviceModel{T, D},
+    network_model::NetworkModel{<:AbstractActivePowerModel},
+) where {
+    T <: PSY.Source,
+    D <: FixedOutput,
+}
+    # FixedOutput doesn't add any constraints to the model.
+    return
+end

--- a/test/test_device_source_constructors.jl
+++ b/test/test_device_source_constructors.jl
@@ -150,6 +150,88 @@ end
     @test p_in[6] == 0.0
 end
 
+@testset "FixedOutput Source With CopperPlate and TimeSeries" begin
+    # FixedOutput Source adds ActivePowerIn/OutTimeSeriesParameter and no variables
+    # (PSI #1573 ported to POM). The parameter values follow the in/out time series.
+    sys = make_5_bus_with_import_export(; add_single_time_series = true)
+    source = get_component(Source, sys, "source")
+
+    load = first(get_components(PowerLoad, sys))
+    tstamp =
+        TimeSeries.timestamp(
+            get_time_series_array(SingleTimeSeries, load, "max_active_power"),
+        )
+
+    day_data = [
+        0.9, 0.85, 0.95, 0.2, 0.0, 0.0,
+        0.9, 0.85, 0.95, 0.2, 0.0, 0.0,
+        0.9, 0.85, 0.95, 0.2, 0.0, 0.0,
+        0.9, 0.85, 0.95, 0.2, 0.0, 0.0,
+    ]
+    ts_data = repeat(day_data, 2)
+    ts_out = SingleTimeSeries(
+        "max_active_power_out",
+        TimeArray(tstamp, ts_data);
+        scaling_factor_multiplier = get_max_active_power,
+    )
+    ts_in = SingleTimeSeries(
+        "max_active_power_in",
+        TimeArray(tstamp, ts_data);
+        scaling_factor_multiplier = get_max_active_power,
+    )
+    add_time_series!(sys, source, ts_out)
+    add_time_series!(sys, source, ts_in)
+    transform_single_time_series!(sys, Hour(24), Hour(24))
+
+    template = PowerOperationsProblemTemplate(NetworkModel(CopperPlateNetworkModel))
+    set_device_model!(template, ThermalStandard, ThermalStandardUnitCommitment)
+    set_device_model!(template, PowerLoad, StaticPowerLoad)
+    set_device_model!(template, DeviceModel(Line, StaticBranch))
+    set_device_model!(template, DeviceModel(Source, FixedOutput))
+
+    model = DecisionModel(
+        template,
+        sys;
+        name = "UC",
+        optimizer = HiGHS_optimizer,
+        store_variable_names = true,
+        optimizer_solve_log_print = false,
+    )
+
+    @test build!(model; output_dir = mktempdir()) == ModelBuildStatus.BUILT
+    @test solve!(model) == RunStatus.SUCCESSFULLY_FINALIZED
+
+    res = OptimizationProblemOutputs(model)
+    p_out = read_parameter(
+        res,
+        "ActivePowerOutTimeSeriesParameter__Source";
+        table_format = TableFormat.WIDE,
+    )[
+        !,
+        2,
+    ]
+    p_in = read_parameter(
+        res,
+        "ActivePowerInTimeSeriesParameter__Source";
+        table_format = TableFormat.WIDE,
+    )[
+        !,
+        2,
+    ]
+
+    # FixedOutput adds no In/Out variables
+    @test !has_container_key(
+        get_optimization_container(model),
+        ActivePowerOutVariable,
+        Source,
+    )
+    # Parameter is zero where the time series is zero
+    @test p_out[5] == 0.0
+    @test p_in[5] == 0.0
+    @test p_out[6] == 0.0
+    @test p_in[6] == 0.0
+end
+
 @testset "ImportExportSource Source With CopperPlate and TimeSeries" begin
     sys = make_5_bus_with_import_export(; add_single_time_series = true)
     source = get_component(Source, sys, "source")


### PR DESCRIPTION
Adds a `FixedOutput` formulation for `PSY.Source` (previously only `ImportExportSourceModel` existed): both `construct_device!` stages, default time-series names (`max_active_power_out/in`), and the `FixedOutput` multiplier methods. FixedOutput adds parameters and balance expressions but no constraints. `convert_output_to_natural_units` is enabled for the In/Out active-power TS parameters.

### Ported from PSI
- Sienna-Platform/PowerSimulations.jl#1549 (Source default time-series names)
- Sienna-Platform/PowerSimulations.jl#1573 (Source FixedOutput)

New test coverage: `test/test_device_source_constructors.jl`.

---
Part of splitting the former #154 into focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)