### PR TITLE
Support InterconnectingConverter under AreaPTDFNetworkModel

### DIFF
--- a/src/mt_hvdc_models/HVDCsystems.jl
+++ b/src/mt_hvdc_models/HVDCsystems.jl
@@ -319,7 +319,33 @@ function add_to_expression!(
     V <: PSY.InterconnectingConverter,
     W <: AbstractConverterFormulation,
 }
-    error("AreaPTDFNetworkModel doesn't support InterconnectingConverter")
+    variable = get_variable(container, U, V)
+    expression_dc = get_expression(container, T, PSY.DCBus)
+    expression_ac = get_expression(container, T, PSY.ACBus)
+    area_expr = get_expression(container, T, PSY.Area)
+    network_reduction = get_network_reduction(network_model)
+    for d in devices, t in get_time_steps(container)
+        name = PSY.get_name(d)
+        device_bus = PSY.get_bus(d)
+        area_name = PSY.get_name(PSY.get_area(device_bus))
+        bus_number_dc = PSY.get_number(PSY.get_dc_bus(d))
+        bus_number_ac = PNM.get_mapped_bus_number(network_reduction, device_bus)
+        add_proportional_to_jump_expression!(
+            area_expr[area_name, t],
+            variable[name, t],
+            get_variable_multiplier(U, V, W),
+        )
+        add_proportional_to_jump_expression!(
+            expression_ac[bus_number_ac, t],
+            variable[name, t],
+            get_variable_multiplier(U, V, W),
+        )
+        add_proportional_to_jump_expression!(
+            expression_dc[bus_number_dc, t],
+            variable[name, t],
+            -1.0,
+        )
+    end
     return
 end
 

--- a/test/test_network_constructors.jl
+++ b/test/test_network_constructors.jl
@@ -72,3 +72,45 @@ end
         @test "4-5-i_1" in axes(cons)[1]
     end
 end
+
+# Regression test for AreaPTDFNetworkModel + InterconnectingConverter support
+# (Sienna-Platform/PowerSimulations.jl#1605). No PSB system ships with both areas
+# and converters, so the two 5-bus sides of sys10_pjm_ac_dc are split into two
+# areas bridged by the DC links. Before the fix in
+# src/mt_hvdc_models/HVDCsystems.jl the AreaPTDF converter method errored; it now
+# injects each converter into the Area, AC-bus, and DC-bus balance expressions.
+@testset "AreaPTDFNetworkModel with InterconnectingConverter" begin
+    sys = PSB.build_system(PSISystems, "sys10_pjm_ac_dc"; force_build = true)
+    areas = [PSY.Area("Area_1", 0, 0, 0), PSY.Area("Area_2", 0, 0, 0)]
+    for a in areas
+        add_component!(sys, a)
+    end
+    for b in get_components(PSY.ACBus, sys)
+        set_area!(b, PSY.get_number(b) <= 5 ? areas[1] : areas[2])
+    end
+
+    template = get_thermal_dispatch_template_network(NetworkModel(AreaPTDFNetworkModel))
+    set_device_model!(template, RenewableDispatch, RenewableFullDispatch)
+    set_device_model!(template, DeviceModel(InterconnectingConverter, LosslessConverter))
+    set_device_model!(template, DeviceModel(TModelHVDCLine, LosslessLine))
+    set_hvdc_network_model!(template, TransportHVDCNetworkModel)
+
+    ps_model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
+    @test build!(ps_model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(ps_model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    container = IOM.get_optimization_container(ps_model)
+    # The patched AreaPTDF method injects each converter into all three balance
+    # expressions; assert every container it writes into is present and sized.
+    area_expr = IOM.get_expression(container, ActivePowerBalance, PSY.Area)
+    @test axes(area_expr)[1] == ["Area_1", "Area_2"]
+    ac_expr = IOM.get_expression(container, ActivePowerBalance, PSY.ACBus)
+    @test length(axes(ac_expr)[1]) == 10
+    dc_expr = IOM.get_expression(container, ActivePowerBalance, PSY.DCBus)
+    @test length(axes(dc_expr)[1]) == 4
+    conv =
+        IOM.get_variable(container, ActivePowerVariable, PSY.InterconnectingConverter)
+    @test Set(axes(conv)[1]) ==
+          Set(PSY.get_name.(get_components(PSY.InterconnectingConverter, sys)))
+end


### PR DESCRIPTION
## What

Adds support for `PSY.InterconnectingConverter` injections under `AreaPTDFNetworkModel`. Previously this combination hit an `error("AreaPTDFPowerModel doesn't support InterconnectingConverter")`; now the converter contributes to the `Area`, AC-bus, and DC-bus `ActivePowerBalance` expressions.

- `src/mt_hvdc_models/HVDCsystems.jl` — replace the error stub with the balance injection.
- `test/test_network_constructors.jl` — one targeted build/solve test.

## Implementation notes (addressing review)

- **AC bus indexed by mapped bus number.** Under `AreaPTDFNetworkModel` the AC-bus balance expression is keyed by *mapped* bus numbers when network reductions are active (`make_system_expressions!`). The method now uses `PNM.get_mapped_bus_number(network_reduction, device_bus)` instead of the raw number, matching the PSI original and avoiding a `KeyError` under reductions.
- **`get_variable_multiplier` for signed contributions**, matching the pattern used by the other converter `add_to_expression!` methods in this file (the DC side keeps the `-1.0` sink sign, as in PSI).

## Test

No PSB system ships with *both* areas and converters, so the test assigns the two 5-bus sides of `sys10_pjm_ac_dc` to two areas (bridged by the existing DC links) and asserts the `AreaPTDFNetworkModel` case **builds and solves** with the `Area`/AC/DC balance expressions and converter variables populated. (This gap is why PSI #1605 shipped the method without a dedicated test — verified there is none upstream.)

## Ported from PSI

- `Sienna-Platform/PowerSimulations.jl#1605` — AreaPTDF `InterconnectingConverter` injection.

## Split note

The broad PSI baseline network-constructor test port that previously rode along in this branch has been moved to **#187** so this PR stays focused on the #1605 feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)