### PR TITLE
Add PrecompileTools.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -25,10 +26,10 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 PowerFlows = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
 
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-PowerSystems = {rev = "jd/converter-dc-current-base", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
 InfrastructureOptimizationModels = {rev = "main", url = "https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl"}
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
 PowerNetworkMatrices = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl"}
+PowerSystems = {rev = "jd/converter-dc-current-base", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
 
 [extensions]
 PowerFlowsExt = "PowerFlows"
@@ -39,9 +40,10 @@ DocStringExtensions = "~0.8, ~0.9"
 InfrastructureSystems = "3"
 InteractiveUtils = "1.11.0"
 JuMP = "^1.28"
-PowerSystems = "^5.10"
 PowerFlows = "0.21, 0.22"
 PowerNetworkMatrices = "^0.24"
+PowerSystems = "^5.10"
+PrecompileTools = "1"
 PrettyTables = "3"
 ProgressMeter = "1.11.0"
 TimerOutputs = "~0.5"

--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -973,4 +973,6 @@ export PostContingencyBranchRatingTimeSeriesParameter
 # Network model capability traits (IOM default + POM overrides in core/network_formulations.jl)
 export branches_modeled
 
+include("precompile_tools.jl")
+
 end

--- a/src/precompile_tools.jl
+++ b/src/precompile_tools.jl
@@ -1,0 +1,11 @@
+import PrecompileTools
+
+PrecompileTools.@setup_workload begin
+    PrecompileTools.@compile_workload begin
+        template = PowerOperationsProblemTemplate()
+        set_device_model!(template, PSY.ThermalStandard, ThermalDispatchNoMin)
+        set_device_model!(template, PSY.PowerLoad, StaticPowerLoad)
+        set_device_model!(template, DeviceModel(PSY.Line, StaticBranch))
+        set_device_model!(template, PSY.TModelHVDCLine, DCLossyLine)
+    end
+end


### PR DESCRIPTION
Part of https://github.com/Sienna-Platform/PowerOperationsModels.jl/issues/115

This needs some discussing/direction, because we need to decide _what_ to precompile.

Things we can precompile:

 * Anything that uses ONLY stuff inside PowerOperationsModels or its direct dependencies

Things we cannot precompile:

 * Anything that uses a package that is not a direct dependency. This means stuff like `solve!` which require an optimizer.

I think we also need a small-scale system that we can build with some data. What's the best way to do this? Can we include a file that we read in at precompile time?

A downside to the design of a mix of packages is that it's harder to precompile things. It would be trivial if there was a single Sienna.jl where we could build and load an entire test system.

In PowerModels, we do:
```Julia
PrecompileTools.@setup_workload begin
    logger_config!("error")  # Turn off logging for this precompile block
    case3 = joinpath(dirname(@__DIR__), "test/data/matpower/case3.m")
    case9 = joinpath(dirname(@__DIR__), "test/data/matpower/case9.m")
    PrecompileTools.@compile_workload begin
        for case in [case3, case9]
            data = parse_file(case)
            _ = instantiate_model(data, ACPPowerModel, build_opf)
            _ = instantiate_model(data, ACPPowerModel, build_pf)
            _ = instantiate_model(data, DCPPowerModel, build_opf)
            _ = instantiate_model(data, DCPPowerModel, build_pf)
        end
        _ = compute_ac_pf(case9)
        _ = compute_dc_pf(case9)
    end
    logger_config!("info")   # Re-enable default logging
end
```
We chose two small systems, and we choose to precompile only ACP and DCP, for both OPF and PF. This is a win, but it doesn't help the user if they're doing something more exotic.