### PR TITLE
Phase C: merged ORDC cost params + per-device reserve offers (stacked on #207)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,9 @@ make_tutorials()
 
 pages = OrderedDict(
     "Welcome Page" => "index.md",
-    # "Tutorials" => Any["stub" => "tutorials/generated_stub.md"],
+    "Tutorials" => Any[
+        "Running a Problem with Service Bids" => "tutorials/generated_service_bids.md",
+    ],
     # "How to..." => Any["stub" => "how_to_guides/stub.md"],
     # "Explanation" => Any["stub" => "explanation/stub.md"],
     "Reference" => Any[

--- a/docs/make_tutorials.jl
+++ b/docs/make_tutorials.jl
@@ -441,7 +441,13 @@ function make_tutorials()
 
                 outputfile = string("generated_", replace("$file", ".jl" => ""))
 
-                # Generate markdown
+                # Generate markdown with the Documenter flavor (so `@ref`/`@extref` links and
+                # `!!! admonition` blocks render). Code-block execution follows the `execute`
+                # opt-in: tutorials marked `EXECUTE = TRUE` keep Documenter `@example` blocks
+                # (run at `makedocs` time, output captured); all others have their `@example`
+                # fences rewritten to plain `julia` blocks that Documenter does not execute - so
+                # a tutorial needing solvers or data the docs environment does not carry still
+                # builds, and the downloadable script/notebook remains fully runnable.
                 Literate.markdown(infile_path,
                     tutorial_outputdir;
                     name = outputfile,
@@ -449,11 +455,15 @@ function make_tutorials()
                     flavor = Literate.DocumenterFlavor(),
                     documenter = true,
                     postprocess = (
-                        content -> add_download_links(
-                            insert_md(content),
-                            file,
-                            string(outputfile, ".ipynb"),
-                        )
+                        content -> begin
+                            content = add_download_links(
+                                insert_md(content),
+                                file,
+                                string(outputfile, ".ipynb"),
+                            )
+                            execute ? content :
+                            replace(content, r"```@example[^\n]*" => "```julia")
+                        end
                     ),
                     execute = execute)
 

--- a/docs/src/tutorials/service_bids.jl
+++ b/docs/src/tutorials/service_bids.jl
@@ -77,7 +77,9 @@ for (i, g) in enumerate(contributors)
     ## Keep the unit's own marginal energy cost as its energy offer: read the proportional
     ## (linear) term of its existing variable cost before we replace the operation cost.
     energy_slope =
-        PSY.get_proportional_term(PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))))
+        PSY.get_proportional_term(
+            PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))),
+        )
     ## Give the unit a MarketBidCost carrying that energy offer ...
     set_operation_cost!(
         g,

--- a/docs/src/tutorials/service_bids.jl
+++ b/docs/src/tutorials/service_bids.jl
@@ -97,6 +97,19 @@ for (i, g) in enumerate(contributors)
     set_service_bid!(sys, g, reserve, ts, IS.NaturalUnit())
 end
 
+# `set_service_bid!` is what actually wires the offer to the device. For each call it does two
+# things (after validating that the device's cost is an `OfferCurveCost`, that the units are
+# natural, and that the device is eligible to provide the service):
+#
+# 1. **Attaches the offer curve as a time series** on the device, via `add_time_series!`. The
+#    time series *must* be named after the service (`get_name(reserve)`) - that name is how the
+#    curve is later looked up for this `(device, service)` pair.
+# 2. **Registers the service** in the device cost's `ancillary_service_offers` list, marking the
+#    device as an offering participant in that service.
+#
+# Together these two effects are what let the model find the per-device curve at build time and
+# price the reserve award by it instead of the flat `DEFAULT_RESERVE_COST`.
+
 # Each contributor now exposes its offer through `get_services_bid`:
 
 cost = get_operation_cost(first(contributors))

--- a/docs/src/tutorials/service_bids.jl
+++ b/docs/src/tutorials/service_bids.jl
@@ -1,0 +1,148 @@
+# # Running a Problem with Service Bids
+#
+# This tutorial shows how to price an ancillary service (a reserve) using **per-device
+# offer curves** - "service bids" - instead of a single flat reserve price.
+#
+# By default, `PowerOperationsModels` prices every unit of a reserve award at a flat
+# `DEFAULT_RESERVE_COST`. Real markets instead let each resource submit a **piecewise-linear
+# price/quantity offer** for providing the service: the first few MW are cheap, later MW cost
+# more. When a device carries such an offer, POM prices *that device's* reserve award by its own
+# curve rather than the flat cost.
+#
+# We will:
+#
+# 1. Build a small system that already has a reserve requirement.
+# 2. Attach a per-device reserve offer curve to each contributing thermal unit.
+# 3. Build and solve a unit-commitment problem whose reserve is priced by those offers.
+# 4. Read back the reserve award.
+#
+# !!! note
+#     This tutorial mirrors the `test_device_reserve_offers.jl` test in the POM repository.
+
+# ## Packages
+#
+# Alongside `PowerOperationsModels` we use `PowerSystems` for the data model,
+# `PowerSystemCaseBuilder` for a ready-made test system, `HiGHS` as the MILP solver, and
+# `InfrastructureSystems`/`Dates` for the offer-curve and time-series types.
+
+using PowerOperationsModels
+using PowerSystems
+using PowerSystemCaseBuilder
+using HiGHS
+using Dates
+import PowerSystems as PSY
+import InfrastructureSystems as IS
+
+# ## Build a system with a reserve
+#
+# `c_sys5_uc` is a 5-bus unit-commitment case. Passing `add_reserves = true` attaches an
+# upward reserve product, `Reserve1`, with a time-varying requirement and a set of contributing
+# thermal units.
+
+sys = build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
+reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+
+# The devices that can supply this reserve are those that list it among their services:
+
+contributors =
+    [d for d in get_components(ThermalStandard, sys) if reserve in get_services(d)]
+
+# ## Attach a per-device reserve offer
+#
+# A service bid has two parts on the device:
+#
+# 1. The device's operation cost must be an `OfferCurveCost` - here a
+#    `MarketBidCost` - which is the cost type that can *carry* ancillary
+#    service offers.
+# 2. The offer curve itself is a `PiecewiseStepData` time series, named after the service and
+#    attached with `set_service_bid!`.
+#
+# The offer curve's breakpoints are cumulative **quantities** (MW) and its values are the
+# **marginal prices** (\$/MWh) of each segment. Below, each unit offers two 50 MW blocks: the
+# first at `price`, the second 50% more expensive. We give each unit a slightly different price
+# so the solver has a meaningful merit order to sort.
+#
+# The offer's time series must span the model's forecast window, so we build it over the same
+# initial times, horizon, and resolution as the system's forecasts.
+
+init_times = [DateTime("2024-01-01T00:00:00"), DateTime("2024-01-02T00:00:00")]
+horizon = 24
+resolution = Hour(1)
+
+## One two-segment offer: 0-50 MW at `price`, 50-100 MW at 1.5 * price.
+offer_curve(price) = IS.PiecewiseStepData([0.0, 50.0, 100.0], [price, price * 1.5])
+
+for (i, g) in enumerate(contributors)
+    pmax = get_max_active_power(g, PSY.NU)
+    ## Keep the unit's own marginal energy cost as its energy offer: read the proportional
+    ## (linear) term of its existing variable cost before we replace the operation cost.
+    energy_slope =
+        PSY.get_proportional_term(PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))))
+    ## Give the unit a MarketBidCost carrying that energy offer ...
+    set_operation_cost!(
+        g,
+        MarketBidCost(;
+            no_load_cost = LinearCurve(0.0),
+            start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
+            shut_down = LinearCurve(0.0),
+            incremental_offer_curves = make_market_bid_curve(
+                [0.0, pmax], [energy_slope], 0.0; power_units = IS.NaturalUnit(),
+            ),
+        ),
+    )
+    ## ... and its per-device reserve offer, named after the service.
+    price = 8.0 + 2.0 * i
+    data = Dict(it => [offer_curve(price) for _ in 1:horizon] for it in init_times)
+    ts = Deterministic(get_name(reserve), data, resolution)
+    set_service_bid!(sys, g, reserve, ts, IS.NaturalUnit())
+end
+
+# Each contributor now exposes its offer through `get_services_bid`:
+
+cost = get_operation_cost(first(contributors))
+bid = get_services_bid(first(contributors), cost, reserve; len = 1)
+
+# ## Build the problem template
+#
+# A `ProblemTemplate` pairs component types with formulations. We use a copper-plate
+# unit-commitment template and add a `RangeReserve` service model for the reserve type.
+# One `ServiceModel` covers every service of that type in the system.
+
+template = PowerOperationsProblemTemplate(CopperPlateNetworkModel)
+set_device_model!(template, PowerLoad, StaticPowerLoad)
+set_device_model!(template, ThermalStandard, ThermalStandardUnitCommitment)
+set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+
+# ## Build and solve
+#
+# When the model is built, POM detects that the contributing units carry reserve offers and adds
+# the block-offer cost terms: for each unit it creates award segments `δ_k`, constrains them by
+# the offer breakpoints (`δ_k ≤ P_{k+1} - P_k`), ties their sum to the reserve award
+# (`Σ_k δ_k = award`), and prices them at the offer slopes in the objective
+# (`Σ_k slope_k · δ_k · Δt`). Units *without* an offer keep the flat `DEFAULT_RESERVE_COST`.
+
+model = DecisionModel(template, sys; optimizer = HiGHS.Optimizer)
+build!(model; output_dir = mktempdir())
+solve!(model)
+
+# ## Read the results
+#
+# The reserve award is stored per `(service, device, time)`. Its output is in natural units (MW).
+
+results = OptimizationProblemOutputs(model)
+award = read_variable(results, "ActivePowerReserveVariable__VariableReserve__ReserveUp")
+first(award, 5)
+
+# !!! note
+#     The internal block-offer variable (`PiecewiseLinearBlockReserveOffer`) that decomposes each
+#     award into priced segments is not exported to results - it is an implementation detail of
+#     the cost. What you read back is the reserve award itself; its *price* is what the offers
+#     changed.
+
+# ## Recap
+#
+# We started from a system with a flat-priced reserve, attached a piecewise offer curve to each
+# contributing unit via `set_service_bid!`, and solved a unit-commitment problem in which the
+# reserve is priced by those per-device offers. The only modeling switch was on the data side -
+# swapping each contributor's cost to a `MarketBidCost` carrying the offer; the `RangeReserve`
+# service model consumes the offers automatically.

--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -321,6 +321,7 @@ include("network_models/network_constructor.jl")
 # Services Models
 include("services_models/service_slacks.jl")
 include("services_models/reserves.jl")
+include("services_models/reserve_offers.jl")
 include("services_models/reserve_group.jl")
 # include("services_models/agc.jl")  # TODO: needs _get_ace_error
 include("services_models/transmission_interface.jl")

--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -60,24 +60,26 @@ function add_parameters!(
     return
 end
 
+# Per-type ORDC PWL cost params: all the type's services share one merged container
+# (names axis + tranche axis, empty meta).
 function add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
-    service::U,
-    model::ServiceModel{U, V},
+    services::Vector{U},
+    model::ServiceModel{V, W},
 ) where {
     T <: Union{
         AbstractPiecewiseLinearSlopeParameter,
         AbstractPiecewiseLinearBreakpointParameter,
     },
     U <: PSY.ReserveDemandTimeSeriesCurve,
-    V <: AbstractServiceFormulation,
+    V <: PSY.ReserveDemandTimeSeriesCurve,
+    W <: AbstractServiceFormulation,
 }
-    if get_rebuild_model(get_settings(container)) &&
-       has_container_key(container, T, U, PSY.get_name(service))
+    if get_rebuild_model(get_settings(container)) && has_container_key(container, T, U)
         return
     end
-    _add_parameters!(container, T, service, model)
+    _add_parameters!(container, T, services, model)
     return
 end
 
@@ -570,33 +572,38 @@ function get_max_tranches(component::PSY.Component, piecewise_ts::IS.TimeSeriesK
     return IOM.get_max_tranches(data)
 end
 
+# Batch form (mirrors the device methods below): the tranche axis is sized to the
+# batch-wide maximum tranche count across all the type's ORDC services, and each service's
+# shorter per-hour curves are padded in `unwrap_for_param`. A covariant `Vector{<:...}`
+# signature avoids the invariant-`Vector` unification problem between the concrete service
+# instance type and the `ServiceModel`'s (possibly partially-applied) component type.
 function calc_additional_axes(
     ::OptimizationContainer,
     ::Type{P},
-    service::U,
-    ::ServiceModel{U, W},
+    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
+    ::ServiceModel{<:PSY.ReserveDemandTimeSeriesCurve, W},
 ) where {
     P <: AbstractPiecewiseLinearSlopeParameter,
-    U <: PSY.ReserveDemandTimeSeriesCurve,
     W <: AbstractServiceFormulation,
 }
-    ts_key = IS.get_time_series_key(PSY.get_variable(service))
-    max_tranches = get_max_tranches(service, ts_key)
+    max_tranches = maximum(services) do service
+        get_max_tranches(service, IS.get_time_series_key(PSY.get_variable(service)))
+    end
     return (IOM.make_tranche_axis(max_tranches),)
 end
 
 function calc_additional_axes(
     ::OptimizationContainer,
     ::Type{P},
-    service::U,
-    ::ServiceModel{U, W},
+    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
+    ::ServiceModel{<:PSY.ReserveDemandTimeSeriesCurve, W},
 ) where {
     P <: AbstractPiecewiseLinearBreakpointParameter,
-    U <: PSY.ReserveDemandTimeSeriesCurve,
     W <: AbstractServiceFormulation,
 }
-    ts_key = IS.get_time_series_key(PSY.get_variable(service))
-    max_tranches = get_max_tranches(service, ts_key)
+    max_tranches = maximum(services) do service
+        get_max_tranches(service, IS.get_time_series_key(PSY.get_variable(service)))
+    end
     return (IOM.make_tranche_axis(max_tranches + 1),)  # one more breakpoint than tranches
 end
 
@@ -660,23 +667,15 @@ function calc_additional_axes(
     return (IOM.make_tranche_axis(max_tranches + 1),)  # one more breakpoint than tranches
 end
 
-# The shared `_add_objective_function_parameters!` helper holds the active components
-# as a vector, but `calc_additional_axes` is called differently per model: devices have
-# collection forms, while a service is passed singly (its concrete two-parameter type
-# can't unify with the ServiceModel's partially-applied component type through an
-# invariant `Vector`, and its forms take one service). Dispatch on the model type.
+# `_add_objective_function_parameters!` holds the active components as a vector and both
+# device and service `calc_additional_axes` now take that batch (services size the tranche
+# axis to the batch-wide maximum, like devices), so this simply forwards the collection.
 _calc_additional_axes(
     container::OptimizationContainer,
     ::Type{P},
     active,
-    model::DeviceModel,
+    model::Union{DeviceModel, ServiceModel},
 ) where {P <: ParameterType} = calc_additional_axes(container, P, active, model)
-_calc_additional_axes(
-    container::OptimizationContainer,
-    ::Type{P},
-    active,
-    model::ServiceModel,
-) where {P <: ParameterType} = calc_additional_axes(container, P, only(active), model)
 
 #################################################################################
 # _add_parameters! for ObjectiveFunctionParameter
@@ -787,34 +786,27 @@ end
 #################################################################################
 # _add_parameters! for time-varying ORDC slope/breakpoint cost parameters
 #
-# Same cost-parameter machinery as the device path, keyed per service by `meta = name`.
-#
-# TODO(services PWL cost): this per-service `meta` keying is temporary. It will be removed
-# or folded once the 3D/4D PWL cost containers for services (StepwiseCostReserve/ORDC and
-# the AS offers) land. The whole ORDC cost path -- these slope/breakpoint params, the
-# per-service `ProductionCostExpression` (add_expressions.jl), and the delta-PWL
-# block-offer machinery -- is intentionally kept on `meta` for now so it stays coherent
-# until that migration. (Contrast `RequirementTimeSeriesParameter`, already merged per
-# type; these ORDC params can be merged the same way, just not before their delta-PWL
-# siblings that PR2 reworks.)
+# Same cost-parameter machinery as the device path: batch all the type's ORDC services into
+# one merged container (names axis + tranche axis, empty meta), the tranche axis sized to the
+# batch-wide maximum via `calc_additional_axes`. Read back name-keyed (no meta) by the
+# delta-PWL machinery, matching the device offer path.
 #################################################################################
 
 function _add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
-    service::U,
-    model::ServiceModel{U, V},
+    services::Vector{U},
+    model::ServiceModel{V, W},
 ) where {
     T <: Union{
         AbstractPiecewiseLinearSlopeParameter,
         AbstractPiecewiseLinearBreakpointParameter,
     },
     U <: PSY.ReserveDemandTimeSeriesCurve,
-    V <: AbstractServiceFormulation,
+    V <: PSY.ReserveDemandTimeSeriesCurve,
+    W <: AbstractServiceFormulation,
 }
-    _add_objective_function_parameters!(
-        container, T, [service], model, V; meta = PSY.get_name(service),
-    )
+    _add_objective_function_parameters!(container, T, services, model, W)
     return
 end
 

--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -31,20 +31,6 @@ function add_parameters!(
     return
 end
 
-function add_parameters!(
-    container::OptimizationContainer,
-    ::Type{T},
-    service::U,
-    model::ServiceModel{U, V},
-) where {T <: TimeSeriesParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
-    if get_rebuild_model(get_settings(container)) &&
-       has_container_key(container, T, U, PSY.get_name(service))
-        return
-    end
-    _add_parameters!(container, T, service, model)
-    return
-end
-
 # Per-type service time-series parameter: all services of the type share one container
 # keyed `(ParameterType, ServiceType)` with empty meta, axed by service name.
 function add_parameters!(
@@ -813,56 +799,6 @@ end
 #################################################################################
 # _add_parameters! for ServiceModel TimeSeriesParameter
 #################################################################################
-
-function _add_parameters!(
-    container::OptimizationContainer,
-    ::Type{T},
-    service::U,
-    model::ServiceModel{U, V},
-) where {T <: TimeSeriesParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
-    ts_type = get_default_time_series_type(container)
-    if !(ts_type <: Union{PSY.AbstractDeterministic, PSY.StaticTimeSeries})
-        error("add_parameters! for TimeSeriesParameter is not compatible with $ts_type")
-    end
-    ts_name = get_time_series_names(model)[T]
-    time_steps = get_time_steps(container)
-    name = PSY.get_name(service)
-    model_interval = get_interval(get_settings(container))
-    ts_interval = model_interval
-    ts_uuid = string(
-        IS.get_time_series_uuid(
-            ts_type,
-            service,
-            ts_name;
-            interval = _to_is_interval(ts_interval),
-        ),
-    )
-    @debug "adding" T U _group = IOM.LOG_GROUP_OPTIMIZATION_CONTAINER
-    additional_axes = calc_additional_axes(container, T, [service], model)
-    parameter_container = add_param_container!(container, T,
-        U,
-        ts_type,
-        ts_name,
-        [ts_uuid],
-        [name],
-        additional_axes,
-        time_steps;
-        meta = name,
-    )
-
-    IOM.set_subsystem!(IOM.get_attributes(parameter_container), IOM.get_subsystem(model))
-    jump_model = get_jump_model(container)
-    ts_vector = IOM.get_time_series(container, service, T, name; interval = ts_interval)
-    multiplier = get_multiplier_value(T, service, V)
-    parent_param = IOM.get_parameter_array_data(parameter_container)
-    parent_mult = IOM.get_multiplier_array_data(parameter_container)
-    IOM._set_multiplier_at!(parent_mult, multiplier, 1)
-    for t in time_steps
-        IOM._set_parameter_at!(parent_param, jump_model, ts_vector[t], 1, t)
-    end
-    IOM.add_component_name!(IOM.get_attributes(parameter_container), name, ts_uuid)
-    return
-end
 
 function _add_parameters!(
     container::OptimizationContainer,

--- a/src/common_models/market_bid_overrides.jl
+++ b/src/common_models/market_bid_overrides.jl
@@ -363,7 +363,8 @@ function add_pwl_term_delta!(
     time_steps = get_time_steps(container)
     pwl_cost_expressions = Vector{JuMP.AffExpr}(undef, time_steps[end])
     for t in time_steps
-        break_points, slopes = IOM._get_pwl_data(dir, container, component, t; meta = name)
+        # Merged (name-keyed, empty meta) slope/breakpoint params, same as the device offer path.
+        break_points, slopes = IOM._get_pwl_data(dir, container, component, t)
         pwl_vars = add_pwl_variables_delta!(
             container,
             IOM._block_offer_var(dir),

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -25,6 +25,9 @@ The specified constraint is generally formulated as:
 """
 struct AreaParticipationAssignmentConstraint <: ConstraintType end
 struct BalanceAuxConstraint <: ConstraintType end
+# Links a device's per-service reserve OFFER blocks to its reserve award:
+# `Σ_k δ[(service, device, k, t)] == ActivePowerReserveVariable[(service, device, t)]`.
+struct ReserveOfferLinkingConstraint <: ConstraintType end
 """
 Struct to create the commitment constraint between the on, start, and stop variables.
 For more information check [ThermalGen Formulations](@ref ThermalGen-Formulations).

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -532,6 +532,11 @@ structure on top of the 3D `(service, device, time)` reserve award `ActivePowerR
 """
 struct PiecewiseLinearBlockReserveOffer <: SparseVariableType end
 
+# Widen the auto-created sparse container to the 4D reserve-offer key. The IOM default is the
+# 3D device-offer shape `(device, segment, time)`; this adds the leading service axis.
+IOM.sparse_variable_key_type(::Type{PiecewiseLinearBlockReserveOffer}) =
+    Tuple{String, String, Int, Int}
+
 """
 Struct to dispatch the creation of HVDC Piecewise Loss Variables
 

--- a/src/core/variables.jl
+++ b/src/core/variables.jl
@@ -526,6 +526,13 @@ Docs abbreviation: ``\\t^i``
 struct HVDCInverterTapSettingVariable <: VariableType end
 
 """
+Block-offer delta variable for a per-device ancillary-service (reserve) OFFER. Sparse, keyed
+`(service_name, device_name, segment, time)` - the 4D `(service, device, segment, time)` cost
+structure on top of the 3D `(service, device, time)` reserve award `ActivePowerReserveVariable`.
+"""
+struct PiecewiseLinearBlockReserveOffer <: SparseVariableType end
+
+"""
 Struct to dispatch the creation of HVDC Piecewise Loss Variables
 
 Docs abbreviation: ``h`` or ``w``
@@ -832,6 +839,7 @@ const MULTI_START_VARIABLES = (HotStartVariable, WarmStartVariable, ColdStartVar
 should_write_resulting_value(::Type{PiecewiseLinearCostVariable}) = false
 should_write_resulting_value(::Type{PiecewiseLinearBlockIncrementalOffer}) = false
 should_write_resulting_value(::Type{PiecewiseLinearBlockDecrementalOffer}) = false
+should_write_resulting_value(::Type{PiecewiseLinearBlockReserveOffer}) = false
 should_write_resulting_value(::Type{HVDCPiecewiseLossVariable}) = false
 should_write_resulting_value(::Type{HVDCPiecewiseBinaryLossVariable}) = false
 should_write_resulting_value(::Type{<:InterpolationVariableType}) = false

--- a/src/services_models/reserve_offers.jl
+++ b/src/services_models/reserve_offers.jl
@@ -11,9 +11,13 @@
 # top of the 3D `(service, device, time)` reserve award. Reuses the device offer PWL machinery
 # (`_get_raw_pwl_data`, `get_piecewise_curve_per_system_unit`, `get_pwl_cost_expression_delta`).
 
+# Does `device` offer into `service`? Dispatch on the operation-cost type: only an
+# `OfferCurveCost` carries ancillary-service offers; every other cost never offers.
 _has_reserve_offer(device, service) =
-    (c = PSY.get_operation_cost(device);
-    c isa PSY.OfferCurveCost && service in PSY.get_ancillary_service_offers(c))
+    _cost_offers_reserve(PSY.get_operation_cost(device), service)
+_cost_offers_reserve(cost::PSY.OfferCurveCost, service) =
+    service in PSY.get_ancillary_service_offers(cost)
+_cost_offers_reserve(::PSY.OperationalCost, service) = false
 
 # Price every contributing device that offers into `service` by its offer curve; returns the set of
 # device names so priced (the flat-cost pass skips them).
@@ -36,14 +40,14 @@ function add_reserve_offer_costs!(
         offering = [d for d in devices if _has_reserve_offer(d, service)]
         isempty(offering) && continue
         names = [PSY.get_name(d) for d in offering]
-        # 4D block var keyed (service, device, segment, time). The segment axis `1:1` is only a
-        # key-type carrier: `sparse_container_spec` infers `Tuple{String,String,Int,Int}` from the
-        # axis eltypes and returns an empty SparseAxisArray with no axis validation, so segments
-        # (which vary per device/time) are filled sparsely below - same pattern IOM uses for its
-        # hardcoded 3-tuple device-cost PWL container, one axis wider.
-        blk = lazy_container_addition!(container, PiecewiseLinearBlockReserveOffer,
+        # 4D block var keyed (service, device, segment, time). The auto-created sparse container
+        # uses the 4-tuple key from `IOM.sparse_variable_key_type(PiecewiseLinearBlockReserveOffer)`;
+        # segments (which vary per device/time) are filled sparsely below.
+        blk = lazy_container_addition!(
+            container,
+            PiecewiseLinearBlockReserveOffer,
             device_type,
-            [service_name], names, 1:1, time_steps; sparse = true)
+        )
         cons =
             lazy_container_addition!(container, ReserveOfferLinkingConstraint, device_type,
                 [service_name], names, time_steps; sparse = true)

--- a/src/services_models/reserve_offers.jl
+++ b/src/services_models/reserve_offers.jl
@@ -1,0 +1,84 @@
+# Per-device ancillary-service (reserve) OFFER costs.
+#
+# A contributing device can OFFER a PWL price/quantity curve for providing a reserve service,
+# stored via the PSY `set_service_bid!` path and retrieved with `get_services_bid`. This prices the
+# device's reserve award `ActivePowerReserveVariable[(service, device, t)]` by its own offer curve
+# instead of the flat `DEFAULT_RESERVE_COST`, using the delta/block-offer formulation:
+#
+#   δ_k >= 0,  δ_k <= P_{k+1} - P_k,  Σ_k δ_k == award,  objective += Σ_k slope_k · δ_k · dt
+#
+# Block variables are keyed 4D `(service_name, device_name, segment, time)` - the segment axis on
+# top of the 3D `(service, device, time)` reserve award. Reuses the device offer PWL machinery
+# (`_get_raw_pwl_data`, `get_piecewise_curve_per_system_unit`, `get_pwl_cost_expression_delta`).
+
+_has_reserve_offer(device, service) =
+    (c = PSY.get_operation_cost(device);
+    c isa PSY.OfferCurveCost && service in PSY.get_ancillary_service_offers(c))
+
+# Price every contributing device that offers into `service` by its offer curve; returns the set of
+# device names so priced (the flat-cost pass skips them).
+function add_reserve_offer_costs!(
+    container::OptimizationContainer,
+    service::SR,
+    model::ServiceModel{SR, T},
+) where {SR <: PSY.AbstractReserve, T <: AbstractReservesFormulation}
+    service_name = PSY.get_name(service)
+    award = get_variable(container, ActivePowerReserveVariable, SR)
+    time_steps = get_time_steps(container)
+    resolution = get_resolution(container)
+    dt = Dates.value(Dates.Second(resolution)) / SECONDS_IN_HOUR
+    base_p = get_model_base_power(container)
+    initial_time = IOM.get_initial_time(container)
+    jump_model = get_jump_model(container)
+    offered = Set{String}()
+
+    for (device_type, devices) in get_contributing_devices_map(model, service_name)
+        offering = [d for d in devices if _has_reserve_offer(d, service)]
+        isempty(offering) && continue
+        names = [PSY.get_name(d) for d in offering]
+        # 4D block var keyed (service, device, segment, time). The segment axis `1:1` is only a
+        # key-type carrier: `sparse_container_spec` infers `Tuple{String,String,Int,Int}` from the
+        # axis eltypes and returns an empty SparseAxisArray with no axis validation, so segments
+        # (which vary per device/time) are filled sparsely below - same pattern IOM uses for its
+        # hardcoded 3-tuple device-cost PWL container, one axis wider.
+        blk = lazy_container_addition!(container, PiecewiseLinearBlockReserveOffer,
+            device_type,
+            [service_name], names, 1:1, time_steps; sparse = true)
+        cons =
+            lazy_container_addition!(container, ReserveOfferLinkingConstraint, device_type,
+                [service_name], names, time_steps; sparse = true)
+        for d in offering
+            dev_name = PSY.get_name(d)
+            cost = PSY.get_operation_cost(d)
+            dev_base = PSY.get_base_power(d)
+            bid = PSY.get_services_bid(
+                d, cost, service; start_time = initial_time, len = length(time_steps))
+            curves = values(bid)
+            for t in time_steps
+                bp_c, slope_c, unit = IOM._get_raw_pwl_data(
+                    IOM.IncrementalOffer(), container, device_type, dev_name, curves[t],
+                    t)
+                breakpoints, slopes = IOM.get_piecewise_curve_per_system_unit(
+                    bp_c, slope_c, unit, base_p, dev_base)
+                nseg = length(slopes)
+                pwl_vars = Vector{JuMP.VariableRef}(undef, nseg)
+                for k in 1:nseg
+                    v =
+                        blk[(service_name, dev_name, k, t)] = JuMP.@variable(
+                            jump_model,
+                            base_name = "PiecewiseLinearBlockReserveOffer_$(device_type)_{$(service_name), $(dev_name), $(k), $(t)}",
+                            lower_bound = 0.0,
+                        )
+                    JuMP.@constraint(jump_model, v <= breakpoints[k + 1] - breakpoints[k])
+                    pwl_vars[k] = v
+                end
+                cons[(service_name, dev_name, t)] = JuMP.@constraint(
+                    jump_model, sum(pwl_vars) == award[(service_name, dev_name, t)])
+                add_to_objective_invariant_expression!(
+                    container, get_pwl_cost_expression_delta(pwl_vars, slopes, dt))
+            end
+            push!(offered, dev_name)
+        end
+    end
+    return offered
+end

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -625,11 +625,13 @@ ORDC (`ReserveDemandTimeSeriesCurve`) service.
 function process_stepwise_cost_reserve_parameters!(
     container::OptimizationContainer,
     model::ServiceModel,
-    service::D,
+    services::Vector{D},
 ) where {D <: PSY.ReserveDemandTimeSeriesCurve}
-    dir = _reserve_offer_direction(service)
+    # All services of a per-type model share the same offer direction; build the merged
+    # slope/breakpoint param containers once over all services (empty meta).
+    dir = _reserve_offer_direction(first(services))
     for param in (IOM._breakpoint_param(dir), IOM._slope_param(dir))
-        add_parameters!(container, param, service, model)
+        add_parameters!(container, param, services, model)
     end
     return
 end

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -307,9 +307,13 @@ end
 function add_to_objective_function!(
     container::OptimizationContainer,
     service::SR,
-    ::ServiceModel{SR, T},
+    model::ServiceModel{SR, T},
 ) where {SR <: PSY.AbstractReserve, T <: AbstractReservesFormulation}
-    add_reserves_proportional_cost!(container, ActivePowerReserveVariable, service, T)
+    # Devices that submitted a reserve OFFER are priced by their offer curve; the rest keep the
+    # flat DEFAULT_RESERVE_COST.
+    offered = add_reserve_offer_costs!(container, service, model)
+    add_reserves_proportional_cost!(
+        container, ActivePowerReserveVariable, service, T; skip_devices = offered)
     return
 end
 
@@ -640,7 +644,8 @@ function add_reserves_proportional_cost!(
     container::OptimizationContainer,
     ::Type{U},
     service::T,
-    ::Type{V},
+    ::Type{V};
+    skip_devices = Set{String}(),
 ) where {
     T <: Union{PSY.Reserve, PSY.ReserveNonSpinning},
     U <: ActivePowerReserveVariable,
@@ -650,13 +655,15 @@ function add_reserves_proportional_cost!(
     service_name = PSY.get_name(service)
     reserve_variable = get_variable(container, U, T)
     # Iterate only this service's slice of the merged `(service, device, time)` container
-    # so each service's reserve provision is priced exactly once.
+    # so each service's reserve provision is priced exactly once. Devices in `skip_devices`
+    # are priced by their offer curve (add_reserve_offer_costs!), not the flat cost.
     # TODO(services efficiency, deferred B4): this scans the whole merged container per service
     # (O(entries) x #services). When the service's contributing device names are on hand, replace
     # the `.data` scan with a keyed slice. Build-time-only; typing here is fine (U, T concrete).
     # See .claude/plans/service-refactor-stability.md.
     for (key, var) in reserve_variable.data
         key[1] == service_name || continue
+        key[2] in skip_devices && continue
         add_to_objective_invariant_expression!(
             container,
             # possibly decouple

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -218,9 +218,12 @@ function construct_service!(
     return
 end
 
-_maybe_process_stepwise(container, model, service::PSY.ReserveDemandTimeSeriesCurve) =
-    process_stepwise_cost_reserve_parameters!(container, model, service)
-_maybe_process_stepwise(container, model, service) = nothing
+_maybe_process_stepwise(
+    container,
+    model,
+    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
+) = process_stepwise_cost_reserve_parameters!(container, model, services)
+_maybe_process_stepwise(container, model, services) = nothing
 
 function construct_service!(
     container::OptimizationContainer,
@@ -241,6 +244,8 @@ function construct_service!(
     )
     # Merged dense `(service, time)` cost-expression container, built once over all services.
     add_expressions!(container, ProductionCostExpression, services, model)
+    # Merged slope/breakpoint PWL cost params (empty meta), built once over all services.
+    _maybe_process_stepwise(container, model, services)
     for service in services
         contributing_devices = get_contributing_devices(model, PSY.get_name(service))
         add_service_variables!(
@@ -250,7 +255,6 @@ function construct_service!(
             contributing_devices,
             StepwiseCostReserve,
         )
-        _maybe_process_stepwise(container, model, service)
         add_to_expression!(
             container,
             ActivePowerReserveVariable,

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -28,6 +28,11 @@ function add_device_reserve_offers!(
     base_slope = Dict{String, Float64}()
     for (i, g) in enumerate(contributors)
         pmax = PSY.get_max_active_power(g, PSY.NU)
+        # Keep the unit's own marginal energy cost: read the proportional (linear) term of its
+        # existing variable cost before overwriting, and use it as the single-block energy offer.
+        energy_slope = PSY.get_proportional_term(
+            PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))),
+        )
         set_operation_cost!(
             g,
             MarketBidCost(;
@@ -35,7 +40,7 @@ function add_device_reserve_offers!(
                 start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
                 shut_down = LinearCurve(0.0),
                 incremental_offer_curves = make_market_bid_curve(
-                    [0.0, pmax], [20.0], 0.0; power_units = IS.NaturalUnit(),
+                    [0.0, pmax], [energy_slope], 0.0; power_units = IS.NaturalUnit(),
                 ),
             ),
         )

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -24,6 +24,8 @@ function add_device_reserve_offers!(
         [d for d in get_components(ThermalStandard, sys) if reserve in PSY.get_services(d)]
     @assert !isempty(contributors) "reserve has no thermal contributors"
     offer_curve(price) = IS.PiecewiseStepData([0.0, 50.0, 100.0], [price, price * 1.5])
+    # device name -> first-segment offer slope ($/MWh, natural units); segment 2 is 1.5x it.
+    base_slope = Dict{String, Float64}()
     for (i, g) in enumerate(contributors)
         pmax = PSY.get_max_active_power(g, PSY.NU)
         set_operation_cost!(
@@ -38,17 +40,18 @@ function add_device_reserve_offers!(
             ),
         )
         price = 8.0 + 2.0 * i
+        base_slope[PSY.get_name(g)] = price
         data = Dict(it => [offer_curve(price) for _ in 1:horizon] for it in init_times)
         ts = Deterministic(PSY.get_name(reserve), data, resolution)
         PSY.set_service_bid!(sys, g, reserve, ts, IS.NaturalUnit())
     end
-    return contributors
+    return contributors, base_slope
 end
 
 @testset "Per-device reserve offers: data model" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
     reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    contributors = add_device_reserve_offers!(sys, reserve)
+    contributors, _ = add_device_reserve_offers!(sys, reserve)
 
     # Each contributor now bids into the service and exposes a per-(device, service) offer curve.
     for g in contributors
@@ -68,7 +71,7 @@ end
 @testset "Per-device reserve offers: builds, solves, and prices the offers" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
     reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    contributors = add_device_reserve_offers!(sys, reserve)
+    contributors, base_slope = add_device_reserve_offers!(sys, reserve)
 
     template = get_thermal_standard_uc_template()
     set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
@@ -97,15 +100,19 @@ end
 
     sname = PSY.get_name(reserve)
     obj = JuMP.objective_function(IOM.get_jump_model(container))
+    base_p = IOM.get_model_base_power(container)
+    dt = 1.0  # Hour(1) resolution -> 1 hour per step
     for g in contributors
         gname = PSY.get_name(g)
         # Both offer segments ([0,50,100] breakpoints -> 2 segments) are present at t = 1.
         seg1 = blk[(sname, gname, 1, 1)]
         seg2 = blk[(sname, gname, 2, 1)]
-        # The offer's second slope is 1.5x the first (offer_curve builds [price, 1.5*price]).
-        # The delta-cost coefficient is slope * dt, so the ratio is unit- and dt-invariant.
-        @test JuMP.coefficient(obj, seg2) / JuMP.coefficient(obj, seg1) ≈ 1.5
-        @test JuMP.coefficient(obj, seg1) > 0
+        # Independent magnitude check. The award delta is in system pu; the offer slope is in
+        # natural units ($/MWh). Cost = slope * (delta_pu * base_p) * dt, so the objective
+        # coefficient on delta_pu is slope * base_p * dt. Segment 2's slope is 1.5x segment 1's.
+        slope1 = base_slope[gname]
+        @test JuMP.coefficient(obj, seg1) ≈ slope1 * base_p * dt
+        @test JuMP.coefficient(obj, seg2) ≈ 1.5 * slope1 * base_p * dt
         # Linking constraint sum(segments) == award: normalized to sum(delta) - award == 0.
         lc = cons[(sname, gname, 1)]
         @test JuMP.normalized_coefficient(lc, seg1) ≈ 1.0

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -7,9 +7,9 @@
 #
 # This is the (service, device, segment, time) 4D cost structure: one PWL offer per
 # (device, service) per hour. The reserve AWARD (`ActivePowerReserveVariable`) is already keyed
-# `(service, device, time)`; pricing it by these per-device offers (instead of the flat
-# `DEFAULT_RESERVE_COST`) is the piece not yet built. These tests pin the DATA MODEL and a
-# buildable fixture so that consumer can be developed against them.
+# `(service, device, time)`; `add_reserve_offer_costs!` prices it by these per-device offers
+# (instead of the flat `DEFAULT_RESERVE_COST`). These tests pin the DATA MODEL and assert the
+# consumer builds the 4D block variable, the award-linking constraint, and the offer-slope cost.
 
 # Give every contributing thermal device of `reserve` a MarketBidCost with an energy offer and a
 # per-device reserve OFFER curve (PiecewiseStepData, NaturalUnit) named after the service.
@@ -65,10 +65,10 @@ end
         get_components(ThermalStandard, sys))
 end
 
-@testset "Per-device reserve offers: fixture builds and solves (offers not yet priced)" begin
+@testset "Per-device reserve offers: builds, solves, and prices the offers" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
     reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    add_device_reserve_offers!(sys, reserve)
+    contributors = add_device_reserve_offers!(sys, reserve)
 
     template = get_thermal_standard_uc_template()
     set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
@@ -81,13 +81,35 @@ end
     # The reserve award exists, keyed by service type.
     @test IOM.has_container_key(
         container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
-    # TODO(per-device reserve offers): no reserve-offer cost term is built yet - the device
-    # reserve offer curves are not consumed, the reserve is priced at the flat DEFAULT_RESERVE_COST.
-    # The only block-offer variable present is the ENERGY offer, not a reserve offer.
-    reserve_offer_vars = [
-        k for k in keys(container.variables)
-        if occursin("Reserve", string(IOM.get_entry_type(k))) &&
-        occursin("Offer", string(IOM.get_entry_type(k)))
-    ]
-    @test isempty(reserve_offer_vars)
+
+    # The per-device reserve OFFER is now consumed: a 4D block variable keyed
+    # (service, device, segment, time) exists for the contributing device type, plus the
+    # linking constraint that ties each device's segments to its reserve award.
+    @test IOM.has_container_key(
+        container, POM.PiecewiseLinearBlockReserveOffer, ThermalStandard)
+    @test IOM.has_container_key(
+        container, POM.ReserveOfferLinkingConstraint, ThermalStandard)
+    blk = IOM.get_variable(container, POM.PiecewiseLinearBlockReserveOffer, ThermalStandard)
+    cons = IOM.get_constraint(container, POM.ReserveOfferLinkingConstraint, ThermalStandard)
+    award =
+        IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    @test !isempty(blk)
+
+    sname = PSY.get_name(reserve)
+    obj = JuMP.objective_function(IOM.get_jump_model(container))
+    for g in contributors
+        gname = PSY.get_name(g)
+        # Both offer segments ([0,50,100] breakpoints -> 2 segments) are present at t = 1.
+        seg1 = blk[(sname, gname, 1, 1)]
+        seg2 = blk[(sname, gname, 2, 1)]
+        # The offer's second slope is 1.5x the first (offer_curve builds [price, 1.5*price]).
+        # The delta-cost coefficient is slope * dt, so the ratio is unit- and dt-invariant.
+        @test JuMP.coefficient(obj, seg2) / JuMP.coefficient(obj, seg1) ≈ 1.5
+        @test JuMP.coefficient(obj, seg1) > 0
+        # Linking constraint sum(segments) == award: normalized to sum(delta) - award == 0.
+        lc = cons[(sname, gname, 1)]
+        @test JuMP.normalized_coefficient(lc, seg1) ≈ 1.0
+        @test JuMP.normalized_coefficient(lc, seg2) ≈ 1.0
+        @test JuMP.normalized_coefficient(lc, award[(sname, gname, 1)]) ≈ -1.0
+    end
 end

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -1,0 +1,93 @@
+# Per-device ancillary-service (reserve) OFFERS.
+#
+# A device can submit a price/quantity OFFER curve for providing a reserve service, stored via
+# the PSY `set_service_bid!` path: a `PiecewiseStepData` time series named after the service,
+# attached to the device (whose operation cost must be an `OfferCurveCost`), plus service
+# membership in `MarketBidCost.ancillary_service_offers`. Retrieval is `get_services_bid`.
+#
+# This is the (service, device, segment, time) 4D cost structure: one PWL offer per
+# (device, service) per hour. The reserve AWARD (`ActivePowerReserveVariable`) is already keyed
+# `(service, device, time)`; pricing it by these per-device offers (instead of the flat
+# `DEFAULT_RESERVE_COST`) is the piece not yet built. These tests pin the DATA MODEL and a
+# buildable fixture so that consumer can be developed against them.
+
+# Give every contributing thermal device of `reserve` a MarketBidCost with an energy offer and a
+# per-device reserve OFFER curve (PiecewiseStepData, NaturalUnit) named after the service.
+function add_device_reserve_offers!(
+    sys,
+    reserve;
+    init_times = [DateTime("2024-01-01T00:00:00"), DateTime("2024-01-02T00:00:00")],
+    horizon = 24,
+    resolution = Hour(1),
+)
+    contributors =
+        [d for d in get_components(ThermalStandard, sys) if reserve in PSY.get_services(d)]
+    @assert !isempty(contributors) "reserve has no thermal contributors"
+    offer_curve(price) = IS.PiecewiseStepData([0.0, 50.0, 100.0], [price, price * 1.5])
+    for (i, g) in enumerate(contributors)
+        pmax = PSY.get_max_active_power(g, PSY.NU)
+        set_operation_cost!(
+            g,
+            MarketBidCost(;
+                no_load_cost = LinearCurve(0.0),
+                start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
+                shut_down = LinearCurve(0.0),
+                incremental_offer_curves = make_market_bid_curve(
+                    [0.0, pmax], [20.0], 0.0; power_units = IS.NaturalUnit(),
+                ),
+            ),
+        )
+        price = 8.0 + 2.0 * i
+        data = Dict(it => [offer_curve(price) for _ in 1:horizon] for it in init_times)
+        ts = Deterministic(PSY.get_name(reserve), data, resolution)
+        PSY.set_service_bid!(sys, g, reserve, ts, IS.NaturalUnit())
+    end
+    return contributors
+end
+
+@testset "Per-device reserve offers: data model" begin
+    sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
+    reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    contributors = add_device_reserve_offers!(sys, reserve)
+
+    # Each contributor now bids into the service and exposes a per-(device, service) offer curve.
+    for g in contributors
+        cost = get_operation_cost(g)
+        @test cost isa PSY.OfferCurveCost
+        @test reserve in PSY.get_ancillary_service_offers(cost)
+        bid = PSY.get_services_bid(g, cost, reserve; len = 1)
+        # Per-timestep CostCurve{PiecewiseIncrementalCurve} - the PWL offer for this device.
+        @test eltype(values(bid)) <: PSY.CostCurve
+    end
+    # The device axis of the 4D (service, device, segment, time): every contributor offers.
+    @test length(contributors) ==
+          count(g -> reserve in PSY.get_ancillary_service_offers(get_operation_cost(g)),
+        get_components(ThermalStandard, sys))
+end
+
+@testset "Per-device reserve offers: fixture builds and solves (offers not yet priced)" begin
+    sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
+    reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    add_device_reserve_offers!(sys, reserve)
+
+    template = get_thermal_standard_uc_template()
+    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    container = get_optimization_container(model)
+    # The reserve award exists, keyed by service type.
+    @test IOM.has_container_key(
+        container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    # TODO(per-device reserve offers): no reserve-offer cost term is built yet - the device
+    # reserve offer curves are not consumed, the reserve is priced at the flat DEFAULT_RESERVE_COST.
+    # The only block-offer variable present is the ENERGY offer, not a reserve offer.
+    reserve_offer_vars = [
+        k for k in keys(container.variables)
+        if occursin("Reserve", string(IOM.get_entry_type(k))) &&
+        occursin("Offer", string(IOM.get_entry_type(k)))
+    ]
+    @test isempty(reserve_offer_vars)
+end

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -399,6 +399,19 @@ end
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
     @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    # C1: the ORDC slope/breakpoint PWL cost params are now ONE merged container per service type
+    # (names axis + batch-wide tranche axis, empty meta), not per-service `meta = name`. A 3-arg
+    # fetch succeeds only for the merged container; the two ORDCs above have different tranche
+    # counts, so the successful build+solve also exercises the batch-wide tranche padding.
+    container = get_optimization_container(model)
+    dir = POM._reserve_offer_direction(
+        first(get_components(ReserveDemandTimeSeriesCurve, c_sys5_uc)),
+    )
+    for P in (IOM._slope_param(dir), IOM._breakpoint_param(dir))
+        @test IOM.get_parameter(container, P, ReserveDemandTimeSeriesCurve{ReserveUp}) !==
+              nothing
+    end
 end
 
 # Ported from PSI test_services_constructor.jl. Exact `moi_tests` variable/constraint


### PR DESCRIPTION
Part 3 of the service-container refactor. Stacked on #207 (Phase A+B) → base branch `rh/dev_refactor_services_pt2`.

Review only the commits above #207; GitHub will show the full stack until #207 merges.

## What this adds (Phase C)

**C1 — merged ORDC PWL cost params.** Fold the per-service `TimeSeriesParameter` slope/breakpoint
PWL cost containers into one merged container per service type (covariant `Vector{<:ReserveDemandTimeSeriesCurve}`
axis computation, batch-wide max-tranche padding). Retires the now-dead single-service
`add_parameters!`/`_add_parameters!` path.

**C2 — per-device ancillary-service reserve offers.** A contributing device can OFFER a PWL
price/quantity curve for a reserve service (PSY `set_service_bid!` / `get_services_bid`); it is now
priced by that curve instead of the flat `DEFAULT_RESERVE_COST`. This is the 4D
`(service, device, segment, time)` cost structure on top of the 3D `(service, device, time)` reserve award.

- New `PiecewiseLinearBlockReserveOffer` (SparseVariableType) + `ReserveOfferLinkingConstraint`.
- `add_reserve_offer_costs!` builds the delta/block-offer formulation per offering device and prices
  its segments; the flat-cost pass skips priced devices via a `skip_devices` kwarg.
- The 4D container uses the new IOM `sparse_variable_key_type` trait (Sienna-Platform/InfrastructureOptimizationModels.jl#141).

## Tests

`test_device_reserve_offers.jl`: data model + a fixture that builds/solves and asserts the 4D block
var, the award-linking constraint (±1 coefficients), and the offer-slope objective coefficient
(`≈ slope · base_p · dt`, an independent unit-checked reference).

Full POM suite green (105,495 assertions), 0 method ambiguities.

## Cross-package dependency

Depends on Sienna-Platform/InfrastructureOptimizationModels.jl#141 (adds `sparse_variable_key_type`).
The `[sources]` IOM pin here already tracks `rh/dev_service_refactor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1bssU5YnY8eZWQD9apDBM