### PR TITLE
Add GroupStepwiseReserveCurve: elastic group ASDC over sub-service supply

### DIFF
--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -918,6 +918,7 @@ export PIDSmoothACE
 export GroupReserve
 export RangeReserve
 export StepwiseCostReserve
+export GroupStepwiseReserveCurve
 export RampReserve
 export NonSpinningReserve
 export ConstantMaxInterfaceFlow

--- a/src/common_models/add_expressions.jl
+++ b/src/common_models/add_expressions.jl
@@ -244,3 +244,29 @@ function add_expressions!(
     )
     return
 end
+
+# `ReserveDemandCurveGroup` is `<: Service`, not `<: Reserve`, so it needs its own merged
+# cost-expression container method. Kept separate from the `PSY.Reserve` method above to avoid
+# a dispatch ambiguity with the generic `ExpressionType`/`PSY.Reserve` method (widening the
+# union there would make neither method most-specific).
+function add_expressions!(
+    container::OptimizationContainer,
+    ::Type{T},
+    services::U,
+    model::ServiceModel{V, W},
+) where {
+    T <: CostExpressions,
+    U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
+    V <: PSY.ReserveDemandCurveGroup,
+    W <: AbstractReservesFormulation,
+} where {D <: PSY.Component}
+    time_steps = get_time_steps(container)
+    add_expression_container!(
+        container,
+        T,
+        D,
+        [PSY.get_name(s) for s in services],
+        time_steps,
+    )
+    return
+end

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -2656,7 +2656,8 @@ function add_cost_to_expression!(
     time_period::Int,
 ) where {
     S <: CostExpressions,
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
 }
     if has_container_key(container, S, T, PSY.get_name(component))
         device_cost_expression = get_expression(container, S, T, PSY.get_name(component))
@@ -2985,7 +2986,8 @@ function add_to_expression!(
     time_period::Int,
 ) where {
     S <: CostExpressions,
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
 }
     if has_container_key(container, S, T)
         device_cost_expression = get_expression(container, S, T)

--- a/src/common_models/market_bid_overrides.jl
+++ b/src/common_models/market_bid_overrides.jl
@@ -348,7 +348,8 @@ function add_pwl_term_delta!(
     ::Type{U},
     ::Type{V},
 ) where {
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
     U <: VariableType,
     V <: AbstractServiceFormulation,
 }

--- a/src/common_models/market_bid_plumbing.jl
+++ b/src/common_models/market_bid_plumbing.jl
@@ -110,7 +110,8 @@ get_offer_curves(::IOM.IncrementalOffer, op_cost::PSY.OfferCurveCost) =
 # service-side direction trait (`_reserve_offer_direction`) is decremental.
 get_offer_curves(
     ::IOM.OfferDirection,
-    service::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    service::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
 ) = PSY.get_variable(service)
 
 #################################################################################

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -444,6 +444,13 @@ Struct for to add reserves to be larger than a variable requirement depending of
 """
 struct StepwiseCostReserve <: AbstractReservesFormulation end
 """
+Group reserve formulation whose single elastic demand curve (ASDC) is met by the awards of its
+contributing sub-type services. Combines the demand-curve pricing of [`StepwiseCostReserve`](@ref)
+with the service aggregation of [`GroupReserve`](@ref): one demand, one MCPC, per-sub-type offers and
+caps on the contributing services. Used with `PSY.ReserveDemandCurveGroup`.
+"""
+struct GroupStepwiseReserveCurve <: AbstractReservesFormulation end
+"""
 Struct to add reserves to be larger than a specified requirement, with ramp constraints
 """
 struct RampReserve <: AbstractReservesFormulation end

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -444,10 +444,10 @@ Struct for to add reserves to be larger than a variable requirement depending of
 """
 struct StepwiseCostReserve <: AbstractReservesFormulation end
 """
-Group reserve formulation whose single elastic demand curve (ASDC) is met by the awards of its
+Group reserve formulation whose single elastic demand curve is met by the awards of its
 contributing sub-type services. Combines the demand-curve pricing of [`StepwiseCostReserve`](@ref)
-with the service aggregation of [`GroupReserve`](@ref): one demand, one MCPC, per-sub-type offers and
-caps on the contributing services. Used with `PSY.ReserveDemandCurveGroup`.
+with the service aggregation of [`GroupReserve`](@ref): one demand, one clearing price, per-sub-type
+offers and caps on the contributing services. Used with `PSY.ReserveDemandCurveGroup`.
 """
 struct GroupStepwiseReserveCurve <: AbstractReservesFormulation end
 """

--- a/src/core/problem_template.jl
+++ b/src/core/problem_template.jl
@@ -255,12 +255,15 @@ function _populate_contributing_devices!(
                     )
                 end
             end
-            # Exempt ConstantReserveGroup: a GroupReserve aggregates other services, so its
-            # contributing-device map is empty by design, and this check would otherwise reject
-            # every group reserve. Reserves and transmission interfaces DO draw on
-            # devices/branches, so an empty map there is a real misconfiguration. AGC is not
-            # modeled in POM, so it never reaches here.
-            if !(service_type <: PSY.ConstantReserveGroup) &&
+            # Exempt the group services (`ConstantReserveGroup`, `ReserveDemandCurveGroup`): a
+            # group formulation aggregates other services, so its contributing-device map is empty
+            # by design, and this check would otherwise reject every group reserve. Reserves and
+            # transmission interfaces DO draw on devices/branches, so an empty map there is a real
+            # misconfiguration. AGC is not modeled in POM, so it never reaches here.
+            if !(
+                service_type <:
+                Union{PSY.ConstantReserveGroup, PSY.ReserveDemandCurveGroup}
+            ) &&
                isempty(get_contributing_devices_map(service_model, service_name))
                 error(
                     "Service \"$(service_name)\" of type $(typeof(service)) has no available contributing devices/branches. Assign available contributing devices/branches to it in the system data, or remove its service model from the template.",

--- a/src/core/problem_template.jl
+++ b/src/core/problem_template.jl
@@ -255,15 +255,12 @@ function _populate_contributing_devices!(
                     )
                 end
             end
-            # Exempt the group services (`ConstantReserveGroup`, `ReserveDemandCurveGroup`): a
-            # group formulation aggregates other services, so its contributing-device map is empty
+            # Exempt every `PSY.ReserveGroup` (`ConstantReserveGroup`, `ReserveDemandCurveGroup`):
+            # a group formulation aggregates other services, so its contributing-device map is empty
             # by design, and this check would otherwise reject every group reserve. Reserves and
             # transmission interfaces DO draw on devices/branches, so an empty map there is a real
             # misconfiguration. AGC is not modeled in POM, so it never reaches here.
-            if !(
-                service_type <:
-                Union{PSY.ConstantReserveGroup, PSY.ReserveDemandCurveGroup}
-            ) &&
+            if !(service_type <: PSY.ReserveGroup) &&
                isempty(get_contributing_devices_map(service_model, service_name))
                 error(
                     "Service \"$(service_name)\" of type $(typeof(service)) has no available contributing devices/branches. Assign available contributing devices/branches to it in the system data, or remove its service model from the template.",
@@ -324,7 +321,9 @@ function _add_services_to_device_model!(template::PowerOperationsProblemTemplate
     devices_template = get_device_models(template)
     for (service_key, service_model) in service_models
         S = get_component_type(service_model)
-        (S <: PSY.AGC || S <: PSY.ConstantReserveGroup) && continue
+        # Groups (`PSY.ReserveGroup`) aggregate services, not devices, so they are never attached
+        # to a device model; skip every group (and AGC, which POM does not model).
+        (S <: PSY.AGC || S <: PSY.ReserveGroup) && continue
         contributing_devices = get_contributing_devices(service_model)
         isempty(contributing_devices) && continue
         _modify_device_model!(devices_template, service_model, contributing_devices)

--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -53,7 +53,11 @@ function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.Res
     return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d, PSY.SU).max + PSY.get_input_active_power_limits(d, PSY.SU).max)
 end
 function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
-    return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d, PSY.SU).max + PSY.get_input_active_power_limits(d, PSY.SU).max)
+    # ReserveDemandCurve has no `max_output_fraction` field (unlike VariableReserve/ConstantReserve),
+    # so the full charge+discharge range is available - matching the AncillaryServiceVariableCharge/
+    # Discharge ReserveDemandCurve methods above.
+    return PSY.get_output_active_power_limits(d, PSY.SU).max +
+           PSY.get_input_active_power_limits(d, PSY.SU).max
 end
 
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Storage}, ::Type{<:PSY.Reserve}) = TotalReserveOffering
@@ -735,7 +739,11 @@ function add_to_expression!(
     variable = get_variable(container, U, V)
     for d in devices
         name = PSY.get_name(d)
-        expression = get_expression(container, T, UV, "$(V)_$(s_name)")
+        # Meta must match the creation site (line ~363) and every sibling lookup, which key on the
+        # concrete `typeof(service)`. For ReserveDemandCurve the ServiceModel type param `V` drops
+        # the unit-system parameter (`{ReserveDown}` vs `{ReserveDown, NaturalUnit}`), so keying on
+        # `V` here would miss the stored expression; key on the concrete service type.
+        expression = get_expression(container, T, UV, "$(typeof(service))_$(s_name)")
         for t in get_time_steps(container)
             add_proportional_to_jump_expression!(
                 expression[name, t],

--- a/src/hybrid_system_models/hybrid_systems.jl
+++ b/src/hybrid_system_models/hybrid_systems.jl
@@ -757,7 +757,10 @@ function add_to_expression!(
     variable = get_variable(container, U, V)
     for d in devices
         name = PSY.get_name(d)
-        expression = get_expression(container, T, UV, "$(V)_$(s_name)")
+        # Key on the concrete `typeof(service)` (as the creation site and every sibling lookup do):
+        # for ReserveDemandCurve the ServiceModel type param `V` drops the unit-system parameter,
+        # so keying on `V` would miss the stored expression.
+        expression = get_expression(container, T, UV, "$(typeof(service))_$(s_name)")
         for t in get_time_steps(container)
             add_proportional_to_jump_expression!(
                 expression[name, t],

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -72,10 +72,10 @@ end
 """
 The elastic group-stepwise balance: the sum of the contributing sub-services'
 `ActivePowerReserveVariable` awards must meet the group's endogenous `ServiceRequirementVariable`
-(priced by the ASDC in the objective). Same aggregation as [`GroupReserve`](@ref)
+(priced by the demand curve in the objective). Same aggregation as [`GroupReserve`](@ref)
 (`_group_member_variables`), but the RHS is the demand variable rather than a fixed requirement,
-so the market clears the group demand where the ASDC value meets the marginal sub-service supply.
-The constraint's dual is the single group MCPC.
+so the market clears the group demand where the demand-curve value meets the marginal sub-service
+supply. The constraint's dual is the single group clearing price.
 """
 function add_constraints!(
     container::OptimizationContainer,

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -68,6 +68,44 @@ function add_constraints!(
     return
 end
 
+################################ Group Stepwise (elastic) balance ##########################
+"""
+The elastic group-stepwise balance: the sum of the contributing sub-services'
+`ActivePowerReserveVariable` awards must meet the group's endogenous `ServiceRequirementVariable`
+(priced by the ASDC in the objective). Same aggregation as [`GroupReserve`](@ref)
+(`_group_member_variables`), but the RHS is the demand variable rather than a fixed requirement,
+so the market clears the group demand where the ASDC value meets the marginal sub-service supply.
+The constraint's dual is the single group MCPC.
+"""
+function add_constraints!(
+    container::OptimizationContainer,
+    ::Type{RequirementConstraint},
+    service::SR,
+    contributing_services::Vector{<:PSY.Service},
+    model::ServiceModel{SR, GroupStepwiseReserveCurve},
+) where {SR <: PSY.ReserveDemandCurveGroup}
+    time_steps = get_time_steps(container)
+    service_name = PSY.get_name(service)
+    constraint = get_constraint(container, RequirementConstraint, SR)
+    requirement_variable = get_variable(container, ServiceRequirementVariable, SR)
+    member_vars = _group_member_variables(container, contributing_services)
+
+    for t in time_steps
+        resource_expression = JuMP.GenericAffExpr{Float64, JuMP.VariableRef}()
+        for r in contributing_services
+            for var in get(member_vars, (PSY.get_name(r), t), JuMP.VariableRef[])
+                JuMP.add_to_expression!(resource_expression, var)
+            end
+        end
+        constraint[service_name, t] = JuMP.@constraint(
+            container.JuMPmodel,
+            resource_expression >= requirement_variable[service_name, t],
+        )
+    end
+
+    return
+end
+
 # Bucket the group's contributing reserve variables by `(service_name, time)` in one pass over
 # each contributing service's merged `(service_name, device_name, time)` container, so the
 # constraint loop above does keyed lookups instead of re-scanning the whole container per

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -19,9 +19,9 @@ get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.ReserveNonSpi
 
 ############################### ServiceRequirementVariable, ReserveDemandCurve ################################
 
-get_variable_binary(::Type{ServiceRequirementVariable}, ::Type{<:Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}}, ::Type{<:AbstractReservesFormulation}) = false
-get_variable_upper_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Component, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d, PSY.SU)
-get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::PSY.Component, ::Type{<:AbstractReservesFormulation}) = 0.0
+get_variable_binary(::Type{ServiceRequirementVariable}, ::Type{<:Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}}, ::Type{<:AbstractReservesFormulation}) = false
+get_variable_upper_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}, d::PSY.Component, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d, PSY.SU)
+get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}, ::PSY.Component, ::Type{<:AbstractReservesFormulation}) = 0.0
 
 # `VariableReserve` stores `requirement` as a dimensionless factor that scales its
 # requirement and needs an explicit unit system (PS6 made the reserve requirement
@@ -35,14 +35,17 @@ get_parameter_multiplier(::Type{<:VariableValueParameter}, d::Type{<:PSY.Abstrac
 get_initial_parameter_value(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 0.0
 
 objective_function_multiplier(::Type{ServiceRequirementVariable}, ::Type{StepwiseCostReserve}) = -1.0
+objective_function_multiplier(::Type{ServiceRequirementVariable}, ::Type{GroupStepwiseReserveCurve}) = -1.0
 uses_compact_power(::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::StepwiseCostReserve)=false
-get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::Type{<:AbstractReservesFormulation}) = 1.0
-get_multiplier_value(::Type{<:AbstractPiecewiseLinearSlopeParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::Type{<:AbstractReservesFormulation}) = 1.0
+uses_compact_power(::PSY.ReserveDemandCurveGroup, ::GroupStepwiseReserveCurve)=false
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}, ::Type{<:AbstractReservesFormulation}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearSlopeParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}, ::Type{<:AbstractReservesFormulation}) = 1.0
 # ORDC demand curves are willingness-to-pay (concave), i.e. a decremental offer.
 # Routes the reserve PWL cost path through IOM's OfferDirection dispatch; making
 # this incremental is a one-line change here. Mirrors `_onvar_offer_direction` /
-# `_vom_offer_direction` in market_bid_overrides.jl.
-_reserve_offer_direction(::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}) = IOM.DecrementalOffer()
+# `_vom_offer_direction` in market_bid_overrides.jl. ReserveDemandCurveGroup shares the same
+# decremental demand-curve pricing.
+_reserve_offer_direction(::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve, PSY.ReserveDemandCurveGroup}) = IOM.DecrementalOffer()
 #! format: on
 
 function get_initial_conditions_service_model(
@@ -56,6 +59,15 @@ function get_initial_conditions_service_model(
     ::IOM.AbstractOptimizationModel,
     ::ServiceModel{T, D},
 ) where {T <: PSY.VariableReserveNonSpinning, D <: AbstractReservesFormulation}
+    return ServiceModel(T, D)
+end
+
+# The group services (`<: Service`, not `<: PSY.Reserve`) carry no initial conditions, so the IC
+# service model is just a copy of themselves.
+function get_initial_conditions_service_model(
+    ::IOM.AbstractOptimizationModel,
+    ::ServiceModel{T, D},
+) where {T <: PSY.ReserveDemandCurveGroup, D <: AbstractReservesFormulation}
     return ServiceModel(T, D)
 end
 
@@ -98,6 +110,22 @@ function get_default_attributes(
     return Dict{String, Any}()
 end
 
+# ReserveDemandCurveGroup is `<: Service` (a group), not `<: Reserve`, so the generic reserve
+# defaults above do not cover it.
+function get_default_time_series_names(
+    ::Type{<:PSY.ReserveDemandCurveGroup},
+    ::Type{GroupStepwiseReserveCurve},
+)
+    return Dict{Type{<:TimeSeriesParameter}, String}()
+end
+
+function get_default_attributes(
+    ::Type{<:PSY.ReserveDemandCurveGroup},
+    ::Type{GroupStepwiseReserveCurve},
+)
+    return Dict{String, Any}()
+end
+
 """
 Add variables for ServiceRequirementVariable for StepWiseCostReserve
 """
@@ -108,7 +136,8 @@ function add_reserve_variables!(
     formulation,
 ) where {
     T <: ServiceRequirementVariable,
-    D <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    D <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
 }
     time_steps = get_time_steps(container)
     service_names = [PSY.get_name(s) for s in services]
@@ -563,6 +592,21 @@ function add_to_objective_function!(
     return
 end
 
+function add_to_objective_function!(
+    container::OptimizationContainer,
+    service::S,
+    ::ServiceModel{S, SR},
+) where {
+    S <: PSY.ReserveDemandCurveGroup,
+    SR <: GroupStepwiseReserveCurve,
+}
+    # The group's demand: price its ServiceRequirementVariable by the ASDC (a benefit, multiplier
+    # -1). No offer costs on the group itself - offers live on the contributing sub-services, which
+    # are priced by their own (RangeReserve) objective.
+    add_reserves_variable_cost!(container, ServiceRequirementVariable, service, SR)
+    return
+end
+
 # originally was add_variable_cost!, but I don't see other call sites besides the above.
 function add_reserves_variable_cost!(
     container::OptimizationContainer,
@@ -570,9 +614,10 @@ function add_reserves_variable_cost!(
     service::T,
     ::Type{V},
 ) where {
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve,
+        PSY.ReserveDemandCurveGroup},
     U <: VariableType,
-    V <: StepwiseCostReserve,
+    V <: Union{StepwiseCostReserve, GroupStepwiseReserveCurve},
 }
     _add_reserves_variable_cost_to_objective!(container, U, service, V)
     return
@@ -581,9 +626,9 @@ end
 function _add_reserves_variable_cost_to_objective!(
     container::OptimizationContainer,
     ::Type{T},
-    component::PSY.Reserve,
+    component::Union{PSY.Reserve, PSY.ReserveDemandCurveGroup},
     ::Type{U},
-) where {T <: VariableType, U <: StepwiseCostReserve}
+) where {T <: VariableType, U <: Union{StepwiseCostReserve, GroupStepwiseReserveCurve}}
     component_name = PSY.get_name(component)
     @debug "PWL Variable Cost" _group = LOG_GROUP_COST_FUNCTIONS component_name
     # If array is full of tuples with zeros return 0.0

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -581,7 +581,7 @@ function add_to_objective_function!(
     S <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
     SR <: StepwiseCostReserve,
 }
-    # Demand side: price the endogenous ServiceRequirementVariable by the (decremental) ORDC/ASDC
+    # Demand side: price the endogenous ServiceRequirementVariable by the (decremental) ORDC
     # demand curve. `objective_function_multiplier(ServiceRequirementVariable, StepwiseCostReserve)`
     # is -1, so this enters the objective as a benefit.
     add_reserves_variable_cost!(container, ServiceRequirementVariable, service, SR)
@@ -600,8 +600,9 @@ function add_to_objective_function!(
     S <: PSY.ReserveDemandCurveGroup,
     SR <: GroupStepwiseReserveCurve,
 }
-    # The group's demand: price its ServiceRequirementVariable by the ASDC (a benefit, multiplier
-    # -1). No offer costs on the group itself - offers live on the contributing sub-services, which
+    # The group's demand: price its ServiceRequirementVariable by the demand curve (a benefit,
+    # multiplier -1). No offer costs on the group itself - offers live on the contributing
+    # sub-services, which
     # are priced by their own (RangeReserve) objective.
     add_reserves_variable_cost!(container, ServiceRequirementVariable, service, SR)
     return

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -465,9 +465,9 @@ function _groups_with_subservices(model::ServiceModel, sys::PSY.System)
 end
 
 """
-    Constructs the elastic (ASDC-priced) group service `GroupStepwiseReserveCurve`.
+    Constructs the elastic (demand-curve-priced) group service `GroupStepwiseReserveCurve`.
 
-The group adds its own endogenous demand variable priced by the group ASDC, then binds the
+The group adds its own endogenous demand variable priced by the group demand curve, then binds the
 sum of the contributing sub-services' awards to that demand. It has no direct devices; the
 contributing services (and their `ActivePowerReserveVariable`) are constructed first because
 group formulations are deferred to the end of each stage.

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -30,10 +30,12 @@ function construct_services!(
     isempty(services_template) && return
     incompatible_device_types = get_incompatible_devices(devices_template)
 
-    groupservice = nothing
+    # Group formulations aggregate other services, so they must be constructed after the
+    # services they reference. Defer every group key to the end of the loop.
+    deferred_groups = Symbol[]
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # constructed last
-            groupservice = key
+        if _is_deferred_group_formulation(get_formulation(service_model))
+            push!(deferred_groups, key)
             continue
         end
         isempty(get_contributing_devices_map(service_model)) && continue
@@ -47,15 +49,17 @@ function construct_services!(
             network_model,
         )
     end
-    groupservice === nothing || construct_service!(
-        container,
-        sys,
-        stage,
-        services_template[groupservice],
-        devices_template,
-        incompatible_device_types,
-        network_model,
-    )
+    for key in deferred_groups
+        construct_service!(
+            container,
+            sys,
+            stage,
+            services_template[key],
+            devices_template,
+            incompatible_device_types,
+            network_model,
+        )
+    end
     return
 end
 
@@ -70,10 +74,10 @@ function construct_services!(
     isempty(services_template) && return
     incompatible_device_types = get_incompatible_devices(devices_template)
 
-    groupservice = nothing
+    deferred_groups = Symbol[]
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # constructed last
-            groupservice = key
+        if _is_deferred_group_formulation(get_formulation(service_model))
+            push!(deferred_groups, key)
             continue
         end
         isempty(get_contributing_devices_map(service_model)) && continue
@@ -87,17 +91,26 @@ function construct_services!(
             network_model,
         )
     end
-    groupservice === nothing || construct_service!(
-        container,
-        sys,
-        stage,
-        services_template[groupservice],
-        devices_template,
-        incompatible_device_types,
-        network_model,
-    )
+    for key in deferred_groups
+        construct_service!(
+            container,
+            sys,
+            stage,
+            services_template[key],
+            devices_template,
+            incompatible_device_types,
+            network_model,
+        )
+    end
     return
 end
+
+# Group formulations (`GroupReserve`, `GroupStepwiseReserveCurve`) aggregate the awards of
+# other contributing services, so they are constructed after every non-group service.
+_is_deferred_group_formulation(::Type{GroupReserve}) = true
+_is_deferred_group_formulation(::Type{GroupStepwiseReserveCurve}) = true
+# Catch-all for every other service formulation (reserves, transmission interfaces, ...).
+_is_deferred_group_formulation(::Type) = false
 
 function construct_service!(
     container::OptimizationContainer,
@@ -437,6 +450,83 @@ function construct_service!(
             contributing_services,
             model,
         )
+    end
+    add_constraint_dual!(container, sys, model)
+    return
+end
+
+# Collect the type's available groups that reference at least one contributing service.
+# The group is device-less, so `_services_with_contributors` (device-map filter) excludes it.
+function _groups_with_subservices(model::ServiceModel, sys::PSY.System)
+    return [
+        s for s in get_available_components(model, sys) if
+        !isempty(PSY.get_contributing_services(s))
+    ]
+end
+
+"""
+    Constructs the elastic (ASDC-priced) group service `GroupStepwiseReserveCurve`.
+
+The group adds its own endogenous demand variable priced by the group ASDC, then binds the
+sum of the contributing sub-services' awards to that demand. It has no direct devices; the
+contributing services (and their `ActivePowerReserveVariable`) are constructed first because
+group formulations are deferred to the end of each stage.
+"""
+function construct_service!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ArgumentConstructStage,
+    model::ServiceModel{SR, GroupStepwiseReserveCurve},
+    ::Dict{Symbol, DeviceModel},
+    ::Set{<:DataType},
+    ::NetworkModel{<:AbstractNetworkModel},
+) where {SR <: PSY.ReserveDemandCurveGroup}
+    groups = _groups_with_subservices(model, sys)
+    isempty(groups) && return
+    add_reserve_variables!(
+        container,
+        ServiceRequirementVariable,
+        groups,
+        GroupStepwiseReserveCurve(),
+    )
+    # Merged dense `(group, time)` cost-expression container, built once over all groups.
+    add_expressions!(container, ProductionCostExpression, groups, model)
+    for group in groups
+        # The group's supply is the sum of the contributing services' awards, which must
+        # already exist (groups are constructed last).
+        check_activeservice_variables(container, PSY.get_contributing_services(group))
+    end
+    return
+end
+
+function construct_service!(
+    container::OptimizationContainer,
+    sys::PSY.System,
+    ::ModelConstructStage,
+    model::ServiceModel{SR, GroupStepwiseReserveCurve},
+    ::Dict{Symbol, DeviceModel},
+    ::Set{<:DataType},
+    ::NetworkModel{<:AbstractNetworkModel},
+) where {SR <: PSY.ReserveDemandCurveGroup}
+    groups = _groups_with_subservices(model, sys)
+    isempty(groups) && return
+    # Dense group-indexed requirement container, built once over all groups of the type.
+    add_constraints_container!(
+        container,
+        RequirementConstraint,
+        SR,
+        PSY.get_name.(groups),
+        get_time_steps(container),
+    )
+    for group in groups
+        add_constraints!(
+            container,
+            RequirementConstraint,
+            group,
+            PSY.get_contributing_services(group),
+            model,
+        )
+        add_to_objective_function!(container, group, model)
     end
     add_constraint_dual!(container, sys, model)
     return

--- a/test/test_group_stepwise_reserve.jl
+++ b/test/test_group_stepwise_reserve.jl
@@ -1,0 +1,190 @@
+# GroupStepwiseReserveCurve: a group Ancillary Service Demand Curve (ASDC) whose single elastic
+# demand is met by the awards of several contributing sub-services. This is the ERCOT RTC+B
+# pattern where one product (e.g. RRS) has one demand curve but several sub-types (PFR, FFR, UFR)
+# that each carry their own per-resource offers and per-resource caps.
+#
+# The group (`PSY.ReserveDemandCurveGroup`, `<: Service`) adds ONE `ServiceRequirementVariable`
+# priced by the group ASDC (a decremental benefit), and ONE `RequirementConstraint` binding the
+# sum of the contributing sub-services' `ActivePowerReserveVariable` awards to that demand. The
+# sub-services themselves are ordinary `RangeReserve` reserves with no own demand (requirement 0)
+# whose awards are priced by their per-resource offers. So supply merit order lives on the
+# sub-services and the single clearing (one MCPC) lives on the group.
+
+# Add both RRS sub-services to every thermal, then give each thermal a MarketBidCost (keeping its
+# own energy offer) plus a flat per-hour reserve offer into each sub-service: PFR cheap, FFR
+# pricey. Reading the energy slope from the ORIGINAL cost before overwriting keeps a single cost
+# overwrite per device.
+function _setup_group_reserve_offers!(
+    sys,
+    pfr,
+    ffr;
+    pfr_price = 5.0,
+    ffr_price = 9.0e5,
+    init_times = [DateTime("2024-01-01T00:00:00"), DateTime("2024-01-02T00:00:00")],
+    horizon = 24,
+    resolution = Hour(1),
+)
+    flat_offer(price) = IS.PiecewiseStepData([0.0, 100.0], [price])
+    flat_ts(reserve, price) = Deterministic(
+        PSY.get_name(reserve),
+        Dict(it => [flat_offer(price) for _ in 1:horizon] for it in init_times),
+        resolution,
+    )
+    for g in get_components(ThermalStandard, sys)
+        pmax = PSY.get_max_active_power(g, PSY.NU)
+        energy_slope = PSY.get_proportional_term(
+            PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))),
+        )
+        set_operation_cost!(
+            g,
+            MarketBidCost(;
+                no_load_cost = LinearCurve(0.0),
+                start_up = (hot = 0.0, warm = 0.0, cold = 0.0),
+                shut_down = LinearCurve(0.0),
+                incremental_offer_curves = make_market_bid_curve(
+                    [0.0, pmax], [energy_slope], 0.0; power_units = IS.NaturalUnit(),
+                ),
+            ),
+        )
+        PSY.set_service_bid!(sys, g, pfr, flat_ts(pfr, pfr_price), IS.NaturalUnit())
+        PSY.set_service_bid!(sys, g, ffr, flat_ts(ffr, ffr_price), IS.NaturalUnit())
+    end
+    return
+end
+
+# Build a self-contained system: c_sys5_uc thermals + two RRS sub-services (ConstantReserve, no
+# own demand) offered by every thermal, plus one group ASDC over both. PFR is cheap ($5/MWh) and
+# FFR is prohibitively pricey, so the elastic group demand clears through PFR, not FFR.
+function build_group_reserve_system(; pfr_price = 5.0, ffr_price = 9.0e5)
+    sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
+    thermals = collect(get_components(ThermalStandard, sys))
+    # ConstantReserve{ReserveUp}(name, available, time_frame, requirement): requirement 0 -> the
+    # sub-service imposes no demand; procurement is driven only by the group.
+    pfr = ConstantReserve{ReserveUp}("RRS_PFR", true, 3600.0, 0.0)
+    ffr = ConstantReserve{ReserveUp}("RRS_FFR", true, 3600.0, 0.0)
+    add_service!(sys, pfr, thermals)
+    add_service!(sys, ffr, thermals)
+    _setup_group_reserve_offers!(
+        sys,
+        pfr,
+        ffr;
+        pfr_price = pfr_price,
+        ffr_price = ffr_price,
+    )
+    # ASDC: first 40 MW valued $80/MWh, next 40 MW $10/MWh; both above the cheap PFR offer, so the
+    # group procures reserve where the ASDC price meets the marginal (PFR) supply.
+    asdc = make_market_bid_curve(
+        [0.0, 40.0, 80.0], [80.0, 10.0], 0.0; power_units = IS.NaturalUnit(),
+    )
+    group = ReserveDemandCurveGroup{ReserveUp}(;
+        variable = asdc,
+        name = "RRS",
+        available = true,
+        time_frame = 5.0,
+    )
+    add_service!(sys, group, Service[pfr, ffr])
+    return sys, pfr, ffr, group
+end
+
+function _group_reserve_template(; include_group = true)
+    template = get_thermal_standard_uc_template()
+    set_service_model!(template, ServiceModel(ConstantReserve{ReserveUp}, RangeReserve))
+    if include_group
+        set_service_model!(
+            template,
+            ServiceModel(ReserveDemandCurveGroup{ReserveUp}, GroupStepwiseReserveCurve),
+        )
+    end
+    return template
+end
+
+_sub_cols(df, prefix) = [c for c in names(df) if startswith(c, prefix)]
+
+@testset "GroupStepwiseReserveCurve: builds, solves, single group clearing constraint" begin
+    sys, pfr, ffr, group = build_group_reserve_system()
+    model = DecisionModel(_group_reserve_template(), sys; optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    container = get_optimization_container(model)
+    # The group owns exactly one endogenous demand variable and one clearing constraint (the
+    # single MCPC-bearing balance), keyed by the concrete group service type.
+    @test IOM.has_container_key(container, ServiceRequirementVariable, typeof(group))
+    @test IOM.has_container_key(container, POM.RequirementConstraint, typeof(group))
+
+    res = IOM.OptimizationProblemOutputs(model)
+    demand = read_variable(
+        res, "ServiceRequirementVariable__ReserveDemandCurveGroup__ReserveUp";
+        table_format = TableFormat.WIDE)
+    # One group -> one demand column ("RRS"); the sub-services carry no demand variable of their own.
+    @test setdiff(names(demand), ["DateTime"]) == ["RRS"]
+end
+
+@testset "GroupStepwiseReserveCurve: aggregation binds sub-service awards to group demand" begin
+    sys, pfr, ffr, group = build_group_reserve_system()
+    model = DecisionModel(_group_reserve_template(), sys; optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    res = IOM.OptimizationProblemOutputs(model)
+    awards = read_variable(
+        res, "ActivePowerReserveVariable__ConstantReserve__ReserveUp";
+        table_format = TableFormat.WIDE)
+    demand = read_variable(
+        res, "ServiceRequirementVariable__ReserveDemandCurveGroup__ReserveUp";
+        table_format = TableFormat.WIDE)
+    # WIDE columns are "<service>__<device>"; values are per-hour awards in MW (both variables
+    # convert to natural units on read, so the balance holds in MW).
+    sub_cols = [_sub_cols(awards, "RRS_PFR__"); _sub_cols(awards, "RRS_FFR__")]
+    @test !isempty(sub_cols)
+    for t in 1:24
+        subtotal = sum(awards[t, c] for c in sub_cols)
+        @test subtotal ≈ demand[t, "RRS"] atol = 1e-3
+    end
+end
+
+@testset "GroupStepwiseReserveCurve: sub-service merit order (cheap PFR clears, pricey FFR does not)" begin
+    sys, pfr, ffr, group = build_group_reserve_system()
+    model = DecisionModel(_group_reserve_template(), sys; optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    res = IOM.OptimizationProblemOutputs(model)
+    awards = read_variable(
+        res, "ActivePowerReserveVariable__ConstantReserve__ReserveUp";
+        table_format = TableFormat.WIDE)
+    pfr_cols = _sub_cols(awards, "RRS_PFR__")
+    ffr_cols = _sub_cols(awards, "RRS_FFR__")
+    pfr_total = sum(awards[1, c] for c in pfr_cols)
+    ffr_total = sum(awards[1, c] for c in ffr_cols)
+    # The group demand is met by the cheap sub-service; the prohibitively priced sub-service
+    # clears essentially nothing even though both sub-services share the same devices and caps.
+    @test pfr_total > 1.0
+    @test ffr_total <= 1e-2
+    @test pfr_total > ffr_total
+end
+
+@testset "GroupStepwiseReserveCurve: no group -> no procurement (group is the demand driver)" begin
+    # Same system, but the group is left OUT of the template. The sub-services have requirement 0
+    # and costly offers, so with no group demand the model procures no reserve at all - confirming
+    # the group ASDC is what drives sub-service procurement.
+    sys, pfr, ffr, group = build_group_reserve_system()
+    model = DecisionModel(
+        _group_reserve_template(; include_group = false), sys;
+        optimizer = HiGHS_optimizer)
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    res = IOM.OptimizationProblemOutputs(model)
+    awards = read_variable(
+        res, "ActivePowerReserveVariable__ConstantReserve__ReserveUp";
+        table_format = TableFormat.WIDE)
+    sub_cols = [_sub_cols(awards, "RRS_PFR__"); _sub_cols(awards, "RRS_FFR__")]
+    for t in 1:24, c in sub_cols
+        @test awards[t, c] <= 1e-2
+    end
+end

--- a/test/test_group_stepwise_reserve.jl
+++ b/test/test_group_stepwise_reserve.jl
@@ -1,14 +1,13 @@
-# GroupStepwiseReserveCurve: a group Ancillary Service Demand Curve (ASDC) whose single elastic
-# demand is met by the awards of several contributing sub-services. This is the ERCOT RTC+B
-# pattern where one product (e.g. RRS) has one demand curve but several sub-types (PFR, FFR, UFR)
-# that each carry their own per-resource offers and per-resource caps.
+# GroupStepwiseReserveCurve: a group with a single elastic demand curve whose demand is met by the
+# awards of several contributing sub-services - one product with one demand curve but several
+# sub-type services (here PFR/FFR/UFR), each carrying its own per-resource offers and caps.
 #
 # The group (`PSY.ReserveDemandCurveGroup`, `<: Service`) adds ONE `ServiceRequirementVariable`
-# priced by the group ASDC (a decremental benefit), and ONE `RequirementConstraint` binding the
-# sum of the contributing sub-services' `ActivePowerReserveVariable` awards to that demand. The
+# priced by the group demand curve (a decremental benefit), and ONE `RequirementConstraint` binding
+# the sum of the contributing sub-services' `ActivePowerReserveVariable` awards to that demand. The
 # sub-services themselves are ordinary `RangeReserve` reserves with no own demand (requirement 0)
 # whose awards are priced by their per-resource offers. So supply merit order lives on the
-# sub-services and the single clearing (one MCPC) lives on the group.
+# sub-services and the single clearing (one clearing price) lives on the group.
 
 # Add both RRS sub-services to every thermal, then give each thermal a MarketBidCost (keeping its
 # own energy offer) plus a flat per-hour reserve offer into each sub-service: PFR cheap, FFR
@@ -53,7 +52,7 @@ function _setup_group_reserve_offers!(
 end
 
 # Build a self-contained system: c_sys5_uc thermals + two RRS sub-services (ConstantReserve, no
-# own demand) offered by every thermal, plus one group ASDC over both. PFR is cheap ($5/MWh) and
+# own demand) offered by every thermal, plus one group demand curve over both. PFR is cheap ($5/MWh) and
 # FFR is prohibitively pricey, so the elastic group demand clears through PFR, not FFR.
 function build_group_reserve_system(; pfr_price = 5.0, ffr_price = 9.0e5)
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
@@ -71,8 +70,8 @@ function build_group_reserve_system(; pfr_price = 5.0, ffr_price = 9.0e5)
         pfr_price = pfr_price,
         ffr_price = ffr_price,
     )
-    # ASDC: first 40 MW valued $80/MWh, next 40 MW $10/MWh; both above the cheap PFR offer, so the
-    # group procures reserve where the ASDC price meets the marginal (PFR) supply.
+    # demand curve: first 40 MW valued $80/MWh, next 40 MW $10/MWh; both above the cheap PFR offer,
+    # so the group procures reserve where the demand-curve price meets the marginal (PFR) supply.
     asdc = make_market_bid_curve(
         [0.0, 40.0, 80.0], [80.0, 10.0], 0.0; power_units = IS.NaturalUnit(),
     )
@@ -109,7 +108,7 @@ _sub_cols(df, prefix) = [c for c in names(df) if startswith(c, prefix)]
 
     container = get_optimization_container(model)
     # The group owns exactly one endogenous demand variable and one clearing constraint (the
-    # single MCPC-bearing balance), keyed by the concrete group service type.
+    # single clearing balance), keyed by the concrete group service type.
     @test IOM.has_container_key(container, ServiceRequirementVariable, typeof(group))
     @test IOM.has_container_key(container, POM.RequirementConstraint, typeof(group))
 
@@ -170,7 +169,7 @@ end
 @testset "GroupStepwiseReserveCurve: no group -> no procurement (group is the demand driver)" begin
     # Same system, but the group is left OUT of the template. The sub-services have requirement 0
     # and costly offers, so with no group demand the model procures no reserve at all - confirming
-    # the group ASDC is what drives sub-service procurement.
+    # the group demand curve is what drives sub-service procurement.
     sys, pfr, ffr, group = build_group_reserve_system()
     model = DecisionModel(
         _group_reserve_template(; include_group = false), sys;


### PR DESCRIPTION
## Summary

Adds `GroupStepwiseReserveCurve`, a reserve formulation that composes `GroupReserve` aggregation with `StepwiseCostReserve` demand pricing. It models an elastic group Ancillary Service Demand Curve (ASDC) whose single demand is met by the awards of several contributing sub-services - e.g. one RRS product cleared over PFR/FFR/UFR sub-types.

A `ReserveDemandCurveGroup` service (new PSY struct, on the local psy6 branch) adds:
- one endogenous `ServiceRequirementVariable`, priced by the group ASDC (a decremental benefit), and
- one `RequirementConstraint` binding the sum of the contributing sub-services' `ActivePowerReserveVariable` awards to that demand.

So supply merit order lives on the sub-services (their per-resource offers) and the single clearing (one MCPC) lives on the group.

## Changes

- `GroupStepwiseReserveCurve` formulation type + export.
- Elastic aggregation constraint (`reserve_group.jl`) - same `_group_member_variables` aggregation as `GroupReserve`, RHS is the demand variable rather than a fixed requirement.
- Group two-stage `construct_service!` + a `_is_deferred_group_formulation` dispatcher so group formulations construct after their sub-services.
- Widen the reserve cost/expression/offer chain (`add_reserves_variable_cost!`, `add_expressions!`, `add_to_expression!`, `add_pwl_term_delta!`, `get_offer_curves`) and the problem-template contributing-device check to the group, which is a `Service` (not a `Reserve`).
- Storage/hybrid reserve meta-key fixes (key on the concrete `typeof(service)` so the unit-system type parameter is not dropped) and the `ReserveDemandCurve` storage upper-bound fix.

## Testing

New self-contained `test/test_group_stepwise_reserve.jl` on `c_sys5_uc`: builds + solves, asserts a single demand variable / single clearing constraint, the aggregation balance holds every hour, cheap sub-service clears while the pricey one does not, and a no-group regression procures nothing. `Test.detect_ambiguities` clean; existing `test_device_reserve_offers` and `test_services_constructor` still pass.

## Notes for review

- Depends on the local psy6 `ReserveDemandCurveGroup` struct (not yet merged); the `[sources]` PowerSystems path override is a local dev-only change and is intentionally NOT part of this branch.
- Draft while the load-side reserve work proceeds on a separate branch.