### PR TITLE
Support time-varying ORDC (ReserveDemandTimeSeriesCurve) via transform

### DIFF
--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -559,9 +559,15 @@ calc_additional_axes(
 #################################################################################
 
 function get_max_tranches(component::PSY.Component, piecewise_ts::IS.TimeSeriesKey)
-    data = PSY.get_data(PSY.get_time_series(component, piecewise_ts))
-    return IOM.get_max_tranches(data)
+    return IOM.get_max_tranches(_ordc_ts_data(PSY.get_time_series(component, piecewise_ts)))
 end
+
+# A real `Deterministic` exposes its windows via `get_data`. The `transform_single_time_series!`
+# product (`DeterministicSingleTimeSeries`) has no `get_data`, but its wrapped `SingleTimeSeries`
+# holds the same per-hour curves as a `TimeArray`, which `IOM.get_max_tranches` also accepts.
+_ordc_ts_data(ts) = PSY.get_data(ts)
+_ordc_ts_data(ts::IS.DeterministicSingleTimeSeries) =
+    PSY.get_data(IS.get_single_time_series(ts))
 
 # Batch form (mirrors the device methods below): size the tranche axis to the largest tranche
 # count across the type's services; shorter per-hour curves are padded in `unwrap_for_param`.

--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -41,11 +41,11 @@ function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::
     return PSY.get_max_output_fraction(r) * PSY.get_output_active_power_limits(d, PSY.SU).max
 end
 
-function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
+function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_input_active_power_limits(d, PSY.SU).max
 end
 
-function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::PSY.ReserveDemandCurve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
+function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_output_active_power_limits(d, PSY.SU).max
 end
 

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1479,3 +1479,69 @@ end
 # Hydro reserves (`HydroTurbineEnergyDispatch` absent), the old bare-`TimeSeriesKey` ORDC
 # tests (the current PowerSystems model uses `ReserveDemandTimeSeriesCurve`; covered by the two ORDC testsets above),
 # and all Simulation-orchestration testsets (Simulation framework absent in the IOM/POM split).
+
+# Time-varying ORDC support when the curve is attached as a `SingleTimeSeries` and materialized by
+# `transform_single_time_series!` (the ORDC testsets above attach a direct `Deterministic` with
+# thermal contributors, so neither path below is otherwise covered):
+#   (a) `StorageDispatchWithReserves` reserve bounds must accept `ReserveDemandTimeSeriesCurve`
+#       (only `ReserveDemandCurve` was specialized, so a storage contributor fell through to the
+#       generic method's `get_max_output_fraction`, which the demand curves lack).
+#   (b) `get_max_tranches` must handle the `DeterministicSingleTimeSeries` produced by transform
+#       (which has no `get_data`).
+
+@testset "StorageDispatchWithReserves reserve bound accepts ReserveDemandTimeSeriesCurve" begin
+    sys = PSB.build_system(PSITestSystems, "c_sys5_bat")
+    storage = first(get_components(PSY.EnergyReservoirStorage, sys))
+    ordc_ts = ReserveDemandTimeSeriesCurve{ReserveUp}(
+        stub_ts_offer_curve(; power_units = PSY.SU), "ORDC_TS", true, 1.0)
+    # Full input/output range (no get_max_output_fraction), exactly as for a static ReserveDemandCurve.
+    @test POM.get_variable_upper_bound(
+        POM.AncillaryServiceVariableDischarge, ordc_ts, storage,
+        POM.StorageDispatchWithReserves) ==
+          PSY.get_output_active_power_limits(storage, PSY.SU).max
+    @test POM.get_variable_upper_bound(
+        POM.AncillaryServiceVariableCharge, ordc_ts, storage,
+        POM.StorageDispatchWithReserves) ==
+          PSY.get_input_active_power_limits(storage, PSY.SU).max
+end
+
+@testset "get_max_tranches handles the transform product (DeterministicSingleTimeSeries)" begin
+    sys = PSB.build_system(PSITestSystems, "c_sys5_bat"; add_reserves = true)
+    it = first(PSY.get_forecast_initial_times(sys))
+    res = first(PSY.get_time_series_resolutions(sys))
+    n = IS.get_horizon_count(PSY.get_forecast_horizon(sys), res)
+    times = collect(range(it; step = res, length = n))
+
+    # Per-hour demand curves with alternating tranche counts (2 and 3); max tranches = 3.
+    two = IS.PiecewiseStepData([0.0, 100.0, 200.0], [50.0, 30.0])
+    three = IS.PiecewiseStepData([0.0, 100.0, 200.0, 300.0], [50.0, 30.0, 10.0])
+    curves = [isodd(k) ? three : two for k in 1:n]
+
+    ordc_ts = ReserveDemandTimeSeriesCurve{ReserveUp}(
+        stub_ts_offer_curve(; power_units = IS.NaturalUnit()), "ORDC_TS", true, 1.0)
+    add_service!(sys, ordc_ts, get_components(PSY.EnergyReservoirStorage, sys))
+    add_time_series!(sys, ordc_ts,
+        IS.SingleTimeSeries(;
+            name = "variable_cost",
+            data = IS.TimeSeries.TimeArray(times, curves),
+        ))
+    key = IS.ForecastKey(; time_series_type = IS.Deterministic, name = "variable_cost",
+        initial_timestamp = it, resolution = res,
+        horizon = PSY.get_forecast_horizon(sys),
+        interval = PSY.get_forecast_interval(sys),
+        count = PSY.get_forecast_window_count(sys),
+        features = Dict{String, Any}())
+    PSY.set_variable!(ordc_ts,
+        PSY.make_market_bid_ts_curve(key, nothing, IS.NaturalUnit()))
+
+    transform_single_time_series!(sys, PSY.get_forecast_horizon(sys),
+        PSY.get_forecast_interval(sys); delete_existing = false)
+
+    resolved =
+        PSY.get_time_series(ordc_ts, IS.get_time_series_key(PSY.get_variable(ordc_ts)))
+    @test resolved isa IS.DeterministicSingleTimeSeries      # the case that broke get_data
+    @test POM.get_max_tranches(
+        ordc_ts,
+        IS.get_time_series_key(PSY.get_variable(ordc_ts)),
+    ) == 3
+end


### PR DESCRIPTION
## Summary

Fixes two gaps that prevented a **time-varying ORDC** (`ReserveDemandTimeSeriesCurve`) from building when its curve is attached as a `SingleTimeSeries` and materialized by `transform_single_time_series!` (the attach-then-transform pattern data builders use). The existing ORDC-TS tests attach a *direct* `Deterministic` with thermal contributors, so neither path below was exercised.

## Changes

- **`energy_storage_models/storage_models.jl`** — widen the `AncillaryServiceVariable{Charge,Discharge}` storage reserve upper bounds from `ReserveDemandCurve` to `Union{ReserveDemandCurve, ReserveDemandTimeSeriesCurve}`. These specializations exist to return the full input/output range and **avoid** the generic `PSY.Reserve` method's `get_max_output_fraction(r)` call, which the demand curves have no field for. A storage contributor to a `ReserveDemandTimeSeriesCurve` previously fell through to the generic method and hit `MethodError: get_max_output_fraction(::ReserveDemandTimeSeriesCurve)`. This mirrors the `ActivePowerReserveVariable` method directly below, which already unions both.

- **`common_models/add_parameters.jl`** — `get_max_tranches` called `get_data` on the forecast, but the `transform_single_time_series!` product (`DeterministicSingleTimeSeries`) has no `get_data`. Unwrap it to its wrapped `SingleTimeSeries`, whose `get_data` returns a `TimeArray` that `IOM.get_max_tranches` already accepts.

- **`test/test_patch_ordc_ts.jl`** — regression test: the storage reserve bound resolves for a `ReserveDemandTimeSeriesCurve`, and `get_max_tranches` handles the `DeterministicSingleTimeSeries` produced by transform (the test asserts the resolved series is that type — the exact case that broke `get_data`).

## Testing

- New test passes; `Test.detect_ambiguities(PowerOperationsModels) == 0`; formatter clean.
- Both fixes were also validated end-to-end in a downstream one-bus build (transform-based per-hour ASDC with a storage contributor builds and solves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
