### PR TITLE
Add PSY-style docs workflow concurrency guard.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,9 +8,12 @@ on:
     tags: '*'
   pull_request:
 
+# Prevent simultaneous gh-pages deployments (tag + branch race condition).
+# PR previews each get their own group and cancel on new pushes.
+# All other deploys (main, tags) share one group and queue instead of cancel.
 concurrency:
-  group: docs-deploy
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.event.pull_request.number) || 'docs-deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
PR previews get their own cancelable group; main and tag deploys share docs-deploy and queue instead of canceling.
