### PR TITLE
Disable reserve code referencing PSY types removed on psy6

### DIFF
--- a/src/core/problem_template.jl
+++ b/src/core/problem_template.jl
@@ -251,8 +251,9 @@ function _populate_contributing_devices!(
             # A reserve or interface with no available provider can never meet its requirement,
             # so error rather than let it silently force slacks or go infeasible.
             # ConstantReserveGroup aggregates other services, so its empty map is by design.
-            if !(service_type <: PSY.ConstantReserveGroup) &&
-               isempty(get_contributing_devices_map(service_model, service_name))
+            # PSY6-PORT-DISABLED: PSY.ConstantReserveGroup removed on jd/schema_matching
+            # (dropped from this condition; original: `!(service_type <: PSY.ConstantReserveGroup) &&`)
+            if isempty(get_contributing_devices_map(service_model, service_name))
                 error(
                     "Service \"$(service_name)\" of type $(typeof(service)) has no available contributing devices/branches. Assign available contributing devices/branches to it in the system data, or remove its service model from the template.",
                 )
@@ -283,6 +284,8 @@ function _modify_device_model!(
     return
 end
 
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+#=
 function _modify_device_model!(
     ::Dict{Symbol, DeviceModel},
     ::ServiceModel{<:PSY.ReserveNonSpinning, <:AbstractReservesFormulation},
@@ -290,6 +293,7 @@ function _modify_device_model!(
 )
     return
 end
+=#
 
 function _modify_device_model!(
     ::Dict{Symbol, DeviceModel},
@@ -312,7 +316,9 @@ function _add_services_to_device_model!(template::PowerOperationsProblemTemplate
     devices_template = get_device_models(template)
     for (service_key, service_model) in service_models
         S = get_component_type(service_model)
-        (S <: PSY.AGC || S <: PSY.ConstantReserveGroup) && continue
+        # PSY6-PORT-DISABLED: PSY.ConstantReserveGroup removed on jd/schema_matching
+        # (dropped from this disjunction; original: `S <: PSY.AGC || S <: PSY.ConstantReserveGroup`)
+        S <: PSY.AGC && continue
         contributing_devices = get_contributing_devices(service_model)
         isempty(contributing_devices) && continue
         _modify_device_model!(devices_template, service_model, contributing_devices)

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -1,3 +1,5 @@
+# PSY6-PORT-DISABLED: PSY.ConstantReserveGroup removed on jd/schema_matching
+#=
 function get_default_time_series_names(
     ::Type{PSY.ConstantReserveGroup{T}},
     ::Type{GroupReserve}) where {T <: PSY.ReserveDirection}
@@ -9,6 +11,7 @@ function get_default_attributes(
     ::Type{GroupReserve}) where {T <: PSY.ReserveDirection}
     return Dict{String, Any}()
 end
+=#
 
 ############################### Reserve Variables` #########################################
 """
@@ -32,6 +35,8 @@ function check_activeservice_variables(
 end
 
 ################################## Reserve Requirement Constraint ##########################
+# PSY6-PORT-DISABLED: PSY.ConstantReserveGroup removed on jd/schema_matching
+#=
 """
 This function creates the requirement constraint that will be attained by the appropriate services
 """
@@ -65,6 +70,7 @@ function add_constraints!(
 
     return
 end
+=#
 
 # Collect the group's contributing reserve variables into one bucket per time step, so the
 # constraint loop above indexes straight in rather than re-scanning per `(group, t)`. Services

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -11,11 +11,14 @@ get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::Union{PSY.Reserv
 get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.Reserve, ::PSY.Device, ::Type) = 0.0
 
 ############################### ActivePowerReserveVariable, ReserveNonSpinning #########################################
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+#=
 get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ReserveNonSpinning}, ::Type{<:AbstractReservesFormulation}) = false
 function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.ReserveNonSpinning, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_max_active_power(d, PSY.SU)
 end
 get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.ReserveNonSpinning, ::PSY.Device, ::Type) = 0.0
+=#
 
 ############################### ServiceRequirementVariable, ReserveDemandCurve ################################
 
@@ -29,7 +32,8 @@ get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.Reserve
 _get_requirement(service) = PSY.get_requirement(service, PSY.SU)
 
 get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.Reserve, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
-get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.ReserveNonSpinning, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+# get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.ReserveNonSpinning, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
 
 get_parameter_multiplier(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 1.0
 get_initial_parameter_value(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 0.0
@@ -53,12 +57,15 @@ function get_initial_conditions_service_model(
     return ServiceModel(T, D)
 end
 
+# PSY6-PORT-DISABLED: PSY.VariableReserveNonSpinning removed on jd/schema_matching
+#=
 function get_initial_conditions_service_model(
     ::IOM.AbstractOptimizationModel,
     ::ServiceModel{T, D},
 ) where {T <: PSY.VariableReserveNonSpinning, D <: AbstractReservesFormulation}
     return ServiceModel(T, D)
 end
+=#
 
 function get_default_time_series_names(
     ::Type{<:PSY.Reserve},
@@ -69,6 +76,8 @@ function get_default_time_series_names(
     )
 end
 
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+#=
 function get_default_time_series_names(
     ::Type{<:PSY.ReserveNonSpinning},
     ::Type{NonSpinningReserve},
@@ -77,6 +86,7 @@ function get_default_time_series_names(
         RequirementTimeSeriesParameter => "requirement",
     )
 end
+=#
 
 function get_default_time_series_names(
     ::Type{T},
@@ -92,12 +102,15 @@ function get_default_attributes(
     return Dict{String, Any}()
 end
 
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+#=
 function get_default_attributes(
     ::Type{<:PSY.ReserveNonSpinning},
     ::Type{<:AbstractReservesFormulation},
 )
     return Dict{String, Any}()
 end
+=#
 
 """
 Add variables for ServiceRequirementVariable for StepWiseCostReserve
@@ -268,6 +281,8 @@ function add_constraints!(
     return
 end
 
+# PSY6-PORT-DISABLED: PSY.ConstantReserve removed on jd/schema_matching
+#=
 function add_constraints!(
     container::OptimizationContainer,
     T::Type{RequirementConstraint},
@@ -302,6 +317,7 @@ function add_constraints!(
 
     return
 end
+=#
 
 function add_to_objective_function!(
     container::OptimizationContainer,
@@ -461,6 +477,8 @@ function add_constraints!(
     return
 end
 
+# PSY6-PORT-DISABLED: PSY.VariableReserveNonSpinning removed on jd/schema_matching
+#=
 function add_constraints!(
     container::OptimizationContainer,
     T::Type{ReservePowerConstraint},
@@ -510,6 +528,7 @@ function add_constraints!(
     end
     return
 end
+=#
 
 function _add_reserve_power_constraint_device!(
     cons,
@@ -658,7 +677,9 @@ function add_reserves_proportional_cost!(
     contributing_names::Vector{String};
     skip_devices = Set{String}(),
 ) where {
-    T <: Union{PSY.Reserve, PSY.ReserveNonSpinning},
+    # PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+    # (dropped from this Union; original: `T <: Union{PSY.Reserve, PSY.ReserveNonSpinning}`)
+    T <: PSY.Reserve,
     U <: ActivePowerReserveVariable,
     V <: AbstractReservesFormulation,
 }

--- a/src/services_models/service_slacks.jl
+++ b/src/services_models/service_slacks.jl
@@ -1,8 +1,10 @@
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+# (dropped from this Union; original: `T <: Union{PSY.Reserve, PSY.ReserveNonSpinning}`)
 function add_reserve_slacks!(
     container::OptimizationContainer,
     ::Type{T},
     service_names::Vector{String},
-) where {T <: Union{PSY.Reserve, PSY.ReserveNonSpinning}}
+) where {T <: PSY.Reserve}
     time_steps = get_time_steps(container)
     # Dense 2D container keyed `[service_name, time]`, built once per service type over all
     # the type's services (`use_slacks` is per type). Lower bound 0, penalty in objective.

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -132,6 +132,8 @@ function construct_service!(
     return
 end
 
+# PSY6-PORT-DISABLED: PSY.ConstantReserve removed on jd/schema_matching
+#=
 # ConstantReserve has no requirement time series, so its argument stage skips the
 # parameter add. The model stage is the shared `SR <: PSY.AbstractReserve` method below.
 function construct_service!(
@@ -165,6 +167,7 @@ function construct_service!(
     end
     return
 end
+=#
 
 # Shared RangeReserve model stage for both `PSY.Reserve` and `PSY.ConstantReserve`;
 # the inner `add_constraints!` calls resolve per service type.
@@ -390,6 +393,8 @@ function construct_service!(
 end
 =#
 
+# PSY6-PORT-DISABLED: PSY.ConstantReserveGroup removed on jd/schema_matching
+#=
 """
     Constructs a service for ConstantReserveGroup.
 """
@@ -441,6 +446,7 @@ function construct_service!(
     add_constraint_dual!(container, sys, model)
     return
 end
+=#
 
 function construct_service!(
     container::OptimizationContainer,
@@ -520,6 +526,8 @@ function construct_service!(
     return
 end
 
+# PSY6-PORT-DISABLED: PSY.ReserveNonSpinning removed on jd/schema_matching
+#=
 function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -596,6 +604,7 @@ function construct_service!(
     add_constraint_dual!(container, sys, model)
     return
 end
+=#
 
 function construct_service!(
     container::OptimizationContainer,


### PR DESCRIPTION
`PowerOperationsModels` does not load against the psy6 line of `PowerSystems`:

```
UndefVarError: `ReserveNonSpinning` not defined in `PowerSystems`
```

The psy6 reserve rework replaced `ConstantReserve`, `ConstantReserveGroup`, `ReserveNonSpinning` and `VariableReserveNonSpinning` with `OnlineReserve`, `OfflineReserve` and `GroupReserve`. POM still dispatches on the old names, so the module fails at precompile and nothing downstream can be built or solved.

This comments out every path referencing the four removed types so the package loads again. Each site is marked `PSY6-PORT-DISABLED:` with the symbol that went away, and where a clause was dropped from a condition or a `Union` the original expression is quoted, so the port back is mechanical.

**This is deliberately the minimum needed to compile, not a port.** Reserve modelling on psy6 is unimplemented until the new semantics are wired up — that is the follow-up.

### One behaviour change beyond commenting out

The empty-contributing-devices guard in `_populate_contributing_devices!` previously excepted `ConstantReserveGroup`, whose empty map was by design. With that type gone the guard now applies to every service type. No currently existing type is affected, but a future group-reserve type will need the exception restored.

### Not addressed here

The test suite still references the removed types, so `Pkg.test()` does not run. Only `using PowerOperationsModels` is fixed. `ext/PowerFlowsExt` needed no changes — it already loads.

### Verification

Against `PowerSystems` `jd/schema_matching` (`a82cf5329`), an RTS-GMLC unit commitment parsed by `PowerTableDataParser` builds and solves:

| network | branches | objective |
|---|---|---|
| CopperPlate | — | 1.1872448e6 |
| PTDF | `StaticBranch` | 1.1930662e6 |
| PTDF | `StaticBranchBounds` | 1.1927738e6 |

Zero balance slacks, 0.0 MW hourly supply-demand residual, peak branch utilisation 100% under PTDF.