### PR TITLE
Migrate services to the psy6 reserve tree (OnlineReserve/OfflineReserve/GroupReserve)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/site/
 Manifest.toml
 .vscode
 *.h5
+.claude/plans
 
 ################################################################################
 #                              Operating systems                               #

--- a/docs/src/reference/formulation_library.md
+++ b/docs/src/reference/formulation_library.md
@@ -518,20 +518,20 @@ no-op.
 |:------------------------------------------------------ |:--------------------------- |:---------------------------------------------------------------------------------------------- |:---------------------------------------------------------- |
 | `RangeReserve`                                         | `PSY.Reserve`               | `RequirementTimeSeriesParameter` (omitted for `ConstantReserve`), `ActivePowerReserveVariable` | `RequirementConstraint`, `ParticipationFractionConstraint` |
 | `RampReserve`                                          | `PSY.Reserve`               | as above                                                                                       | as above **+ `RampConstraint`**                            |
-| `NonSpinningReserve`                                   | `PSY.ReserveNonSpinning`    | as above, but **no** device-range expression wiring                                            | as above **+ `ReservePowerConstraint`**                    |
+| `NonSpinningReserve`                                   | `PSY.OfflineReserve`        | as above, but **no** device-range expression wiring                                            | as above **+ `ReservePowerConstraint`**                    |
 | `StepwiseCostReserve` (operating reserve demand curve) | `PSY.Reserve`               | `ServiceRequirementVariable` + demand-curve slope/breakpoint parameters                        | `RequirementConstraint` only — no participation constraint |
-| `GroupReserve`                                         | `PSY.ConstantReserveGroup`  | no variables                                                                                   | `RequirementConstraint` across contributing services       |
+| `GroupRangeReserve`                                    | `PSY.GroupReserve`          | no variables                                                                                   | `RequirementConstraint` across contributing services       |
 | `ConstantMaxInterfaceFlow`                             | `PSY.TransmissionInterface` | optional slacks, `InterfaceTotalFlow` expression                                               | `InterfaceFlowLimit` (`"ub"`/`"lb"`)                       |
 | `VariableMaxInterfaceFlow`                             | `PSY.TransmissionInterface` | as above **+ min/max flow-limit parameters**                                                   | as above, with parameterized limits                        |
 
-`GroupReserve` is deliberately constructed **last** in both stages, because it aggregates the other
+`GroupRangeReserve` is deliberately constructed **last** in both stages, because it aggregates the other
 services' variables.
 
-!!! warning "GroupReserve does not support slacks"
+!!! warning "GroupRangeReserve does not support slacks"
     
-    `GroupReserve`'s requirement-constraint builder reads a `slack_vars` binding that is never
+    `GroupRangeReserve`'s requirement-constraint builder reads a `slack_vars` binding that is never
     created, so a `ServiceModel` with `use_slacks = true` raises `UndefVarError`. A group reserve
-    also cannot currently be built end to end: a `ConstantReserveGroup` aggregates services rather
+    also cannot currently be built end to end: a `PSY.GroupReserve` aggregates services rather
     than devices, so its contributing-device list is empty and construction errors out before the
     requirement constraint is reached.
 

--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -19,7 +19,7 @@ import ProgressMeter
 import Serialization
 import SparseArrays
 import TimerOutputs
-import InteractiveUtils: methodswith
+import InteractiveUtils: methodswith, subtypes
 
 using DocStringExtensions
 using JSON3
@@ -915,7 +915,7 @@ export VoltageDispatchHVDCNetworkModel
 export AbstractServiceFormulation
 export AbstractReservesFormulation
 export PIDSmoothACE
-export GroupReserve
+export GroupRangeReserve
 export RangeReserve
 export StepwiseCostReserve
 export RampReserve

--- a/src/common_models/add_expressions.jl
+++ b/src/common_models/add_expressions.jl
@@ -203,7 +203,7 @@ function add_expressions!(
 ) where {
     T <: ExpressionType,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
-    V <: PSY.Reserve,
+    V <: PSY.AbstractReserve,
     W <: AbstractReservesFormulation,
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)
@@ -221,7 +221,7 @@ end
 Cost-expression container for reserve services, e.g. `ProductionCostExpression` for an
 operating reserve demand curve: one dense `(service_name, time)` container per service type,
 the same shape as the device `ProductionCostExpression`. Read and written by
-`add_to_expression!(container, ::CostExpressions, cost, ::ReserveDemand*, t)`.
+`add_to_expression!(container, ::CostExpressions, cost, ::AbstractReserve, t)`.
 """
 function add_expressions!(
     container::OptimizationContainer,
@@ -231,7 +231,7 @@ function add_expressions!(
 ) where {
     T <: CostExpressions,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
-    V <: PSY.Reserve,
+    V <: PSY.AbstractReserve,
     W <: AbstractReservesFormulation,
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)

--- a/src/common_models/add_parameters.jl
+++ b/src/common_models/add_parameters.jl
@@ -33,13 +33,24 @@ end
 
 # Per-type service time-series parameter: all services of the type share one container
 # keyed `(ParameterType, ServiceType)`, axed by service name.
+#
+# `U` is decoupled from the model's component type `V`: a `ServiceModel` can be declared with a
+# partially applied type, e.g. `OnlineReserve{ReserveDown}` (a `UnionAll` with a free unit-system
+# parameter), while the vector holds concrete `OnlineReserve{ReserveDown, NaturalUnit}` instances.
+# `Vector` is invariant, so no single type variable can bind both. Container keys are unaffected
+# (`canonical_component_type` strips the unit parameter).
 function add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
     services::Vector{U},
-    model::ServiceModel{U, V},
-) where {T <: TimeSeriesParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
-    if get_rebuild_model(get_settings(container)) && has_container_key(container, T, U)
+    model::ServiceModel{V, W},
+) where {
+    T <: TimeSeriesParameter,
+    U <: PSY.Service,
+    V <: PSY.Service,
+    W <: AbstractServiceFormulation,
+}
+    if get_rebuild_model(get_settings(container)) && has_container_key(container, T, V)
         return
     end
     _add_parameters!(container, T, services, model)
@@ -48,6 +59,7 @@ end
 
 # Per-type operating reserve demand curve (ORDC) PWL cost params: all the type's services
 # share one container (names axis + tranche axis).
+# Element type decoupled from the `ServiceModel`'s component type; see `add_parameters!` above.
 function add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
@@ -58,8 +70,8 @@ function add_parameters!(
         AbstractPiecewiseLinearSlopeParameter,
         AbstractPiecewiseLinearBreakpointParameter,
     },
-    U <: PSY.ReserveDemandTimeSeriesCurve,
-    V <: PSY.ReserveDemandTimeSeriesCurve,
+    U <: PSY.AbstractReserve,
+    V <: PSY.AbstractReserve,
     W <: AbstractServiceFormulation,
 }
     if get_rebuild_model(get_settings(container)) && has_container_key(container, T, U)
@@ -412,7 +424,7 @@ _get_time_series_name(
             DecrementalPiecewiseLinearBreakpointParameter,
         },
     },
-    service::PSY.ReserveDemandTimeSeriesCurve,
+    service::PSY.AbstractReserve,
     ::ServiceModel,
 ) = IS.get_name(IS.get_time_series_key(PSY.get_variable(service)))
 
@@ -543,14 +555,14 @@ calc_additional_axes(
     W <: AbstractDeviceFormulation,
 } where {D <: PSY.Component} = ()
 
+# Element type decoupled from the `ServiceModel`'s component type; see `add_parameters!` above.
 calc_additional_axes(
     ::OptimizationContainer,
     ::Type{T},
-    ::U,
+    ::Union{Vector{<:PSY.Service}, IS.FlattenIteratorWrapper{<:PSY.Service}},
     ::ServiceModel{D, W},
 ) where {
     T <: ParameterType,
-    U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
     W <: AbstractServiceFormulation,
 } where {D <: PSY.Service} = ()
 
@@ -572,15 +584,14 @@ _ordc_ts_data(ts::IS.DeterministicSingleTimeSeries) =
 # Batch form (mirrors the device methods below): size the tranche axis to the largest tranche
 # count across the type's services; shorter per-hour curves are padded in `unwrap_for_param`.
 #
-# `services` is typed `Vector{<:ReserveDemandTimeSeriesCurve}` rather than tied to the
-# `ServiceModel`'s component type, because that type can be partially applied (e.g.
-# `ReserveDemandCurve` without its reserve-direction parameter) and `Vector` is invariant, so a
-# vector of the concrete service instances would not match `Vector{D}`.
+# Element type decoupled from the `ServiceModel`'s component type; see `add_parameters!` above.
+# Only time-series-backed ORDCs reach here (the caller filters on `_ordc_is_ts`), so the
+# `get_time_series_key`/`get_max_tranches` reads are valid.
 function calc_additional_axes(
     ::OptimizationContainer,
     ::Type{P},
-    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
-    ::ServiceModel{<:PSY.ReserveDemandTimeSeriesCurve, W},
+    services::Vector{<:PSY.AbstractReserve},
+    ::ServiceModel{<:PSY.AbstractReserve, W},
 ) where {
     P <: AbstractPiecewiseLinearSlopeParameter,
     W <: AbstractServiceFormulation,
@@ -594,8 +605,8 @@ end
 function calc_additional_axes(
     ::OptimizationContainer,
     ::Type{P},
-    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
-    ::ServiceModel{<:PSY.ReserveDemandTimeSeriesCurve, W},
+    services::Vector{<:PSY.AbstractReserve},
+    ::ServiceModel{<:PSY.AbstractReserve, W},
 ) where {
     P <: AbstractPiecewiseLinearBreakpointParameter,
     W <: AbstractServiceFormulation,
@@ -785,6 +796,7 @@ end
 # Same cost-parameter machinery as the device path: batch all the type's services into one
 # container (names axis + tranche axis), the tranche axis sized to the batch-wide maximum via
 # `calc_additional_axes`. Read back name-keyed by the delta-PWL machinery.
+# Element type decoupled from the `ServiceModel`'s component type; see `add_parameters!` above.
 #################################################################################
 
 function _add_parameters!(
@@ -797,8 +809,8 @@ function _add_parameters!(
         AbstractPiecewiseLinearSlopeParameter,
         AbstractPiecewiseLinearBreakpointParameter,
     },
-    U <: PSY.ReserveDemandTimeSeriesCurve,
-    V <: PSY.ReserveDemandTimeSeriesCurve,
+    U <: PSY.AbstractReserve,
+    V <: PSY.AbstractReserve,
     W <: AbstractServiceFormulation,
 }
     _add_objective_function_parameters!(container, T, services, model, W)
@@ -808,13 +820,18 @@ end
 #################################################################################
 # _add_parameters! for ServiceModel TimeSeriesParameter
 #################################################################################
-
+# Element type decoupled from the `ServiceModel`'s component type; see `add_parameters!` above.
 function _add_parameters!(
     container::OptimizationContainer,
     ::Type{T},
     services::Vector{U},
-    model::ServiceModel{U, V},
-) where {T <: TimeSeriesParameter, U <: PSY.Service, V <: AbstractServiceFormulation}
+    model::ServiceModel{V, W},
+) where {
+    T <: TimeSeriesParameter,
+    U <: PSY.Service,
+    V <: PSY.Service,
+    W <: AbstractServiceFormulation,
+}
     ts_type = get_default_time_series_type(container)
     if !(ts_type <: Union{PSY.AbstractDeterministic, PSY.StaticTimeSeries})
         error("add_parameters! for TimeSeriesParameter is not compatible with $ts_type")
@@ -857,8 +874,11 @@ function _add_parameters!(
 
     uuid_axis = collect(keys(initial_values))
     additional_axes = calc_additional_axes(container, T, services, model)
+    # Key the container by the MODEL's component type `V`, not the element type `U`: readers
+    # fetch with `SR` from the `ServiceModel`, and the two diverge when the model is declared
+    # with a broader type (e.g. `ServiceModel{OnlineReserve, ...}` covering both directions).
     parameter_container = add_param_container!(container, T,
-        U,
+        V,
         ts_type,
         ts_name,
         uuid_axis,
@@ -882,7 +902,7 @@ function _add_parameters!(
     end
     for (i, service) in enumerate(services)
         name = names[i]
-        IOM._set_multiplier_at!(parent_mult, get_multiplier_value(T, service, V), i)
+        IOM._set_multiplier_at!(parent_mult, get_multiplier_value(T, service, W), i)
         IOM.add_component_name!(attributes, name, service_ts_uuids[name])
     end
     return

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -1987,7 +1987,9 @@ function add_to_expression!(
     T <: ActivePowerRangeExpressionUB,
     U <: VariableType,
     V <: PSY.Component,
-    X <: PSY.Reserve{PSY.ReserveUp},
+    # OfflineReserve (non-spin) is upward-only and has no direction param, so it routes to the
+    # same upper-bound expression as a ReserveUp reserve.
+    X <: Union{PSY.Reserve{PSY.ReserveUp}, PSY.OfflineReserve},
     W <: AbstractReservesFormulation,
 }
     service_name = PSY.get_name(service)
@@ -2485,7 +2487,7 @@ function add_to_expression!(
     service::V,
     model::ServiceModel{V, W},
     devices_template::Dict{Symbol, DeviceModel},
-) where {U <: VariableType, V <: PSY.Reserve, W <: AbstractReservesFormulation}
+) where {U <: VariableType, V <: PSY.AbstractReserve, W <: AbstractReservesFormulation}
     contributing_devices_map = get_contributing_devices_map(model, PSY.get_name(service))
     for (device_type, devices) in contributing_devices_map
         device_model = get(devices_template, Symbol(device_type), nothing)
@@ -2656,7 +2658,7 @@ function add_cost_to_expression!(
     time_period::Int,
 ) where {
     S <: CostExpressions,
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: PSY.AbstractReserve,
 }
     if has_container_key(container, S, T, PSY.get_name(component))
         device_cost_expression = get_expression(container, S, T, PSY.get_name(component))
@@ -2985,7 +2987,7 @@ function add_to_expression!(
     time_period::Int,
 ) where {
     S <: CostExpressions,
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: PSY.AbstractReserve,
 }
     if has_container_key(container, S, T)
         device_cost_expression = get_expression(container, S, T)

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -2490,7 +2490,10 @@ function add_to_expression!(
 ) where {U <: VariableType, V <: PSY.AbstractReserve, W <: AbstractReservesFormulation}
     contributing_devices_map = get_contributing_devices_map(model, PSY.get_name(service))
     for (device_type, devices) in contributing_devices_map
-        device_model = get(devices_template, Symbol(device_type), nothing)
+        # Template keys are `nameof(D)` (IOM `set_model!`). `Symbol(T)` would qualify the
+        # name whenever the type is not visible from Main (every parallel test worker),
+        # silently skipping the whole service-device wiring on a key miss.
+        device_model = get(devices_template, nameof(device_type), nothing)
         device_model === nothing && continue
         expression_type = get_expression_type_for_reserve(U, device_type, V)
         add_to_expression!(container, expression_type, U, service, devices, model)

--- a/src/common_models/market_bid_overrides.jl
+++ b/src/common_models/market_bid_overrides.jl
@@ -334,12 +334,12 @@ _vom_offer_direction(::Type{<:AbstractControllablePowerLoadFormulation}) =
     DecrementalOffer()
 
 #################################################################################
-# Section 7: Service-specific PWL (ReserveDemandCurve, StepwiseCostReserve)
+# Section 7: Service-specific PWL (ORDC on a reserve, StepwiseCostReserve)
 #################################################################################
 
 """
 Add the delta PWL objective terms for an operating reserve demand curve (ORDC) service
-(`StepwiseCostReserve` over `ReserveDemandCurve` / `ReserveDemandTimeSeriesCurve`).
+(`StepwiseCostReserve` over an `OnlineReserve`/`OfflineReserve` carrying a demand curve).
 """
 function add_pwl_term_delta!(
     container::OptimizationContainer,
@@ -348,7 +348,7 @@ function add_pwl_term_delta!(
     ::Type{U},
     ::Type{V},
 ) where {
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: PSY.AbstractReserve,
     U <: VariableType,
     V <: AbstractServiceFormulation,
 }

--- a/src/common_models/market_bid_plumbing.jl
+++ b/src/common_models/market_bid_plumbing.jl
@@ -110,7 +110,7 @@ get_offer_curves(::IOM.IncrementalOffer, op_cost::PSY.OfferCurveCost) =
 # service-side direction trait (`_reserve_offer_direction`) is decremental.
 get_offer_curves(
     ::IOM.OfferDirection,
-    service::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    service::PSY.AbstractReserve,
 ) = PSY.get_variable(service)
 
 #################################################################################

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -229,8 +229,8 @@ For more information check [Service Formulations](@ref service_formulations).
 The constraint is as follows:
 
 ```math
-r_{d,t} \\le \\text{Req} \\cdot \\text{PF} ,\\quad \\forall d\\in \\mathcal{D}_s, \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(for a ConstantReserve)} \\\\
-r_{d,t} \\le \\text{RequirementTimeSeriesParameter}_{t} \\cdot \\text{PF}\\quad  \\forall d\\in \\mathcal{D}_s, \\forall t\\in \\{1,\\dots, T\\}, \\quad \\text{(for a VariableReserve)}
+r_{d,t} \\le \\text{Req} \\cdot \\text{PF} ,\\quad \\forall d\\in \\mathcal{D}_s, \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(static requirement)} \\\\
+r_{d,t} \\le \\text{RequirementTimeSeriesParameter}_{t} \\cdot \\text{PF}\\quad  \\forall d\\in \\mathcal{D}_s, \\forall t\\in \\{1,\\dots, T\\}, \\quad \\text{(time-varying requirement)}
 ```
 """
 struct ParticipationFractionConstraint <: ConstraintType end
@@ -307,8 +307,8 @@ For more information check [Service Formulations](@ref service_formulations).
 The constraint is as follows:
 
 ```math
-\\sum_{d\\in\\mathcal{D}_s} r_{d,t} + r_t^\\text{sl} \\ge \\text{Req},\\quad \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(for a ConstantReserve)} \\\\
-\\sum_{d\\in\\mathcal{D}_s} r_{d,t} + r_t^\\text{sl} \\ge \\text{RequirementTimeSeriesParameter}_{t},\\quad \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(for a VariableReserve)}
+\\sum_{d\\in\\mathcal{D}_s} r_{d,t} + r_t^\\text{sl} \\ge \\text{Req},\\quad \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(static requirement)} \\\\
+\\sum_{d\\in\\mathcal{D}_s} r_{d,t} + r_t^\\text{sl} \\ge \\text{RequirementTimeSeriesParameter}_{t},\\quad \\forall t\\in \\{1,\\dots, T\\} \\quad \\text{(time-varying requirement)}
 ```
 """
 struct RequirementConstraint <: ConstraintType end

--- a/src/core/formulations.jl
+++ b/src/core/formulations.jl
@@ -430,9 +430,11 @@ abstract type AbstractAGCFormulation <: AbstractServiceFormulation end
 struct PIDSmoothACE <: AbstractAGCFormulation end
 
 """
-Struct to add reserves to be larger than a specified requirement for an aggregated collection of services
+Group analogue of [`RangeReserve`](@ref): the awards of a `PSY.GroupReserve`'s contributing services
+must together meet the group's specified requirement. Not named `GroupReserve` to avoid clashing
+with the `PSY.GroupReserve` component type.
 """
-struct GroupReserve <: AbstractReservesFormulation end
+struct GroupRangeReserve <: AbstractReservesFormulation end
 
 """
 Struct for to add reserves to be larger than a specified requirement

--- a/src/core/problem_template.jl
+++ b/src/core/problem_template.jl
@@ -250,7 +250,8 @@ function _populate_contributing_devices!(
             end
             # A reserve or interface with no available provider can never meet its requirement,
             # so error rather than let it silently force slacks or go infeasible.
-            # GroupReserve aggregates other services, so its empty map is by design.
+            # GroupReserve aggregates other SERVICES: it is a deviceless `AbstractReserve`,
+            # so its empty device map is by design - do not "simplify" this exemption away.
             if !(service_type <: PSY.GroupReserve) &&
                isempty(get_contributing_devices_map(service_model, service_name))
                 error(

--- a/src/core/problem_template.jl
+++ b/src/core/problem_template.jl
@@ -56,7 +56,7 @@ get_hvdc_network_model(template::PowerOperationsProblemTemplate) =
 
 # Returns `Vector{Type}`, not `Vector{DataType}`: a service's component type can be a
 # `UnionAll` rather than a concrete `DataType` when it carries an unapplied type parameter
-# (e.g. `ReserveDemandCurve{ReserveUp}`, which still has a free parameter).
+# (e.g. `OnlineReserve{ReserveUp}`, which still has a free unit-system parameter).
 function get_component_types(template::PowerOperationsProblemTemplate)::Vector{Type}
     return vcat(
         get_component_type.(values(get_device_models(template))),
@@ -234,7 +234,7 @@ function _populate_contributing_devices!(
         for service in get_available_components(service_model, sys)
             service_name = PSY.get_name(service)
             # Key by the concrete service instance type: the model's stored type can be a
-            # `UnionAll` (e.g. `ReserveDemandCurve{ReserveUp}` with a free parameter), while
+            # `UnionAll` (e.g. `OnlineReserve{ReserveUp}` with a free unit-system parameter), while
             # `get_contributing_device_mapping` keys by `typeof(service)`.
             service_devices_key = (type = typeof(service), name = service_name)
             if haskey(services_mapping, service_devices_key)
@@ -250,8 +250,8 @@ function _populate_contributing_devices!(
             end
             # A reserve or interface with no available provider can never meet its requirement,
             # so error rather than let it silently force slacks or go infeasible.
-            # ConstantReserveGroup aggregates other services, so its empty map is by design.
-            if !(service_type <: PSY.ConstantReserveGroup) &&
+            # GroupReserve aggregates other services, so its empty map is by design.
+            if !(service_type <: PSY.GroupReserve) &&
                isempty(get_contributing_devices_map(service_model, service_name))
                 error(
                     "Service \"$(service_name)\" of type $(typeof(service)) has no available contributing devices/branches. Assign available contributing devices/branches to it in the system data, or remove its service model from the template.",
@@ -285,7 +285,7 @@ end
 
 function _modify_device_model!(
     ::Dict{Symbol, DeviceModel},
-    ::ServiceModel{<:PSY.ReserveNonSpinning, <:AbstractReservesFormulation},
+    ::ServiceModel{<:PSY.OfflineReserve, <:AbstractReservesFormulation},
     ::Vector{<:PSY.Component},
 )
     return
@@ -312,7 +312,7 @@ function _add_services_to_device_model!(template::PowerOperationsProblemTemplate
     devices_template = get_device_models(template)
     for (service_key, service_model) in service_models
         S = get_component_type(service_model)
-        (S <: PSY.AGC || S <: PSY.ConstantReserveGroup) && continue
+        (S <: PSY.AGC || S <: PSY.GroupReserve) && continue
         contributing_devices = get_contributing_devices(service_model)
         isempty(contributing_devices) && continue
         _modify_device_model!(devices_template, service_model, contributing_devices)

--- a/src/core/reserve_traits.jl
+++ b/src/core/reserve_traits.jl
@@ -9,9 +9,9 @@ Trait axis selecting how a reserve contribution is scaled into an aggregation:
 `deployed_fraction`).
 """
 abstract type ReserveScale end
-"Reserve aggregation that uses the raw multiplier (1.0). Was Total / Assignment."
+"Reserve aggregation that uses the raw multiplier (1.0)."
 struct UnscaledReserve <: ReserveScale end
-"Reserve aggregation that scales the multiplier by deployed_fraction. Was Served / Deployment."
+"Reserve aggregation that scales the multiplier by `deployed_fraction`."
 struct DeployedReserve <: ReserveScale end
 
 """
@@ -19,7 +19,59 @@ Trait axis selecting which side of a storage device or hybrid PCC a reserve vari
 on: [`DischargeSide`](@ref) (outflow) or [`ChargeSide`](@ref) (inflow).
 """
 abstract type ReserveSide end
-"Discharge / outflow side of a storage or hybrid PCC. Was Out (PCC) / Discharge (storage)."
+"Discharge / outflow side of a storage or hybrid PCC."
 struct DischargeSide <: ReserveSide end
-"Charge / inflow side of a storage or hybrid PCC. Was In (PCC) / Charge (storage)."
+"Charge / inflow side of a storage or hybrid PCC."
 struct ChargeSide <: ReserveSide end
+
+# ── Reserve-type predicate helpers ────────────────────────────────────────────────────
+# The reserve tree distinguishes reserves by state (direction parameter, demand curve,
+# attached series) rather than by struct type; these centralize that branch logic in one
+# dispatch-based place (no `isa`).
+
+"""
+Direction of a reserve. `OfflineReserve` (non-spinning) has no direction type parameter and is
+upward-only in every US market, so it maps to [`PSY.ReserveUp`](@ref).
+"""
+_reserve_direction(::PSY.Reserve{T}) where {T <: PSY.ReserveDirection} = T
+_reserve_direction(::PSY.OfflineReserve) = PSY.ReserveUp
+
+"Whether a reserve is non-spinning: `OfflineReserve` vs everything else under `AbstractReserve`."
+_is_offline(::PSY.OfflineReserve) = true
+_is_offline(::PSY.AbstractReserve) = false
+
+"""
+Whether a reserve's `requirement` is scaled by an attached requirement time series.
+
+Resolves the series name from the `ServiceModel`'s `time_series_names` (a user can override the
+name there), and deliberately does not pin the series' concrete `TimeSeriesData` type
+(`Deterministic` in recurrent solves, `SingleTimeSeries` otherwise). Returns `false` when the
+model declares no requirement series name (the formulation carries no requirement parameter).
+"""
+function _has_ts_requirement(model::ServiceModel, s::PSY.AbstractReserve)
+    ts_names = get_time_series_names(model)
+    haskey(ts_names, RequirementTimeSeriesParameter) || return false
+    return PSY.has_time_series(s; name = ts_names[RequirementTimeSeriesParameter])
+end
+
+# ── ORDC (operating-reserve-demand-curve) predicates ─────────────────────────────────
+# A demand curve lives on a reserve's `variable` field ("is this an ORDC" is
+# `PSY.has_demand_curve`), so "static vs time-varying" is a runtime inspection of the curve
+# (union-splits cleanly over the two `variable` members; reserves are few and read at build,
+# so the cost is negligible).
+
+"Whether a reserve's ORDC curve is time-varying. Dispatches on the value-curve type (no `isa`)."
+_ordc_is_ts(s::PSY.AbstractReserve) =
+    _value_curve_is_ts(PSY.get_value_curve(PSY.get_variable(s)))
+_value_curve_is_ts(::PSY.TimeSeriesPiecewiseIncrementalCurve) = true
+_value_curve_is_ts(::PSY.PiecewiseIncrementalCurve) = false
+
+"""
+Meta string identifying one service inside the device-side reserve containers
+(ancillary-service variables, `TotalReserveOffering` expressions, coverage constraints).
+Always derive it from the service INSTANCE: a `ServiceModel`'s type parameter can be
+partially applied (`OnlineReserve{ReserveUp}`, a `UnionAll`) while the containers are
+written with the fully concrete instance type, and the two spellings do not match.
+"""
+_service_container_meta(service::PSY.Service) =
+    "$(typeof(service))_$(PSY.get_name(service))"

--- a/src/energy_storage_models/storage_constructor.jl
+++ b/src/energy_storage_models/storage_constructor.jl
@@ -58,7 +58,7 @@ function _add_ancillary_services!(
             T,
             PSY.get_name.(devices),
             time_steps;
-            meta = "$(typeof(s))_$(PSY.get_name(s))",
+            meta = _service_container_meta(s),
         )
     end
 

--- a/src/energy_storage_models/storage_models.jl
+++ b/src/energy_storage_models/storage_models.jl
@@ -33,30 +33,21 @@ get_variable_binary(::Type{ReservationVariable}, ::Type{<:PSY.Storage}, ::Type{<
 get_variable_binary(::Type{AncillaryServiceVariableDischarge}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
 get_variable_binary(::Type{AncillaryServiceVariableCharge}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
 
-function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
+# One method per bound over every AbstractReserve (online + offline). The demand-curve types were
+# removed, so ORDC reserves now use these capped bounds too.
+function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::PSY.AbstractReserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_input_active_power_limits(d, PSY.SU).max
 end
 
-function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
+function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::PSY.AbstractReserve, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_output_active_power_limits(d, PSY.SU).max
 end
 
-function get_variable_upper_bound(::Type{AncillaryServiceVariableCharge}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
-    return PSY.get_input_active_power_limits(d, PSY.SU).max
-end
-
-function get_variable_upper_bound(::Type{AncillaryServiceVariableDischarge}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractStorageFormulation})
-    return PSY.get_output_active_power_limits(d, PSY.SU).max
-end
-
-function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.Reserve, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
-    return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d, PSY.SU).max + PSY.get_input_active_power_limits(d, PSY.SU).max)
-end
-function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.AbstractReserve, d::PSY.Storage, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * (PSY.get_output_active_power_limits(d, PSY.SU).max + PSY.get_input_active_power_limits(d, PSY.SU).max)
 end
 
-get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Storage}, ::Type{<:PSY.Reserve}) = TotalReserveOffering
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Storage}, ::Type{<:PSY.AbstractReserve}) = TotalReserveOffering
 
 ############### Energy Targets Variables #############
 get_variable_binary(::Type{StorageEnergyShortageVariable}, ::Type{<:PSY.Storage}, ::Type{<:AbstractStorageFormulation}) = false
@@ -356,7 +347,7 @@ function add_variables!(
             U,
             PSY.get_name.(devices),
             time_steps;
-            meta = "$(typeof(service))_$(PSY.get_name(service))",
+            meta = _service_container_meta(service),
         )
 
         for d in devices, t in time_steps
@@ -639,7 +630,7 @@ function add_to_expression!(
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
+            variable = get_variable(container, U, V, _service_container_meta(s))
             mult = get_variable_multiplier(U, T, d, W, s) * get_fraction(T, s)
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
@@ -672,7 +663,7 @@ function add_to_expression!(
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
+            variable = get_variable(container, U, V, _service_container_meta(s))
             mult = get_variable_multiplier(U, T, d, W, s) * get_fraction(T, s)
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
@@ -703,8 +694,8 @@ function add_to_expression!(
         services = PSY.get_services(d)
         for s in services
             s_name = PSY.get_name(s)
-            expression = get_expression(container, T, V, "$(typeof(s))_$(s_name)")
-            variable = get_variable(container, U, V, "$(typeof(s))_$s_name")
+            expression = get_expression(container, T, V, _service_container_meta(s))
+            variable = get_variable(container, U, V, _service_container_meta(s))
             for t in get_time_steps(container)
                 add_proportional_to_jump_expression!(
                     expression[name, t],
@@ -735,7 +726,7 @@ function add_to_expression!(
     variable = get_variable(container, U, V)
     for d in devices
         name = PSY.get_name(d)
-        expression = get_expression(container, T, UV, "$(V)_$(s_name)")
+        expression = get_expression(container, T, UV, _service_container_meta(service))
         for t in get_time_steps(container)
             add_proportional_to_jump_expression!(
                 expression[name, t],
@@ -990,14 +981,14 @@ function add_constraints!(
                 V,
                 names,
                 time_steps;
-                meta = "$(typeof(service))_$(service_name)_discharge",
+                meta = "$(_service_container_meta(service))_discharge",
             )
         elseif typeof(service) <: PSY.Reserve{PSY.ReserveDown}
             add_constraints_container!(container, T,
                 V,
                 names,
                 time_steps;
-                meta = "$(typeof(service))_$(service_name)_charge",
+                meta = "$(_service_container_meta(service))_charge",
             )
         end
     end
@@ -1024,18 +1015,18 @@ function add_constraints!(
             reserve_var_discharge =
                 get_variable(container, AncillaryServiceVariableDischarge,
                     V,
-                    "$(typeof(service))_$service_name",
+                    _service_container_meta(service),
                 )
             reserve_var_charge = get_variable(container, AncillaryServiceVariableCharge,
                 V,
-                "$(typeof(service))_$service_name",
+                _service_container_meta(service),
             )
             if typeof(service) <: PSY.Reserve{PSY.ReserveUp}
                 con_discharge = get_constraint(
                     container,
                     T(),
                     V,
-                    "$(typeof(service))_$(service_name)_discharge",
+                    "$(_service_container_meta(service))_discharge",
                 )
 
                 if time_offset(T) == -1
@@ -1065,7 +1056,7 @@ function add_constraints!(
                     container,
                     T(),
                     V,
-                    "$(typeof(service))_$(service_name)_charge",
+                    "$(_service_container_meta(service))_charge",
                 )
                 if time_offset(T) == -1
                     con_charge[ci_name, 1] = JuMP.@constraint(
@@ -1168,11 +1159,11 @@ function add_constraints!(
             reserve_var_discharge =
                 get_variable(container, AncillaryServiceVariableDischarge,
                     V,
-                    "$(typeof(service))_$service_name",
+                    _service_container_meta(service),
                 )
             reserve_var_charge = get_variable(container, AncillaryServiceVariableCharge,
                 V,
-                "$(typeof(service))_$service_name",
+                _service_container_meta(service),
             )
             if typeof(service) <: PSY.Reserve{PSY.ReserveUp}
                 push!(
@@ -1275,7 +1266,7 @@ function add_constraints!(
         s_name = PSY.get_name(s)
         expression = get_expression(container, TotalReserveOffering,
             V,
-            "$(typeof(s))_$(s_name)",
+            _service_container_meta(s),
         )
         device_names, time_steps = axes(expression)
         constraint_container =

--- a/src/hybrid_system_models/hybrid_systems.jl
+++ b/src/hybrid_system_models/hybrid_systems.jl
@@ -431,16 +431,17 @@ get_variable_multiplier(
 ) = 1.0
 
 # When the system-side ActivePowerReserveVariable is added by the service constructor for a HybridSystem,
-# direct it into the TotalReserveOffering channel keyed by HybridSystem (mirrors POM storage line 59).
+# direct it into the TotalReserveOffering channel keyed by HybridSystem (mirrors POM storage).
 get_expression_type_for_reserve(
     ::Type{ActivePowerReserveVariable},
     ::Type{<:PSY.HybridSystem},
-    ::Type{<:PSY.Reserve},
+    ::Type{<:PSY.AbstractReserve},
 ) = TotalReserveOffering
 
+# One capped bound over every AbstractReserve (online + offline).
 function get_variable_upper_bound(
     ::Type{ActivePowerReserveVariable},
-    r::PSY.Reserve,
+    r::PSY.AbstractReserve,
     d::PSY.HybridSystem,
     ::Type{<:AbstractReservesFormulation},
 )
@@ -448,18 +449,6 @@ function get_variable_upper_bound(
         PSY.get_output_active_power_limits(d, PSY.SU).max +
         PSY.get_input_active_power_limits(d, PSY.SU).max
     )
-end
-
-# Disambiguate against the generic operating reserve demand curve method in
-# services_models/reserves.jl.
-function get_variable_upper_bound(
-    ::Type{ActivePowerReserveVariable},
-    r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
-    d::PSY.HybridSystem,
-    ::Type{<:AbstractReservesFormulation},
-)
-    return PSY.get_output_active_power_limits(d, PSY.SU).max +
-           PSY.get_input_active_power_limits(d, PSY.SU).max
 end
 
 #################################################################################
@@ -563,7 +552,7 @@ function add_variables!(
             D,
             PSY.get_name.(participating),
             time_steps;
-            meta = "$(typeof(service))_$(PSY.get_name(service))",
+            meta = _service_container_meta(service),
         )
         for d in participating, t in time_steps
             name = PSY.get_name(d)
@@ -660,7 +649,7 @@ function _add_reserve_term!(
 }
     name = PSY.get_name(d)
     variable =
-        get_variable(container, U, V, "$(typeof(service))_$(PSY.get_name(service))")
+        get_variable(container, U, V, _service_container_meta(service))
     mult = get_variable_multiplier(U, d, W, service) * _reserve_scale(T, service)
     add_proportional_to_jump_expression!(expression[name, t], variable[name, t], mult)
     return
@@ -722,9 +711,9 @@ function add_to_expression!(
         name = PSY.get_name(d)
         for service in PSY.get_services(d)
             expression = get_expression(container, TotalReserveOffering, V,
-                "$(typeof(service))_$(PSY.get_name(service))")
+                _service_container_meta(service))
             variable =
-                get_variable(container, U, V, "$(typeof(service))_$(PSY.get_name(service))")
+                get_variable(container, U, V, _service_container_meta(service))
             mult = get_variable_multiplier(U, d, W, service)
             for t in time_steps
                 add_proportional_to_jump_expression!(
@@ -758,7 +747,7 @@ function add_to_expression!(
     variable = get_variable(container, U, V)
     for d in devices
         name = PSY.get_name(d)
-        expression = get_expression(container, T, UV, "$(V)_$(s_name)")
+        expression = get_expression(container, T, UV, _service_container_meta(service))
         for t in get_time_steps(container)
             add_proportional_to_jump_expression!(
                 expression[name, t],
@@ -1534,7 +1523,7 @@ function _init_coverage_container!(
 ) where {T <: _ReserveCoverageT, V <: PSY.HybridSystem}
     return lazy_container_addition!(
         container, T, V, names, time_steps;
-        meta = "$(typeof(service))_$(PSY.get_name(service))_discharge",
+        meta = "$(_service_container_meta(service))_discharge",
     )
 end
 
@@ -1548,7 +1537,7 @@ function _init_coverage_container!(
 ) where {T <: _ReserveCoverageT, V <: PSY.HybridSystem}
     return lazy_container_addition!(
         container, T, V, names, time_steps;
-        meta = "$(typeof(service))_$(PSY.get_name(service))_charge",
+        meta = "$(_service_container_meta(service))_charge",
     )
 end
 

--- a/src/hybrid_system_models/hybridsystem_constructor.jl
+++ b/src/hybrid_system_models/hybridsystem_constructor.jl
@@ -182,7 +182,7 @@ function _add_hybrid_reserve_arguments!(
     for s in services
         lazy_container_addition!(container, TotalReserveOffering, T,
             PSY.get_name.(devices), time_steps;
-            meta = "$(typeof(s))_$(PSY.get_name(s))")
+            meta = _service_container_meta(s))
     end
     # Only storage hybrids have subcomponent reserve variables to aggregate into the
     # offering; storage-less hybrids feed it via the PCC reserve path instead.

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -10,6 +10,80 @@ function get_default_attributes(
     return Dict{String, Any}()
 end
 
+# ── Formulation-pairing guards ────────────────────────────────────────────────────────
+# A `PSY.GroupReserve` aggregates other services, so only group formulations can model it,
+# and group formulations can model nothing else. These fallbacks fire inside the
+# `ServiceModel` constructor (which resolves the default names/attributes), so a mis-paired
+# model fails at DECLARATION with an actionable message instead of a cryptic dispatch error
+# (or a silent no-op) at build time. The valid direction-applied pairs above are more
+# specific and win.
+
+function _throw_group_pairing_error(D::Type, B::Type)
+    throw(
+        ArgumentError(
+            "ServiceModel($(D), $(B)) is invalid: `PSY.GroupReserve` aggregates other \
+            services and must use a group formulation (e.g. GroupRangeReserve), and group \
+            formulations apply only to `PSY.GroupReserve`.",
+        ),
+    )
+end
+
+get_default_time_series_names(
+    ::Type{D},
+    ::Type{B},
+) where {D <: PSY.GroupReserve, B <: AbstractServiceFormulation} =
+    _throw_group_pairing_error(D, B)
+
+get_default_attributes(
+    ::Type{D},
+    ::Type{B},
+) where {D <: PSY.GroupReserve, B <: AbstractServiceFormulation} =
+    _throw_group_pairing_error(D, B)
+
+# Disambiguates the guard above against the generic reserve defaults
+# (`T <: AbstractReserve, B <: AbstractReservesFormulation`), which a group would
+# otherwise tie with now that `GroupReserve <: AbstractReserve`.
+get_default_time_series_names(
+    ::Type{D},
+    ::Type{B},
+) where {D <: PSY.GroupReserve, B <: AbstractReservesFormulation} =
+    _throw_group_pairing_error(D, B)
+
+get_default_attributes(
+    ::Type{D},
+    ::Type{B},
+) where {D <: PSY.GroupReserve, B <: AbstractReservesFormulation} =
+    _throw_group_pairing_error(D, B)
+
+get_default_time_series_names(
+    ::Type{D},
+    ::Type{GroupRangeReserve},
+) where {D <: PSY.AbstractReserve} = _throw_group_pairing_error(D, GroupRangeReserve)
+
+get_default_attributes(
+    ::Type{D},
+    ::Type{GroupRangeReserve},
+) where {D <: PSY.AbstractReserve} = _throw_group_pairing_error(D, GroupRangeReserve)
+
+# Disambiguates the two guards' intersection (`GroupReserve <: AbstractReserve`) and gives
+# the bare-type declaration an actionable message.
+_throw_group_direction_error(D::Type) = throw(
+    ArgumentError(
+        "ServiceModel($(D), GroupRangeReserve) needs the reserve direction applied, \
+        e.g. `ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve)`.",
+    ),
+)
+
+get_default_time_series_names(
+    ::Type{D},
+    ::Type{GroupRangeReserve},
+) where {D <: PSY.GroupReserve} = _throw_group_direction_error(D)
+
+get_default_attributes(
+    ::Type{D},
+    ::Type{GroupRangeReserve},
+) where {D <: PSY.GroupReserve} = _throw_group_direction_error(D)
+
 ############################### Reserve Variables` #########################################
 """
 This function checks if the variables for reserves were created

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -1,12 +1,12 @@
 function get_default_time_series_names(
-    ::Type{PSY.ConstantReserveGroup{T}},
-    ::Type{GroupReserve}) where {T <: PSY.ReserveDirection}
+    ::Type{PSY.GroupReserve{T}},
+    ::Type{GroupRangeReserve}) where {T <: PSY.ReserveDirection}
     return Dict{String, Any}()
 end
 
 function get_default_attributes(
-    ::Type{PSY.ConstantReserveGroup{T}},
-    ::Type{GroupReserve}) where {T <: PSY.ReserveDirection}
+    ::Type{PSY.GroupReserve{T}},
+    ::Type{GroupRangeReserve}) where {T <: PSY.ReserveDirection}
     return Dict{String, Any}()
 end
 
@@ -40,8 +40,8 @@ function add_constraints!(
     ::Type{RequirementConstraint},
     service::SR,
     contributing_services::Vector{<:PSY.Service},
-    model::ServiceModel{SR, GroupReserve},
-) where {SR <: PSY.ConstantReserveGroup}
+    model::ServiceModel{SR, GroupRangeReserve},
+) where {SR <: PSY.GroupReserve}
     time_steps = get_time_steps(container)
     service_name = PSY.get_name(service)
     # Dense container keyed `[group_name, time]`, built per type; fill this group's row.

--- a/src/services_models/reserve_offers.jl
+++ b/src/services_models/reserve_offers.jl
@@ -23,6 +23,22 @@ _cost_offers_reserve(::PSY.OperationalCost, service) = false
 
 # Price every contributing device that offers into `service` by its offer curve; returns the set of
 # device names so priced (the flat-cost pass skips them).
+# A group has no contributing devices, so it can carry no per-device offers; with
+# `GroupReserve <: AbstractReserve` the generic method below would otherwise accept it.
+# Offers live on the group's contributing services and are priced by their own models.
+function add_reserve_offer_costs!(
+    ::OptimizationContainer,
+    service::SR,
+    ::ServiceModel{SR, T},
+) where {SR <: PSY.GroupReserve, T <: AbstractReservesFormulation}
+    throw(
+        IS.ConflictingInputsError(
+            "Per-resource reserve offers live on a group's contributing services, not on \
+            the group $(PSY.get_name(service)) itself.",
+        ),
+    )
+end
+
 function add_reserve_offer_costs!(
     container::OptimizationContainer,
     service::SR,

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -60,6 +60,9 @@ function _is_group_member(sys::PSY.System, service::PSY.AbstractReserve)
     return false
 end
 
+# Groups do not nest: a skipped group is always standalone, so it always warns.
+_is_group_member(::PSY.System, ::PSY.GroupReserve) = false
+
 function _log_skipped_reserve_demand(
     sys::PSY.System,
     service::PSY.AbstractReserve,
@@ -71,7 +74,7 @@ function _log_skipped_reserve_demand(
     if _is_group_member(sys, service)
         @debug "Service $(name) of type $(typeof(service)) is a GroupReserve member and $(reason); \
                 skipping its own demand-side model. It still contributes supply to its group." _group =
-            LOG_GROUP_SERVICE_CONSTRUCTORS
+            LOG_GROUP_SERVICE_CONSTUCTORS
     else
         @warn "Service $(name) of type $(typeof(service)) is modeled with $(F) but $(reason), so it \
                imposes no demand; skipping its demand-side model. It can still supply reserve to a \

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -1,62 +1,107 @@
 #! format: off
 ############################### Reserve Variables #########################################
 
-get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.Reserve}, ::Type{<:AbstractReservesFormulation}) = NaN
-############################### ActivePowerReserveVariable, Reserve #########################################
-get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.Reserve}, ::Type{<:AbstractReservesFormulation}) = false
-function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.Reserve, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
+get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = NaN
+############################### ActivePowerReserveVariable, AbstractReserve #########################################
+# One method covers OnlineReserve (<: Reserve) and OfflineReserve (<: AbstractReserve, no direction).
+# ORDC reserves carry `max_output_fraction = 1.0`, so the capped bound is a no-op for them.
+get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = false
+function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.AbstractReserve, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
     return PSY.get_max_output_fraction(r) * PSY.get_max_active_power(d, PSY.SU)
 end
-get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Device, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d, PSY.SU)
-get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.Reserve, ::PSY.Device, ::Type) = 0.0
+get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.AbstractReserve, ::PSY.Device, ::Type) = 0.0
 
-############################### ActivePowerReserveVariable, ReserveNonSpinning #########################################
-get_variable_binary(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ReserveNonSpinning}, ::Type{<:AbstractReservesFormulation}) = false
-function get_variable_upper_bound(::Type{ActivePowerReserveVariable}, r::PSY.ReserveNonSpinning, d::PSY.Device, ::Type{<:AbstractReservesFormulation})
-    return PSY.get_max_output_fraction(r) * PSY.get_max_active_power(d, PSY.SU)
-end
-get_variable_lower_bound(::Type{ActivePowerReserveVariable}, ::PSY.ReserveNonSpinning, ::PSY.Device, ::Type) = 0.0
+############################### ServiceRequirementVariable (ORDC / StepwiseCostReserve) ################################
+# Only created on the StepwiseCostReserve construct path, so the formulation gates these to ORDC reserves.
+get_variable_binary(::Type{ServiceRequirementVariable}, ::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = false
+get_variable_upper_bound(::Type{ServiceRequirementVariable}, ::PSY.AbstractReserve, d::PSY.Component, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d, PSY.SU)
+get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::PSY.AbstractReserve, ::PSY.Component, ::Type{<:AbstractReservesFormulation}) = 0.0
 
-############################### ServiceRequirementVariable, ReserveDemandCurve ################################
-
-get_variable_binary(::Type{ServiceRequirementVariable}, ::Type{<:Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}}, ::Type{<:AbstractReservesFormulation}) = false
-get_variable_upper_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, d::PSY.Component, ::Type{<:AbstractReservesFormulation}) = PSY.get_max_active_power(d, PSY.SU)
-get_variable_lower_bound(::Type{ServiceRequirementVariable}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::PSY.Component, ::Type{<:AbstractReservesFormulation}) = 0.0
-
-# `VariableReserve` stores `requirement` as a dimensionless factor that scales its
-# requirement and needs an explicit unit system (PS6 made the reserve requirement
-# getter units-aware for every reserve type, including VariableReserve).
+# Reserve requirement in system units; the getter is units-aware for every reserve type.
 _get_requirement(service) = PSY.get_requirement(service, PSY.SU)
 
-get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.Reserve, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
-get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.ReserveNonSpinning, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
+# ── Degenerate-demand skip (formulation-driven) ──────────────────────────────────────
+# Each reserve formulation has exactly ONE demand driver. When that driver is degenerate for a
+# given service, the service imposes no demand of its own and its demand-side model is SKIPPED
+# rather than emitted as a zero/degenerate constraint. The service is still built as supply: it
+# keeps its `ActivePowerReserveVariable`, its device-side expression contributions, and its
+# per-resource offer costs, so it can serve a `GroupReserve` (the group is then the only demand).
+#
+# Skipping (rather than emitting `requirement = 0` rows) avoids degenerate `sum(awards) >= 0`
+# constraints and, with `max_participation_factor < 1`, a `requirement * factor == 0`
+# participation cap that silently forces awards to zero.
+
+"""
+Whether `service` has a demand driver under `model`'s formulation. Requirement-based formulations
+(`RangeReserve`, `RampReserve`, `NonSpinningReserve`) use `requirement`; `StepwiseCostReserve` uses
+the operating reserve demand curve, and ignores `requirement` entirely.
+"""
+_has_reserve_demand(
+    ::ServiceModel{<:PSY.AbstractReserve, <:AbstractReservesFormulation},
+    service::PSY.AbstractReserve,
+) = !iszero(_get_requirement(service))
+
+_has_reserve_demand(
+    ::ServiceModel{<:PSY.AbstractReserve, StepwiseCostReserve},
+    service::PSY.AbstractReserve,
+) = PSY.has_demand_curve(service)
+
+"Services in `services` that impose a demand of their own under `model`'s formulation."
+_demand_services(model::ServiceModel, services::Vector{<:PSY.AbstractReserve}) =
+    [s for s in services if _has_reserve_demand(model, s)]
+
+# A member of a GroupReserve is EXPECTED to be supply-only, so its skip is routine (`@debug`).
+# A standalone degenerate reserve is more likely an oversight, so it is surfaced (`@warn`).
+function _is_group_member(sys::PSY.System, service::PSY.AbstractReserve)
+    name = PSY.get_name(service)
+    for group in PSY.get_components(PSY.GroupReserve, sys)
+        any(m -> PSY.get_name(m) == name, PSY.get_contributing_services(group)) && return true
+    end
+    return false
+end
+
+function _log_skipped_reserve_demand(
+    sys::PSY.System,
+    service::PSY.AbstractReserve,
+    ::ServiceModel{<:PSY.AbstractReserve, F},
+) where {F <: AbstractReservesFormulation}
+    name = PSY.get_name(service)
+    reason = F === StepwiseCostReserve ? "it has no operating reserve demand curve" :
+             "its requirement is zero"
+    if _is_group_member(sys, service)
+        @debug "Service $(name) of type $(typeof(service)) is a GroupReserve member and $(reason); \
+                skipping its own demand-side model. It still contributes supply to its group." _group =
+            LOG_GROUP_SERVICE_CONSTRUCTORS
+    else
+        @warn "Service $(name) of type $(typeof(service)) is modeled with $(F) but $(reason), so it \
+               imposes no demand; skipping its demand-side model. It can still supply reserve to a \
+               GroupReserve. Set a requirement or a demand curve if this service should procure \
+               reserve on its own."
+    end
+    return
+end
+
+get_multiplier_value(::Type{RequirementTimeSeriesParameter}, d::PSY.AbstractReserve, ::Type{<:AbstractReservesFormulation}) = _get_requirement(d)
 
 get_parameter_multiplier(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 1.0
 get_initial_parameter_value(::Type{<:VariableValueParameter}, d::Type{<:PSY.AbstractReserve}, ::Type{<:AbstractReservesFormulation}) = 0.0
 
 objective_function_multiplier(::Type{ServiceRequirementVariable}, ::Type{StepwiseCostReserve}) = -1.0
-uses_compact_power(::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::StepwiseCostReserve)=false
-get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::Type{<:AbstractReservesFormulation}) = 1.0
-get_multiplier_value(::Type{<:AbstractPiecewiseLinearSlopeParameter}, ::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}, ::Type{<:AbstractReservesFormulation}) = 1.0
+uses_compact_power(::PSY.AbstractReserve, ::StepwiseCostReserve)=false
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearBreakpointParameter}, ::PSY.AbstractReserve, ::Type{<:AbstractReservesFormulation}) = 1.0
+get_multiplier_value(::Type{<:AbstractPiecewiseLinearSlopeParameter}, ::PSY.AbstractReserve, ::Type{<:AbstractReservesFormulation}) = 1.0
 # Operating reserve demand curves (ORDC) are willingness-to-pay (concave), i.e. a decremental
 # offer.
 # Routes the reserve PWL cost path through IOM's OfferDirection dispatch; making
 # this incremental is a one-line change here. Mirrors `_onvar_offer_direction` /
 # `_vom_offer_direction` in market_bid_overrides.jl.
-_reserve_offer_direction(::Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve}) = IOM.DecrementalOffer()
+_reserve_offer_direction(::PSY.AbstractReserve) = IOM.DecrementalOffer()
 #! format: on
 
 function get_initial_conditions_service_model(
     ::IOM.AbstractOptimizationModel,
     ::ServiceModel{T, D},
-) where {T <: PSY.Reserve, D <: AbstractReservesFormulation}
-    return ServiceModel(T, D)
-end
-
-function get_initial_conditions_service_model(
-    ::IOM.AbstractOptimizationModel,
-    ::ServiceModel{T, D},
-) where {T <: PSY.VariableReserveNonSpinning, D <: AbstractReservesFormulation}
+) where {T <: PSY.AbstractReserve, D <: AbstractReservesFormulation}
     return ServiceModel(T, D)
 end
 
@@ -70,7 +115,7 @@ function get_default_time_series_names(
 end
 
 function get_default_time_series_names(
-    ::Type{<:PSY.ReserveNonSpinning},
+    ::Type{<:PSY.OfflineReserve},
     ::Type{NonSpinningReserve},
 )
     return Dict{Type{<:TimeSeriesParameter}, String}(
@@ -81,19 +126,12 @@ end
 function get_default_time_series_names(
     ::Type{T},
     ::Type{<:AbstractReservesFormulation},
-) where {T <: PSY.Reserve}
+) where {T <: PSY.AbstractReserve}
     return Dict{Type{<:TimeSeriesParameter}, String}()
 end
 
 function get_default_attributes(
-    ::Type{<:PSY.Reserve},
-    ::Type{<:AbstractReservesFormulation},
-)
-    return Dict{String, Any}()
-end
-
-function get_default_attributes(
-    ::Type{<:PSY.ReserveNonSpinning},
+    ::Type{<:PSY.AbstractReserve},
     ::Type{<:AbstractReservesFormulation},
 )
     return Dict{String, Any}()
@@ -109,7 +147,7 @@ function add_reserve_variables!(
     formulation,
 ) where {
     T <: ServiceRequirementVariable,
-    D <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    D <: PSY.AbstractReserve,
 }
     time_steps = get_time_steps(container)
     service_names = [PSY.get_name(s) for s in services]
@@ -168,42 +206,67 @@ function add_constraints!(
     constraint = get_constraint(container, T, SR)
     reserve_variable = get_variable(container, ActivePowerReserveVariable, SR)
     use_slacks = get_use_slacks(model)
-
-    ts_vector = IOM.get_time_series(
-        container,
-        service,
-        "requirement";
-        interval = get_interval(get_settings(container)),
-    )
-
     use_slacks && (slack_vars = get_variable(container, ReserveRequirementSlack, SR))
     requirement = _get_requirement(service)
     jump_model = get_jump_model(container)
     extra = use_slacks ? 1 : 0
-    if built_for_recurrent_solves(container)
-        param_container =
-            get_parameter(container, RequirementTimeSeriesParameter, SR)
-        param = get_parameter_column_refs(param_container, service_name)
-        for t in time_steps
-            resource_expression =
-                _sum_service_reserves(reserve_variable, service_name, contributing_devices,
-                    t, extra)
-            use_slacks &&
-                JuMP.add_to_expression!(resource_expression, slack_vars[service_name, t])
-            constraint[service_name, t] =
-                JuMP.@constraint(jump_model, resource_expression >= param[t] * requirement)
+
+    # A static reserve gets a scalar requirement RHS; a time-varying one scales it by an
+    # attached requirement series (resolved by the model-configured name).
+    if _has_ts_requirement(model, service)
+        if built_for_recurrent_solves(container)
+            param_container =
+                get_parameter(container, RequirementTimeSeriesParameter, SR)
+            param = get_parameter_column_refs(param_container, service_name)
+            for t in time_steps
+                resource_expression =
+                    _sum_service_reserves(reserve_variable, service_name,
+                        contributing_devices,
+                        t, extra)
+                use_slacks &&
+                    JuMP.add_to_expression!(
+                        resource_expression,
+                        slack_vars[service_name, t],
+                    )
+                constraint[service_name, t] =
+                    JuMP.@constraint(
+                        jump_model,
+                        resource_expression >= param[t] * requirement
+                    )
+            end
+        else
+            ts_vector = IOM.get_time_series(
+                container,
+                service,
+                get_time_series_names(model)[RequirementTimeSeriesParameter];
+                interval = get_interval(get_settings(container)),
+            )
+            for t in time_steps
+                resource_expression =
+                    _sum_service_reserves(reserve_variable, service_name,
+                        contributing_devices,
+                        t, extra)
+                use_slacks &&
+                    JuMP.add_to_expression!(
+                        resource_expression,
+                        slack_vars[service_name, t],
+                    )
+                constraint[service_name, t] = JuMP.@constraint(
+                    jump_model,
+                    resource_expression >= ts_vector[t] * requirement
+                )
+            end
         end
     else
         for t in time_steps
             resource_expression =
                 _sum_service_reserves(reserve_variable, service_name, contributing_devices,
-                    t, extra)
+                    t,
+                    extra)
             use_slacks &&
                 JuMP.add_to_expression!(resource_expression, slack_vars[service_name, t])
-            constraint[service_name, t] = JuMP.@constraint(
-                jump_model,
-                resource_expression >= ts_vector[t] * requirement
-            )
+            constraint[service_name, t] =
+                JuMP.@constraint(jump_model, resource_expression >= requirement)
         end
     end
     return
@@ -214,7 +277,7 @@ function add_constraints!(
     T::Type{ParticipationFractionConstraint},
     service::SR,
     contributing_devices::U,
-    ::ServiceModel{SR, V},
+    model::ServiceModel{SR, V},
 ) where {
     SR <: PSY.AbstractReserve,
     V <: AbstractReservesFormulation,
@@ -238,66 +301,44 @@ function add_constraints!(
     var_r = get_variable(container, ActivePowerReserveVariable, SR)
     jump_model = get_jump_model(container)
     requirement = _get_requirement(service)
-    ts_vector = IOM.get_time_series(
-        container,
-        service,
-        "requirement";
-        interval = get_interval(get_settings(container)),
-    )
-    param_container =
-        get_parameter(container, RequirementTimeSeriesParameter, SR)
-    param = get_parameter_column_refs(param_container, service_name)
-    for t in time_steps, d in contributing_devices
-        name = PSY.get_name(d)
+    cap = requirement * max_participation_factor
+    # Static reserve: constant participation cap. Time-varying reserve: scale by the requirement
+    # series (recurrent -> parameter, else -> the resolved time series).
+    if _has_ts_requirement(model, service)
         if built_for_recurrent_solves(container)
-            cons[(service_name, name, t)] =
-                JuMP.@constraint(
+            param_container =
+                get_parameter(container, RequirementTimeSeriesParameter, SR)
+            param = get_parameter_column_refs(param_container, service_name)
+            for t in time_steps, d in contributing_devices
+                name = PSY.get_name(d)
+                cons[(service_name, name, t)] = JuMP.@constraint(
                     jump_model,
-                    var_r[(service_name, name, t)] <=
-                    (requirement * max_participation_factor) * param[t]
+                    var_r[(service_name, name, t)] <= cap * param[t]
                 )
+            end
         else
+            ts_vector = IOM.get_time_series(
+                container,
+                service,
+                get_time_series_names(model)[RequirementTimeSeriesParameter];
+                interval = get_interval(get_settings(container)),
+            )
+            for t in time_steps, d in contributing_devices
+                name = PSY.get_name(d)
+                cons[(service_name, name, t)] = JuMP.@constraint(
+                    jump_model,
+                    var_r[(service_name, name, t)] <= cap * ts_vector[t]
+                )
+            end
+        end
+    else
+        for t in time_steps, d in contributing_devices
+            name = PSY.get_name(d)
             cons[(service_name, name, t)] = JuMP.@constraint(
                 jump_model,
-                var_r[(service_name, name, t)] <=
-                (requirement * max_participation_factor) * ts_vector[t]
+                var_r[(service_name, name, t)] <= cap
             )
         end
-    end
-
-    return
-end
-
-function add_constraints!(
-    container::OptimizationContainer,
-    T::Type{RequirementConstraint},
-    service::SR,
-    contributing_devices::U,
-    model::ServiceModel{SR, V},
-) where {
-    SR <: PSY.ConstantReserve,
-    V <: AbstractReservesFormulation,
-    U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
-} where {D <: PSY.Component}
-    time_steps = get_time_steps(container)
-    service_name = PSY.get_name(service)
-    # Dense container keyed `[service_name, time]`, built per type; fill this service's row.
-    constraint = get_constraint(container, T, SR)
-    reserve_variable = get_variable(container, ActivePowerReserveVariable, SR)
-    use_slacks = get_use_slacks(model)
-    use_slacks && (slack_vars = get_variable(container, ReserveRequirementSlack, SR))
-
-    requirement = _get_requirement(service)
-    jump_model = get_jump_model(container)
-    extra = use_slacks ? 1 : 0
-    for t in time_steps
-        resource_expression =
-            _sum_service_reserves(reserve_variable, service_name, contributing_devices, t,
-                extra)
-        use_slacks &&
-            JuMP.add_to_expression!(resource_expression, slack_vars[service_name, t])
-        constraint[service_name, t] =
-            JuMP.@constraint(jump_model, resource_expression >= requirement)
     end
 
     return
@@ -326,7 +367,7 @@ function add_constraints!(
     contributing_devices::U,
     ::ServiceModel{SR, StepwiseCostReserve},
 ) where {
-    SR <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    SR <: PSY.AbstractReserve,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
 } where {D <: PSY.Component}
     time_steps = get_time_steps(container)
@@ -468,7 +509,7 @@ function add_constraints!(
     contributing_devices::U,
     ::ServiceModel{SR, V},
 ) where {
-    SR <: PSY.VariableReserveNonSpinning,
+    SR <: PSY.OfflineReserve,
     V <: AbstractReservesFormulation,
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
 } where {D <: PSY.Component}
@@ -546,7 +587,7 @@ function add_to_objective_function!(
     service::S,
     model::ServiceModel{S, SR},
 ) where {
-    S <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    S <: PSY.AbstractReserve,
     SR <: StepwiseCostReserve,
 }
     # Demand side: price the endogenous ServiceRequirementVariable by the decremental
@@ -567,7 +608,7 @@ function add_reserves_variable_cost!(
     service::T,
     ::Type{V},
 ) where {
-    T <: Union{PSY.ReserveDemandCurve, PSY.ReserveDemandTimeSeriesCurve},
+    T <: PSY.AbstractReserve,
     U <: VariableType,
     V <: StepwiseCostReserve,
 }
@@ -578,7 +619,7 @@ end
 function _add_reserves_variable_cost_to_objective!(
     container::OptimizationContainer,
     ::Type{T},
-    component::PSY.Reserve,
+    component::PSY.AbstractReserve,
     ::Type{U},
 ) where {T <: VariableType, U <: StepwiseCostReserve}
     component_name = PSY.get_name(component)
@@ -599,19 +640,11 @@ function _add_reserves_variable_cost_to_objective!(
         )
     end
 
-    # A time-series-backed cost varies across simulation steps and is read from
-    # per-timestep parameter arrays, which are only populated for
-    # `ReserveDemandTimeSeriesCurve` (see `process_stepwise_cost_reserve_parameters!`).
-    # Reject a time-series-backed cost on any other reserve type up front, rather
-    # than failing later with a missing-parameter error.
+    # A time-varying curve enters the objective as a variant expression, a static curve as an
+    # invariant one. The curve type is the source of truth, read via `is_time_variant`;
+    # its per-timestep parameters are populated only for TS-backed ORDCs (see
+    # `process_stepwise_cost_reserve_parameters!`, gated on `_ordc_is_ts`).
     is_t_variant = is_time_variant(variable_cost)
-    if is_t_variant && !(component isa PSY.ReserveDemandTimeSeriesCurve)
-        error(
-            "Operating reserve demand curve $(component_name) of type $(typeof(component)) \
-            has a time-series-backed cost; a `PSY.ReserveDemandTimeSeriesCurve` is required \
-            for a time-varying demand curve cost.",
-        )
-    end
 
     pwl_cost_expressions =
         add_pwl_term_delta!(container, component, variable_cost, T, U)
@@ -633,19 +666,22 @@ function _add_reserves_variable_cost_to_objective!(
 end
 
 """
-Add the decremental piecewise slope/breakpoint cost parameters for a time-varying operating
-reserve demand curve (`ReserveDemandTimeSeriesCurve`) service.
+Add the decremental piecewise slope/breakpoint cost parameters for the time-varying operating
+reserve demand curves in `services` (those whose `variable` curve is time-series-backed). Static
+ORDCs and fixed-requirement reserves carry no such parameters and are skipped.
 """
 function process_stepwise_cost_reserve_parameters!(
     container::OptimizationContainer,
     model::ServiceModel,
     services::Vector{D},
-) where {D <: PSY.ReserveDemandTimeSeriesCurve}
-    # All services of a per-type model share the same offer direction, so the
-    # slope/breakpoint param containers are built once over all services.
-    dir = _reserve_offer_direction(first(services))
+) where {D <: PSY.AbstractReserve}
+    # Only time-series-backed ORDCs need the per-timestep slope/breakpoint parameters.
+    ts_services = [s for s in services if _ordc_is_ts(s)]
+    isempty(ts_services) && return
+    # These share one offer direction, so the slope/breakpoint param containers are built once.
+    dir = _reserve_offer_direction(first(ts_services))
     for param in (IOM._breakpoint_param(dir), IOM._slope_param(dir))
-        add_parameters!(container, param, services, model)
+        add_parameters!(container, param, ts_services, model)
     end
     return
 end
@@ -658,7 +694,7 @@ function add_reserves_proportional_cost!(
     contributing_names::Vector{String};
     skip_devices = Set{String}(),
 ) where {
-    T <: Union{PSY.Reserve, PSY.ReserveNonSpinning},
+    T <: PSY.AbstractReserve,
     U <: ActivePowerReserveVariable,
     V <: AbstractReservesFormulation,
 }

--- a/src/services_models/service_slacks.jl
+++ b/src/services_models/service_slacks.jl
@@ -1,3 +1,4 @@
+# `T <: AbstractReserve` admits `GroupReserve` type-wise, but never reach it in practice.
 function add_reserve_slacks!(
     container::OptimizationContainer,
     ::Type{T},

--- a/src/services_models/service_slacks.jl
+++ b/src/services_models/service_slacks.jl
@@ -2,7 +2,7 @@ function add_reserve_slacks!(
     container::OptimizationContainer,
     ::Type{T},
     service_names::Vector{String},
-) where {T <: Union{PSY.Reserve, PSY.ReserveNonSpinning}}
+) where {T <: PSY.AbstractReserve}
     time_steps = get_time_steps(container)
     # Dense 2D container keyed `[service_name, time]`, built once per service type over all
     # the type's services (`use_slacks` is per type). Lower bound 0, penalty in objective.

--- a/src/services_models/services_constructor.jl
+++ b/src/services_models/services_constructor.jl
@@ -3,7 +3,7 @@
 # reads each service's contributing devices from the nested per-service map
 # (`get_contributing_devices(model, service_name)`), and builds. Reserve variable and
 # constraint containers are shared per `(entry type, service type)`, with each service
-# filling its own slice. `GroupReserve` is deferred to last.
+# filling its own slice. `GroupRangeReserve` is deferred to last.
 #
 # TODO(services stability): See issue #216.
 
@@ -32,7 +32,7 @@ function construct_services!(
 
     groupservice = nothing
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # constructed last
+        if get_formulation(service_model) === GroupRangeReserve  # constructed last
             groupservice = key
             continue
         end
@@ -72,7 +72,7 @@ function construct_services!(
 
     groupservice = nothing
     for (key, service_model) in services_template
-        if get_formulation(service_model) === GroupReserve  # constructed last
+        if get_formulation(service_model) === GroupRangeReserve  # constructed last
             groupservice = key
             continue
         end
@@ -99,6 +99,8 @@ function construct_services!(
     return
 end
 
+# One argument stage covers static and time-series-scaled reserves: the requirement
+# time-series parameter is added only for services that carry a requirement series.
 function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -107,10 +109,16 @@ function construct_service!(
     devices_template::Dict{Symbol, DeviceModel},
     incompatible_device_types::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.Reserve}
+) where {SR <: PSY.AbstractReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    add_parameters!(container, RequirementTimeSeriesParameter, services, model)
+    # A service with a zero requirement imposes no demand: its demand-side model is skipped, so it
+    # needs no requirement parameter either. It is still built as supply below (its
+    # `ActivePowerReserveVariable` awards, wired into the device-side expressions).
+    demand_services = _demand_services(model, services)
+    ts_services = [s for s in demand_services if _has_ts_requirement(model, s)]
+    isempty(ts_services) ||
+        add_parameters!(container, RequirementTimeSeriesParameter, ts_services, model)
     for service in services
         contributing_devices = get_contributing_devices(model, PSY.get_name(service))
         add_service_variables!(
@@ -132,42 +140,8 @@ function construct_service!(
     return
 end
 
-# ConstantReserve has no requirement time series, so its argument stage skips the
-# parameter add. The model stage is the shared `SR <: PSY.AbstractReserve` method below.
-function construct_service!(
-    container::OptimizationContainer,
-    sys::PSY.System,
-    ::ArgumentConstructStage,
-    model::ServiceModel{SR, RangeReserve},
-    devices_template::Dict{Symbol, DeviceModel},
-    incompatible_device_types::Set{<:DataType},
-    ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.ConstantReserve}
-    services = _services_with_contributors(model, sys)
-    isempty(services) && return
-    for service in services
-        contributing_devices = get_contributing_devices(model, PSY.get_name(service))
-        add_service_variables!(
-            container,
-            ActivePowerReserveVariable,
-            service,
-            contributing_devices,
-            RangeReserve,
-        )
-        add_to_expression!(
-            container,
-            ActivePowerReserveVariable,
-            service,
-            model,
-            devices_template,
-        )
-        add_feedforward_arguments!(container, model, service)
-    end
-    return
-end
-
-# Shared RangeReserve model stage for both `PSY.Reserve` and `PSY.ConstantReserve`;
-# the inner `add_constraints!` calls resolve per service type.
+# Shared RangeReserve model stage for every `OnlineReserve`/`OfflineReserve`;
+# the inner `add_constraints!` calls branch on the attached requirement series.
 function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,
@@ -179,45 +153,50 @@ function construct_service!(
 ) where {SR <: PSY.AbstractReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    service_names = PSY.get_name.(services)
-    # Dense service-indexed containers are built once per type, then filled per service.
-    add_constraints_container!(
-        container,
-        RequirementConstraint,
-        SR,
-        service_names,
-        get_time_steps(container),
-    )
-    get_use_slacks(model) && add_reserve_slacks!(container, SR, service_names)
-    for service in services
-        contributing_devices = get_contributing_devices(model, PSY.get_name(service))
-        add_constraints!(
+    # Only services that actually impose a demand get requirement rows; the containers are sized to
+    # that subset so a skipped service leaves no empty rows behind.
+    demand_services = _demand_services(model, services)
+    if !isempty(demand_services)
+        demand_names = PSY.get_name.(demand_services)
+        # Dense service-indexed containers are built once per type, then filled per service.
+        add_constraints_container!(
             container,
             RequirementConstraint,
-            service,
-            contributing_devices,
-            model,
+            SR,
+            demand_names,
+            get_time_steps(container),
         )
-        add_constraints!(
-            container,
-            ParticipationFractionConstraint,
-            service,
-            contributing_devices,
-            model,
-        )
-        add_to_objective_function!(container, service, model)
+        get_use_slacks(model) && add_reserve_slacks!(container, SR, demand_names)
+    end
+    for service in services
+        contributing_devices = get_contributing_devices(model, PSY.get_name(service))
+        if _has_reserve_demand(model, service)
+            add_constraints!(
+                container,
+                RequirementConstraint,
+                service,
+                contributing_devices,
+                model,
+            )
+            add_constraints!(
+                container,
+                ParticipationFractionConstraint,
+                service,
+                contributing_devices,
+                model,
+            )
+            add_to_objective_function!(container, service, model)
+        else
+            # Supply-only: no requirement of its own (it may serve a GroupReserve). Price any
+            # per-resource offers, but add no requirement constraint and no flat reserve cost.
+            _log_skipped_reserve_demand(sys, service, model)
+            add_reserve_offer_costs!(container, service, model)
+        end
         add_feedforward_constraints!(container, model, service)
     end
     add_constraint_dual!(container, sys, model)
     return
 end
-
-_maybe_process_stepwise(
-    container,
-    model,
-    services::Vector{<:PSY.ReserveDemandTimeSeriesCurve},
-) = process_stepwise_cost_reserve_parameters!(container, model, services)
-_maybe_process_stepwise(container, model, services) = nothing
 
 function construct_service!(
     container::OptimizationContainer,
@@ -227,19 +206,26 @@ function construct_service!(
     devices_template::Dict{Symbol, DeviceModel},
     incompatible_device_types::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.Reserve}
+) where {SR <: PSY.AbstractReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    add_reserve_variables!(
-        container,
-        ServiceRequirementVariable,
-        services,
-        StepwiseCostReserve(),
-    )
-    # Dense `(service, time)` cost-expression container, built once over all services.
-    add_expressions!(container, ProductionCostExpression, services, model)
-    # Slope/breakpoint PWL cost params, built once over all services.
-    _maybe_process_stepwise(container, model, services)
+    # A service with no demand curve imposes no demand: it gets no ServiceRequirementVariable, no
+    # cost expression, and no PWL parameters. It is still built as supply below (its
+    # `ActivePowerReserveVariable` awards, wired into the device-side expressions), so it can serve
+    # a GroupReserve. Sizing these containers to the demand subset keeps them free of empty rows.
+    demand_services = _demand_services(model, services)
+    if !isempty(demand_services)
+        add_reserve_variables!(
+            container,
+            ServiceRequirementVariable,
+            demand_services,
+            StepwiseCostReserve(),
+        )
+        # Dense `(service, time)` cost-expression container, built once over the demand services.
+        add_expressions!(container, ProductionCostExpression, demand_services, model)
+        # Slope/breakpoint PWL cost params for the time-series-backed ORDCs (no-op otherwise).
+        process_stepwise_cost_reserve_parameters!(container, model, demand_services)
+    end
     for service in services
         contributing_devices = get_contributing_devices(model, PSY.get_name(service))
         add_service_variables!(
@@ -268,27 +254,37 @@ function construct_service!(
     devices_template::Dict{Symbol, DeviceModel},
     incompatible_device_types::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.Reserve}
+) where {SR <: PSY.AbstractReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    # Dense service-indexed requirement container, built once per type, filled per service.
-    add_constraints_container!(
-        container,
-        RequirementConstraint,
-        SR,
-        PSY.get_name.(services),
-        get_time_steps(container),
-    )
-    for service in services
-        contributing_devices = get_contributing_devices(model, PSY.get_name(service))
-        add_constraints!(
+    demand_services = _demand_services(model, services)
+    if !isempty(demand_services)
+        # Dense service-indexed requirement container, sized to the demand subset.
+        add_constraints_container!(
             container,
             RequirementConstraint,
-            service,
-            contributing_devices,
-            model,
+            SR,
+            PSY.get_name.(demand_services),
+            get_time_steps(container),
         )
-        add_to_objective_function!(container, service, model)
+    end
+    for service in services
+        contributing_devices = get_contributing_devices(model, PSY.get_name(service))
+        if _has_reserve_demand(model, service)
+            add_constraints!(
+                container,
+                RequirementConstraint,
+                service,
+                contributing_devices,
+                model,
+            )
+            add_to_objective_function!(container, service, model)
+        else
+            # Supply-only: no demand curve of its own (it may serve a GroupReserve). Price any
+            # per-resource offers; emit no requirement equality and no demand-side objective term.
+            _log_skipped_reserve_demand(sys, service, model)
+            add_reserve_offer_costs!(container, service, model)
+        end
         add_feedforward_constraints!(container, model, service)
     end
     add_constraint_dual!(container, sys, model)
@@ -391,17 +387,17 @@ end
 =#
 
 """
-    Constructs a service for ConstantReserveGroup.
+    Constructs a service for GroupRangeReserve.
 """
 function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ArgumentConstructStage,
-    model::ServiceModel{SR, GroupReserve},
+    model::ServiceModel{SR, GroupRangeReserve},
     ::Dict{Symbol, DeviceModel},
     ::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.ConstantReserveGroup}
+) where {SR <: PSY.GroupReserve}
     for service in get_available_components(model, sys)
         contributing_services = PSY.get_contributing_services(service)
         # check if variables exist
@@ -414,11 +410,11 @@ function construct_service!(
     container::OptimizationContainer,
     sys::PSY.System,
     ::ModelConstructStage,
-    model::ServiceModel{SR, GroupReserve},
+    model::ServiceModel{SR, GroupRangeReserve},
     ::Dict{Symbol, DeviceModel},
     ::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.ConstantReserveGroup}
+) where {SR <: PSY.GroupReserve}
     groups = collect(get_available_components(model, sys))
     # Dense group-indexed requirement container, built once over all groups of the type.
     add_constraints_container!(
@@ -453,7 +449,11 @@ function construct_service!(
 ) where {SR <: PSY.Reserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    add_parameters!(container, RequirementTimeSeriesParameter, services, model)
+    # Only services carrying a requirement series get the parameter (a curve-only ORDC of the
+    # same type has none).
+    ts_services = [s for s in services if _has_ts_requirement(model, s)]
+    isempty(ts_services) ||
+        add_parameters!(container, RequirementTimeSeriesParameter, ts_services, model)
     for service in services
         contributing_devices = get_contributing_devices(model, PSY.get_name(service))
         add_service_variables!(
@@ -528,10 +528,14 @@ function construct_service!(
     devices_template::Dict{Symbol, DeviceModel},
     incompatible_device_types::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.ReserveNonSpinning}
+) where {SR <: PSY.OfflineReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
-    add_parameters!(container, RequirementTimeSeriesParameter, services, model)
+    # Only services carrying a requirement series get the parameter (a curve-only ORDC of the
+    # same type has none).
+    ts_services = [s for s in services if _has_ts_requirement(model, s)]
+    isempty(ts_services) ||
+        add_parameters!(container, RequirementTimeSeriesParameter, ts_services, model)
     for service in services
         contributing_devices = get_contributing_devices(model, PSY.get_name(service))
         add_service_variables!(
@@ -554,7 +558,7 @@ function construct_service!(
     devices_template::Dict{Symbol, DeviceModel},
     incompatible_device_types::Set{<:DataType},
     ::NetworkModel{<:AbstractNetworkModel},
-) where {SR <: PSY.ReserveNonSpinning}
+) where {SR <: PSY.OfflineReserve}
     services = _services_with_contributors(model, sys)
     isempty(services) && return
     service_names = PSY.get_name.(services)

--- a/src/static_injector_models/hydro_generation.jl
+++ b/src/static_injector_models/hydro_generation.jl
@@ -14,6 +14,8 @@ get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.HydroGen}, ::Type{<
 get_variable_multiplier(::Type{ActivePowerPumpVariable}, ::Type{<:PSY.HydroPumpTurbine}, ::Type{<:AbstractHydroPumpFormulation}) = -1.0
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+# OfflineReserve (non-spin) is upward-only, so it reduces upward headroom like a ReserveUp product.
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.HydroGen}, ::Type{<:PSY.OfflineReserve}) = ActivePowerRangeExpressionUB
 
 ########################### ActivePowerVariable, HydroGen #################################
 # These methods are defined in PowerSimulations

--- a/src/static_injector_models/renewable_generation.jl
+++ b/src/static_injector_models/renewable_generation.jl
@@ -2,6 +2,8 @@
 get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.RenewableGen}, ::Type{<:AbstractRenewableFormulation}) = 1.0
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+# OfflineReserve (non-spin) is upward-only, so it reduces upward headroom like a ReserveUp product.
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.RenewableGen}, ::Type{<:PSY.OfflineReserve}) = ActivePowerRangeExpressionUB
 ########################### Parameter related set functions ################################
 get_parameter_multiplier(::Type{<:VariableValueParameter}, d::PSY.RenewableGen, ::Type{<:AbstractRenewableFormulation}) = 1.0
 ########################### ActivePowerVariable, RenewableGen #################################

--- a/src/static_injector_models/shunt_models.jl
+++ b/src/static_injector_models/shunt_models.jl
@@ -31,24 +31,15 @@ function _shunt_susceptance_limits(d::PSY.SwitchedAdmittance)
 end
 
 function _shunt_susceptance_limits(d::PSY.FACTSControlDevice)
-    # max_shunt_current is stored in MVA at unity voltage. At V = 1 pu the
-    # reactive power equals B * V² = B, so dividing by the system base (MVA)
-    # converts to per-unit susceptance on system base.
-    qmax_mva = PSY.get_max_shunt_current(d)
-    s_base = PSY.get_base_power(d)
-    if !isfinite(qmax_mva) || iszero(qmax_mva)
+    # max_shunt_current is stored in MVA at unity voltage. At V = 1 pu the reactive power
+    # equals B * V² = B, so its system-base per-unit value IS the susceptance bound.
+    b_max = PSY.get_max_shunt_current(d, PSY.SU)
+    if !isfinite(b_max) || iszero(b_max)
         error(
             "FACTSControlDevice $(PSY.get_name(d)) has zero/invalid max_shunt_current; ",
             "cannot bound susceptance",
         )
     end
-    if !isfinite(s_base) || iszero(s_base)
-        error(
-            "FACTSControlDevice $(PSY.get_name(d)) has zero/invalid system base power; ",
-            "cannot convert max_shunt_current to per unit",
-        )
-    end
-    b_max = qmax_mva / s_base
     return (min = -b_max, max = b_max)
 end
 

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -35,6 +35,8 @@ get_variable_multiplier(::Type{<:VariableType}, ::Type{<:PSY.ThermalGen}, ::Type
 get_variable_multiplier(::Type{OnVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:Union{AbstractCompactUnitCommitment, ThermalCompactDispatch}}) = 1.0
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveUp}}) = ActivePowerRangeExpressionUB
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
+# OfflineReserve (non-spin) is upward-only, so it reduces upward headroom like a ReserveUp product.
+get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.OfflineReserve}) = ActivePowerRangeExpressionUB
 
 ############## ActivePowerVariable, ThermalGen ####################
 get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false

--- a/src/utils/generate_valid_formulations.jl
+++ b/src/utils/generate_valid_formulations.jl
@@ -84,7 +84,7 @@ end
 function generate_service_formulation_combinations()
     combos = []
     for (d, f) in Iterators.product(
-        IS.get_all_concrete_subtypes(PSY.Service),
+        _leaf_service_types(PSY.Service),
         IS.get_all_concrete_subtypes(AbstractServiceFormulation),
     )
         if !isempty(methodswith(ServiceModel{d, f}, construct_service!; supertypes = true))
@@ -93,4 +93,25 @@ function generate_service_formulation_combinations()
     end
 
     return combos
+end
+
+# `IS.get_all_concrete_subtypes` drops parametric leaf types (a `UnionAll` is neither
+# concrete nor abstract), and every psy6 reserve type carries a free unit-system
+# parameter. Collect those leaves as-is - the bare `UnionAll` (`OfflineReserve`,
+# `OnlineReserve`) is exactly the shape a `ServiceModel` is declared with.
+function _leaf_service_types(::Type{T}) where {T}
+    types = Vector{Union{DataType, UnionAll}}()
+    _collect_leaf_service_types!(types, T)
+    return types
+end
+
+function _collect_leaf_service_types!(types, ::Type{T}) where {T}
+    for sub in subtypes(T)
+        if isabstracttype(sub)
+            _collect_leaf_service_types!(types, sub)
+        else
+            push!(types, sub)
+        end
+    end
+    return
 end

--- a/test/performance/performance_test.jl
+++ b/test/performance/performance_test.jl
@@ -43,11 +43,11 @@ function set_device_models!(template::PowerOperationsProblemTemplate, uc::Bool =
     set_device_model!(template, TwoWindingTransformer, StaticBranchUnbounded)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     return template
 end

--- a/test/test_device_hybrid_constructors.jl
+++ b/test/test_device_hybrid_constructors.jl
@@ -28,7 +28,7 @@ function _build_hybrid_test_system(;
         energy_target = energy_target,
     )
     if with_reserves
-        for s in PSY.get_components(PSY.VariableReserve, sys)
+        for s in PSY.get_components(PSY.OnlineReserve, sys)
             s_name = PSY.get_name(s)
             any(occursin(prefix, s_name) for prefix in _NON_HYBRID_RESERVES) && continue
             PSY.add_service!(hybrid, s, sys)
@@ -55,7 +55,7 @@ function _build_hybrid_template(
         # each distinct type once. (The per-name `_NON_HYBRID_RESERVES` exclusion still
         # governs which reserves are attached to the hybrid in `_build_hybrid_test_system`.)
         modeled_types = Set{DataType}()
-        for service in PSY.get_components(PSY.VariableReserve, sys)
+        for service in PSY.get_components(PSY.OnlineReserve, sys)
             T = typeof(service)
             T in modeled_types && continue
             push!(modeled_types, T)

--- a/test/test_device_hydro_constructors.jl
+++ b/test/test_device_hydro_constructors.jl
@@ -192,15 +192,15 @@ end
     set_device_model!(template, HydroTurbine, HydroDispatchRunOfRiver)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
 
     c_sys5_hyd = PSB.build_system(
@@ -439,8 +439,8 @@ end
     )
 
     # Fix reserve parameters
-    reg_up = only(get_components(VariableReserve{ReserveUp}, c_sys5_hy))
-    reg_dn = only(get_components(VariableReserve{ReserveDown}, c_sys5_hy))
+    reg_up = only(get_components(OnlineReserve{ReserveUp}, c_sys5_hy))
+    reg_dn = only(get_components(OnlineReserve{ReserveDown}, c_sys5_hy))
     set_deployed_fraction!(reg_up, 0.0)
     set_deployed_fraction!(reg_dn, 0.0)
     set_requirement!(reg_up, 0.01 * PSY.SU)
@@ -497,8 +497,8 @@ end
             attributes = Dict("hydro_budget" => true,
                 "hydro_budget_interval" => Hour(hydro_budget))),
     )
-    set_service_model!(template_uc, VariableReserve{ReserveUp}, RangeReserve)
-    set_service_model!(template_uc, VariableReserve{ReserveDown}, RangeReserve)
+    set_service_model!(template_uc, OnlineReserve{ReserveUp}, RangeReserve)
+    set_service_model!(template_uc, OnlineReserve{ReserveDown}, RangeReserve)
     model = DecisionModel(
         template_uc,
         c_sys5_hy;
@@ -528,8 +528,8 @@ end
 
     # The hydro unit is the sole contributing device for both reserves in this system, so
     # the down requirement guarantees a nonzero down award to detect.
-    reg_up = only(get_components(VariableReserve{ReserveUp}, c_sys5_hy))
-    reg_dn = only(get_components(VariableReserve{ReserveDown}, c_sys5_hy))
+    reg_up = only(get_components(OnlineReserve{ReserveUp}, c_sys5_hy))
+    reg_dn = only(get_components(OnlineReserve{ReserveDown}, c_sys5_hy))
     set_deployed_fraction!(reg_up, 0.0)
     set_deployed_fraction!(reg_dn, 0.5)
     set_requirement!(reg_up, 0.01 * PSY.SU)
@@ -543,8 +543,8 @@ end
     set_device_model!(template, PowerLoad, StaticPowerLoad)
     set_device_model!(template, RenewableNonDispatch, FixedOutput)
     set_device_model!(template, HydroDispatch, HydroDispatchRunOfRiver)
-    set_service_model!(template, VariableReserve{ReserveUp}, RangeReserve)
-    set_service_model!(template, VariableReserve{ReserveDown}, RangeReserve)
+    set_service_model!(template, OnlineReserve{ReserveUp}, RangeReserve)
+    set_service_model!(template, OnlineReserve{ReserveDown}, RangeReserve)
 
     model = DecisionModel(
         template,

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -55,7 +55,7 @@ end
 
 @testset "Per-device reserve offers: data model" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    reserve = get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
     contributors, _ = add_device_reserve_offers!(sys, reserve)
 
     # Each contributor now bids into the service and exposes a per-(device, service) offer curve.
@@ -75,11 +75,11 @@ end
 
 @testset "Per-device reserve offers: builds, solves, and prices the offers" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    reserve = get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    reserve = get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
     contributors, base_slope = add_device_reserve_offers!(sys, reserve)
 
     template = get_thermal_standard_uc_template()
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -88,7 +88,7 @@ end
     container = get_optimization_container(model)
     # The reserve award exists, keyed by service type.
     @test IOM.has_container_key(
-        container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+        container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
 
     # The per-device reserve OFFER is now consumed: a 4D block variable keyed
     # (service, device, segment, time) exists for the contributing device type, plus the
@@ -100,7 +100,7 @@ end
     blk = IOM.get_variable(container, POM.PiecewiseLinearBlockReserveOffer, ThermalStandard)
     cons = IOM.get_constraint(container, POM.ReserveOfferLinkingConstraint, ThermalStandard)
     award =
-        IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+        IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     @test !isempty(blk)
 
     sname = PSY.get_name(reserve)
@@ -128,7 +128,7 @@ end
 
 @testset "StepwiseCostReserve prices per-device reserve offers (demand curve + offer supply)" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    ordc = first(get_components(PSY.ReserveDemandCurve, sys))
+    ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, sys))
     # Ensure thermal devices contribute to the operating reserve demand curve (ORDC) so they
     # can carry per-device offers.
     for g in get_components(ThermalStandard, sys)
@@ -138,7 +138,7 @@ end
 
     template = get_thermal_standard_uc_template()
     set_service_model!(
-        template, ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve))
+        template, ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -202,7 +202,7 @@ end
 
 @testset "StepwiseCostReserve: per-hour offer participation (dummy hours not awarded)" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    ordc = first(get_components(PSY.ReserveDemandCurve, sys))
+    ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, sys))
     for g in get_components(ThermalStandard, sys)
         ordc in PSY.get_services(g) || PSY.add_service!(g, ordc, sys)
     end
@@ -214,7 +214,7 @@ end
 
     template = get_thermal_standard_uc_template()
     set_service_model!(
-        template, ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve))
+        template, ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -222,7 +222,7 @@ end
 
     res = IOM.OptimizationProblemOutputs(model)
     awards = read_variable(
-        res, "ActivePowerReserveVariable__ReserveDemandCurve__ReserveUp";
+        res, "ActivePowerReserveVariable__OnlineReserve__ReserveUp";
         table_format = TableFormat.WIDE)
     # WIDE columns are "<service>__<device>"; values are per-hour reserve awards in MW.
     col = "$(PSY.get_name(ordc))__$(PSY.get_name(g1))"
@@ -235,7 +235,7 @@ end
 
 @testset "StepwiseCostReserve: no device offers -> no offer containers (ORDC unchanged)" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    ordc = first(get_components(PSY.ReserveDemandCurve, sys))
+    ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, sys))
     for g in get_components(ThermalStandard, sys)
         ordc in PSY.get_services(g) || PSY.add_service!(g, ordc, sys)
     end
@@ -243,7 +243,7 @@ end
 
     template = get_thermal_standard_uc_template()
     set_service_model!(
-        template, ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve))
+        template, ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -260,7 +260,7 @@ end
 
 @testset "StepwiseCostReserve: merit order (cheaper offer clears, pricier does not)" begin
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    ordc = first(get_components(PSY.ReserveDemandCurve, sys))
+    ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, sys))
     for g in get_components(ThermalStandard, sys)
         ordc in PSY.get_services(g) || PSY.add_service!(g, ordc, sys)
     end
@@ -270,7 +270,7 @@ end
 
     template = get_thermal_standard_uc_template()
     set_service_model!(
-        template, ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve))
+        template, ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -278,7 +278,7 @@ end
 
     res = IOM.OptimizationProblemOutputs(model)
     awards = read_variable(
-        res, "ActivePowerReserveVariable__ReserveDemandCurve__ReserveUp";
+        res, "ActivePowerReserveVariable__OnlineReserve__ReserveUp";
         table_format = TableFormat.WIDE)
     sname = PSY.get_name(ordc)
     order = sort(collect(keys(base_slope)); by = n -> base_slope[n])
@@ -301,7 +301,7 @@ end
     # field but is not handled by `get_services_bid`, so an ImportExport-cost device (e.g. a Source)
     # carrying a reserve offer must NOT enter the offering branch - which would MethodError.
     # Regression for the previously over-broad OfferCurveCost dispatch.
-    reserve = PSY.ConstantReserve{ReserveUp}("iec_regression", true, 10.0, 1.0)
+    reserve = PSY.OnlineReserve{ReserveUp}("iec_regression", true, 10.0, 1.0)
 
     iec = PSY.ImportExportCost(nothing)
     @test POM._cost_offers_reserve(iec, reserve) == false

--- a/test/test_formulation_combinations.jl
+++ b/test/test_formulation_combinations.jl
@@ -11,7 +11,7 @@
     end
 
     for item in res["service_formulations"]
-        if item["service_type"] == PSY.ConstantReserveNonSpinning &&
+        if item["service_type"] == PSY.OfflineReserve &&
            item["formulation"] == NonSpinningReserve
             found_valid_service = true
         end

--- a/test/test_model_decision.jl
+++ b/test/test_model_decision.jl
@@ -360,7 +360,7 @@ end
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserveNonSpinning, NonSpinningReserve),
+        ServiceModel(OfflineReserve, NonSpinningReserve),
     )
 
     UC = DecisionModel(template, c_sys5; optimizer = HiGHS_optimizer)
@@ -375,14 +375,14 @@ end
     # `(service_name, device_name, time)`.
     service_key = IOM.VariableKey(
         ActivePowerReserveVariable,
-        PSY.VariableReserveNonSpinning,
+        PSY.OfflineReserve,
     )
     @test service_key in keys(vars)
     # That container flattens to `"service_name__device_name"` result columns
     # (WIDE format one column per flattened pair).
     result = read_variable(
         res,
-        "ActivePowerReserveVariable__VariableReserveNonSpinning";
+        "ActivePowerReserveVariable__OfflineReserve";
         table_format = TableFormat.WIDE,
     )
     @test any(startswith(string(n), "NonSpinningReserve__") for n in names(result))

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1543,3 +1543,25 @@ end
         IS.get_time_series_key(PSY.get_variable(ordc_ts)),
     ) == 3
 end
+
+@testset "GroupReserve guards: formulation pairing and offer costs" begin
+    # Mis-pairs fail at ServiceModel declaration with an actionable error.
+    @test_throws ArgumentError ServiceModel(GroupReserve{ReserveUp}, RangeReserve)
+    @test_throws ArgumentError ServiceModel(GroupReserve{ReserveDown}, StepwiseCostReserve)
+    @test_throws ArgumentError ServiceModel(OnlineReserve{ReserveUp}, GroupRangeReserve)
+    @test_throws ArgumentError ServiceModel(OfflineReserve, GroupRangeReserve)
+    # Bare group type: the direction must be applied.
+    @test_throws ArgumentError ServiceModel(GroupReserve, GroupRangeReserve)
+    # The valid pair still constructs.
+    @test ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve) isa ServiceModel
+
+    # A group carries no per-device offers; the guard keeps the structural guarantee the
+    # `GroupReserve <: AbstractReserve` move would otherwise relax.
+    sys = System(100.0)
+    container = build_test_container(sys, 1:2)
+    group = GroupReserve{ReserveUp}(nothing)
+    model = ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve)
+    @test_throws IS.ConflictingInputsError POM.add_reserve_offer_costs!(
+        container, group, model,
+    )
+end

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1,12 +1,9 @@
-# Time-varying operating reserve demand curve (ORDC). Adapted from PowerSimulations.jl PR #1629
-# to the current PowerSystems data model,
-# where a time-varying ORDC is a `ReserveDemandTimeSeriesCurve` whose `variable` is a
-# `CostCurve{TimeSeriesPiecewiseIncrementalCurve}` (rather than a `ReserveDemandCurve`
-# carrying a bare `TimeSeriesKey`). The multi-step Simulation scenario from that PR is
-# omitted: the Simulation framework is not yet available in the IOM/POM split.
+# Time-varying operating reserve demand curve (ORDC): an `OnlineReserve` whose `variable` is a
+# `CostCurve{TimeSeriesPiecewiseIncrementalCurve}`. Multi-step Simulation scenarios are omitted:
+# the Simulation framework is not available in the IOM/POM split.
 
-# Build a time-varying ORDC (`ReserveDemandTimeSeriesCurve`) from the system's existing
-# static ORDC baseline curve, backing it with a deterministic cost-curve forecast.
+# Build a time-varying ORDC from the system's existing static ORDC baseline curve, backing it
+# with a deterministic cost-curve forecast.
 function _add_ts_ordc!(
     sys,
     name::String,
@@ -22,11 +19,12 @@ function _add_ts_ordc!(
     # Construct with a stub TS curve so the component can be added; the real forecast is
     # attached and set below.
     stub = stub_ts_offer_curve(; power_units = power_units)
-    ordc_ts = ReserveDemandTimeSeriesCurve{ReserveUp}(
-        stub,
-        name,
-        true,
-        PSY.get_time_frame(static_ordc),
+    # Keyword form: `variable` sits fifth positionally on `OnlineReserve`, so name the fields.
+    ordc_ts = OnlineReserve{ReserveUp}(;
+        name = name,
+        available = true,
+        time_frame = PSY.get_time_frame(static_ordc),
+        variable = stub,
     )
     add_service!(sys, ordc_ts, get_components(ThermalStandard, sys))
 
@@ -47,23 +45,21 @@ end
 
 @testset "Test ORDC time series (build)" begin
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
-    static_ordc = first(get_components(PSY.ReserveDemandCurve, c_sys5_uc))
+    static_ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, c_sys5_uc))
     _add_ts_ordc!(c_sys5_uc, "ORDC_TS", static_ordc)
 
     template = get_thermal_standard_uc_template()
-    # One per-type model now covers both VariableReserve{ReserveUp} services
+    # One per-type model covers both OnlineReserve{ReserveUp} services
     # (Reserve1 and Reserve11).
+    # OnlineReserve{ReserveUp} carries the ORDC, so it uses StepwiseCostReserve; the curve-less
+    # requirement reserves of that direction are supply-only under the degenerate-demand skip.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
-    )
-    set_service_model!(
-        template,
-        ServiceModel(ReserveDemandTimeSeriesCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
     model = DecisionModel(
         template,
@@ -78,15 +74,13 @@ end
 @testset "Test Reserve Requirement Slack Variables" begin
     # `use_slacks = true` on a reserve ServiceModel triggers `add_reserve_slacks!`
     # (services_models/service_slacks.jl), which builds ReserveRequirementSlack as a dense
-    # 2D container over the type's service-name axis and the time-step axis. This path
-    # previously had zero test coverage in the whole suite. See POM issue #178 /
-    # developer guidelines.
+    # 2D container over the type's service-name axis and the time-step axis.
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
     template = get_thermal_standard_uc_template()
     set_service_model!(
         template,
         ServiceModel(
-            VariableReserve{ReserveUp},
+            OnlineReserve{ReserveUp},
             RangeReserve;
             use_slacks = true,
         ),
@@ -106,7 +100,7 @@ end
     slack_var = IOM.get_variable(
         container,
         ReserveRequirementSlack,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
     time_steps = get_time_steps(container)
     @test all(JuMP.lower_bound(slack_var["Reserve1", t]) == 0.0 for t in time_steps)
@@ -121,31 +115,34 @@ end
 end
 
 @testset "Per-type reserve container isolates services of the same type" begin
-    # Two VariableReserve{ReserveUp} services share one
+    # Two OnlineReserve{ReserveUp} services share one
     # `(service, device, time)` ActivePowerReserveVariable container. Verify (a) each
     # service's requirement constraint sums only its own device variables (no
     # cross-service leakage) and (b) the proportional reserve cost prices each variable
     # exactly once (no double counting across the per-type objective pass).
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    # One per-type model covers both VariableReserve{ReserveUp} services.
+    # One per-type model covers both OnlineReserve{ReserveUp} services.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
 
     container = get_optimization_container(model)
-    rv = IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    rv = IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     con = IOM.get_constraint(
         container,
         RequirementConstraint,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
-    # Exactly one container spans both services.
-    @test Set(k[1] for k in keys(rv.data)) == Set(["Reserve1", "Reserve11"])
+    # One container spans every OnlineReserve{ReserveUp} in the system. ORDC1 is one of them: it
+    # carries a demand curve but no requirement, so under RangeReserve its demand-side model is
+    # skipped and it is supply-only - it keeps award variables but gets no requirement rows.
+    @test Set(k[1] for k in keys(rv.data)) == Set(["Reserve1", "Reserve11", "ORDC1"])
+    @test Set(axes(con)[1]) == Set(["Reserve1", "Reserve11"])
 
     # (a) Reserve1's requirement constraint at t=1 has coefficient 1 for Reserve1's
     # variables and 0 for Reserve11's.
@@ -156,12 +153,15 @@ end
         @test JuMP.normalized_coefficient(c1, var) == expected
     end
 
-    # (b) Each reserve variable is priced exactly once at DEFAULT_RESERVE_COST / base.
+    # (b) Each reserve variable of a demand-imposing service is priced exactly once at
+    # DEFAULT_RESERVE_COST / base. A skipped (supply-only) service gets no flat cost: its awards
+    # are driven by a group or by its own offers, not by this fallback.
     obj = JuMP.objective_function(get_jump_model(model))
     base_p = get_model_base_power(container)
     expected_cost = POM.DEFAULT_RESERVE_COST / base_p
-    for (_, var) in rv.data
-        @test JuMP.coefficient(obj, var) == expected_cost
+    for (key, var) in rv.data
+        expected = key[1] == "ORDC1" ? 0.0 : expected_cost
+        @test JuMP.coefficient(obj, var) == expected
     end
 end
 
@@ -169,8 +169,8 @@ end
     # Bulk `add_time_series!` stores one array for both services, so both resolve to the same
     # UUID. The UUID parameter axis must dedupe or JuMP rejects the repeated axis element.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    r11 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve11")
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
+    r11 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve11")
     PSY.set_requirement!(r11, 2 * PSY.get_requirement(r1, PSY.SU) * PSY.SU)
     forecast = PSY.get_time_series(PSY.Deterministic, r1, "requirement")
     PSY.remove_time_series!(sys, PSY.Deterministic, r1, "requirement")
@@ -180,7 +180,7 @@ end
           IS.get_time_series_uuid(PSY.Deterministic, r11, "requirement")
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -189,7 +189,7 @@ end
     param_container = IOM.get_parameter(
         container,
         RequirementTimeSeriesParameter,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
     # One parameter row for the shared series; still one multiplier row per service.
     @test length(axes(IOM.get_parameter_array(param_container))[1]) == 1
@@ -211,7 +211,7 @@ end
     # must be rejected rather than silently read at the wrong resolution. The explicit
     # `resolution` kwarg is required: `_reconcile_resolution!` errors first without it.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    fast = VariableReserve{ReserveUp}("ReserveFast", true, 60.0, 0.05)
+    fast = OnlineReserve{ReserveUp}("ReserveFast", true, 60.0, 0.05)
     PSY.add_service!(sys, fast, get_components(ThermalStandard, sys))
     initial_time = DateTime("2024-01-01T00:00:00")
     five_min_values = collect(range(0.01, 0.05; length = 288))
@@ -230,7 +230,7 @@ end
     @test length(IOM.get_time_series_resolutions(sys)) == 2
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     model = DecisionModel(
         template,
         sys;
@@ -245,18 +245,18 @@ end
 end
 
 @testset "Per-type populate errors when one service of the type has no contributing devices" begin
-    # Under the per-type ServiceModel, one model covers every VariableReserve{ReserveUp}
+    # Under the per-type ServiceModel, one model covers every OnlineReserve{ReserveUp}
     # service. A modeled reserve with no available contributing device can never meet its
     # requirement, so `_populate_contributing_devices!` (run in the DecisionModel
     # constructor) must error and name the offending service - not silently drop it.
     # `deepcopy` so the added service does not leak into the PSB-cached system.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
     # A second service of the same type, added with no contributing devices.
-    empty_reserve = VariableReserve{ReserveUp}("ReserveNoDevices", true, 5.0, 0.1)
+    empty_reserve = OnlineReserve{ReserveUp}("ReserveNoDevices", true, 5.0, 0.1)
     PSY.add_service!(sys, empty_reserve, PSY.Device[])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     @test_throws "ReserveNoDevices" DecisionModel(
         template,
         sys;
@@ -270,7 +270,7 @@ end
     # the per-service map ends up empty and the constructor must error - the reserve has no
     # usable provider. `deepcopy` so the availability edits do not leak into the cache.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    reserve = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    reserve = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
     n_disabled = 0
     for d in PSY.get_components(PSY.Device, sys)
         PSY.supports_services(d) || continue
@@ -284,7 +284,7 @@ end
     @test n_disabled > 0
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     @test_throws "no available contributing devices" DecisionModel(
         template,
         sys;
@@ -302,7 +302,7 @@ end
     set_service_model!(
         template,
         ServiceModel(
-            VariableReserve{ReserveUp},
+            OnlineReserve{ReserveUp},
             RangeReserve;
             use_slacks = true,
         ),
@@ -320,7 +320,7 @@ end
     slack_var = IOM.get_variable(
         container,
         ReserveRequirementSlack,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
     time_steps = get_time_steps(container)
     reserve_names = ["Reserve1", "Reserve11"]
@@ -339,7 +339,7 @@ end
     template_noslack = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
     set_service_model!(
         template_noslack,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     model_noslack =
         DecisionModel(template_noslack, c_sys5_uc_noslack; optimizer = HiGHS_optimizer)
@@ -350,7 +350,7 @@ end
     @test !IOM.has_container_key(
         container_noslack,
         ReserveRequirementSlack,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
 end
 
@@ -365,7 +365,7 @@ end
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
@@ -373,11 +373,11 @@ end
     @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
 
     container = get_optimization_container(model)
-    rv = IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    rv = IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     con = IOM.get_constraint(
         container,
         RequirementConstraint,
-        VariableReserve{ReserveUp},
+        OnlineReserve{ReserveUp},
     )
     reserve_names = ["Reserve1", "Reserve11"]
     @test Set(k[1] for k in keys(rv.data)) >= Set(reserve_names)
@@ -401,7 +401,7 @@ end
     set_service_model!(
         template,
         ServiceModel(
-            VariableReserve{ReserveUp},
+            OnlineReserve{ReserveUp},
             RangeReserve;
             duals = [RequirementConstraint],
         ),
@@ -412,14 +412,14 @@ end
     @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
 
     container = get_optimization_container(model)
-    dual_key = IOM.ConstraintKey(RequirementConstraint, VariableReserve{ReserveUp})
+    dual_key = IOM.ConstraintKey(RequirementConstraint, OnlineReserve{ReserveUp})
     # One dual container per service type, dense (mirrors the constraint container).
     @test dual_key in keys(IOM.get_duals(container))
     @test IOM.get_duals(container)[dual_key] isa
           JuMP.Containers.DenseAxisArray{Float64, 2}
 
     res = OptimizationProblemOutputs(model)
-    df = read_dual(res, "RequirementConstraint__VariableReserve__ReserveUp")
+    df = read_dual(res, "RequirementConstraint__OnlineReserve__ReserveUp")
     # LONG format `(DateTime, name, value)`; the name column covers ALL services of the type.
     @test Set(df.name) == Set(["Reserve1", "Reserve11"])
     # Reserve is priced only at DEFAULT_RESERVE_COST and the requirement binds, so the
@@ -430,7 +430,7 @@ end
 
 @testset "Test ORDC time series (build & solve)" begin
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
-    static_ordc = first(get_components(PSY.ReserveDemandCurve, c_sys5_uc))
+    static_ordc = first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, c_sys5_uc))
     # Two time-varying ORDCs with different per-timestep tranche counts to exercise the
     # tranche-axis padding and per-service (meta-keyed) parameter containers.
     _add_ts_ordc!(
@@ -457,16 +457,16 @@ end
     set_device_model!(template, PowerLoad, StaticPowerLoad)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     # One per-type model covers both time-varying ORDCs (ORDC_TS1 and ORDC_TS2).
     set_service_model!(
         template,
-        ServiceModel(ReserveDemandTimeSeriesCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
     model = DecisionModel(
         template,
@@ -485,10 +485,10 @@ end
     # also exercises the batch-wide tranche padding.
     container = get_optimization_container(model)
     dir = POM._reserve_offer_direction(
-        first(get_components(ReserveDemandTimeSeriesCurve, c_sys5_uc)),
+        first(get_components(PSY.has_demand_curve, PSY.OnlineReserve, c_sys5_uc)),
     )
     for P in (IOM._slope_param(dir), IOM._breakpoint_param(dir))
-        @test IOM.get_parameter(container, P, ReserveDemandTimeSeriesCurve{ReserveUp}) !==
+        @test IOM.get_parameter(container, P, OnlineReserve{ReserveUp}) !==
               nothing
     end
 end
@@ -514,35 +514,33 @@ end
 
 @testset "Test Reserves from Thermal Dispatch" begin
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
+    # OnlineReserve{ReserveUp} carries the ORDC, so it uses StepwiseCostReserve; the curve-less
+    # requirement reserves of that direction are supply-only under the degenerate-demand skip.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
-    )
-    set_service_model!(
-        template,
-        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
 
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
     model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
-    @test _count_reserve_var_containers(model) == 3
+    @test _count_reserve_var_containers(model) == 2
 end
 
 @testset "Test Ramp Reserves from Thermal Dispatch" begin
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RampReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RampReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RampReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RampReserve),
     )
 
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
@@ -554,17 +552,15 @@ end
 
 @testset "Test Reserves from Thermal Standard UC" begin
     template = get_thermal_standard_uc_template()
+    # OnlineReserve{ReserveUp} carries the ORDC, so it uses StepwiseCostReserve; the curve-less
+    # requirement reserves of that direction are supply-only under the degenerate-demand skip.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
-    )
-    set_service_model!(
-        template,
-        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true)
     model = DecisionModel(
@@ -575,7 +571,7 @@ end
     )
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
-    @test _count_reserve_var_containers(model) == 3
+    @test _count_reserve_var_containers(model) == 2
 end
 
 @testset "Test Reserves from Thermal Standard UC with NonSpinningReserve" begin
@@ -586,7 +582,7 @@ end
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserveNonSpinning, NonSpinningReserve),
+        ServiceModel(OfflineReserve, NonSpinningReserve),
     )
 
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc_non_spin"; add_reserves = true)
@@ -599,20 +595,18 @@ end
     template = PowerOperationsProblemTemplate(CopperPlateNetworkModel)
     set_device_model!(template, PowerLoad, StaticPowerLoad)
     set_device_model!(template, RenewableDispatch, RenewableFullDispatch)
+    # OnlineReserve{ReserveUp} carries the ORDC, so it uses StepwiseCostReserve; the curve-less
+    # requirement reserves of that direction are supply-only under the degenerate-demand skip.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
-    )
-    set_service_model!(
-        template,
-        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
 
     c_sys5_re = PSB.build_system(PSITestSystems, "c_sys5_re"; add_reserves = true)
     model = DecisionModel(template, c_sys5_re; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
-    @test _count_reserve_var_containers(model) == 2
+    @test _count_reserve_var_containers(model) == 1
 end
 
 @testset "Test Reserves with slack variables" begin
@@ -622,7 +616,7 @@ end
     set_service_model!(
         template,
         ServiceModel(
-            VariableReserve{ReserveUp},
+            OnlineReserve{ReserveUp},
             RangeReserve;
             use_slacks = true,
         ),
@@ -630,7 +624,7 @@ end
     set_service_model!(
         template,
         ServiceModel(
-            VariableReserve{ReserveDown},
+            OnlineReserve{ReserveDown},
             RangeReserve;
             use_slacks = true,
         ),
@@ -643,15 +637,15 @@ end
     @test _count_reserve_var_containers(model) == 2
 end
 
-@testset "Test ConstantReserve" begin
+@testset "Test OnlineReserve" begin
     template = get_thermal_dispatch_template_network()
     set_service_model!(
         template,
-        ServiceModel(ConstantReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
 
     c_sys5_uc = PSB.build_system(PSITestSystems, "c_sys5_uc")
-    static_reserve = ConstantReserve{ReserveUp}(;
+    static_reserve = OnlineReserve{ReserveUp}(;
         name = "Reserve3",
         available = true,
         time_frame = 100.0,
@@ -671,23 +665,21 @@ end
     end
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
+    # OnlineReserve{ReserveUp} carries the ORDC, so it uses StepwiseCostReserve; the curve-less
+    # requirement reserves of that direction are supply-only under the degenerate-demand skip.
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
-    )
-    set_service_model!(
-        template,
-        ServiceModel(ReserveDemandCurve{ReserveUp}, StepwiseCostReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
     )
 
     model = DecisionModel(template, c_sys5_uc; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
-    @test _count_reserve_var_containers(model) == 3
+    @test _count_reserve_var_containers(model) == 2
 
     found_constraints = 0
     for (k, _) in IOM.get_optimization_container(model).constraints
@@ -1258,17 +1250,17 @@ end
 end
 
 @testset "GroupReserve requirement sums only its contributing services" begin
-    # A ConstantReserveGroup's RequirementConstraint must sum the ActivePowerReserveVariable of
+    # A GroupReserve's RequirementConstraint must sum the ActivePowerReserveVariable of
     # every contributing service (and only those) across the (service, device, time)
     # container. Exercises reserve_group.jl `add_constraints!` and `_group_member_variables`.
     # Reachable only because the no-contributing-devices error in
     # `_populate_contributing_devices!` is scoped to `PSY.Reserve`, exempting groups.
     # `deepcopy` so the added group does not leak into the PSB-cached system.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
     # Group contains ONLY Reserve1, so the constraint must include Reserve1's device variables and
     # exclude Reserve11's — verifying the barrier's per-service `key[1] == r_name` filtering.
-    group = ConstantReserveGroup{ReserveUp}(;
+    group = GroupReserve{ReserveUp}(;
         name = "group_up",
         available = true,
         requirement = 0.0,
@@ -1276,21 +1268,21 @@ end
     add_service!(sys, group, Service[r1])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveUp}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve),
     )
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
 
     container = get_optimization_container(model)
-    rv = IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    rv = IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     con = IOM.get_constraint(
         container,
         RequirementConstraint,
-        ConstantReserveGroup{ReserveUp},
+        GroupReserve{ReserveUp},
     )
 
     # Dense group-indexed requirement container keyed [group_name, time].
@@ -1317,9 +1309,9 @@ end
     # `(service, device, time)` container - the multi-service case the single-service test above
     # does not exercise.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    r11 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve11")
-    group = ConstantReserveGroup{ReserveUp}(;
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
+    r11 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve11")
+    group = GroupReserve{ReserveUp}(;
         name = "group_up",
         available = true,
         requirement = 0.0,
@@ -1327,29 +1319,33 @@ end
     add_service!(sys, group, Service[r1, r11])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveUp}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve),
     )
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
 
     container = get_optimization_container(model)
-    rv = IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    rv = IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     con = IOM.get_constraint(
         container,
         RequirementConstraint,
-        ConstantReserveGroup{ReserveUp},
+        GroupReserve{ReserveUp},
     )
     c1 = con["group_up", 1]
-    # Both members' device variables enter the group sum with coefficient 1 at t=1.
+    # Both members' device variables enter the group sum with coefficient 1 at t=1, and only
+    # theirs: the container is shared by every OnlineReserve{ReserveUp}, so the non-member ORDC1
+    # is present but must not enter the group's constraint.
+    members = Set(["Reserve1", "Reserve11"])
     seen_r1 = 0
     seen_r11 = 0
     for (key, var) in rv.data
         key[3] == 1 || continue
-        @test JuMP.normalized_coefficient(c1, var) == 1.0
+        expected = key[1] in members ? 1.0 : 0.0
+        @test JuMP.normalized_coefficient(c1, var) == expected
         key[1] == "Reserve1" && (seen_r1 += 1)
         key[1] == "Reserve11" && (seen_r11 += 1)
     end
@@ -1358,10 +1354,10 @@ end
 end
 
 @testset "GroupReserve builds and solves for ReserveDown" begin
-    # Direction parity: a ConstantReserveGroup{ReserveDown} over a down reserve.
+    # Direction parity: a GroupReserve{ReserveDown} over a down reserve.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r2 = PSY.get_component(VariableReserve{ReserveDown}, sys, "Reserve2")
-    group = ConstantReserveGroup{ReserveDown}(;
+    r2 = PSY.get_component(OnlineReserve{ReserveDown}, sys, "Reserve2")
+    group = GroupReserve{ReserveDown}(;
         name = "group_dn",
         available = true,
         requirement = 0.0,
@@ -1369,19 +1365,19 @@ end
     add_service!(sys, group, Service[r2])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveDown}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveDown}, RangeReserve))
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveDown}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveDown}, GroupRangeReserve),
     )
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
     container = get_optimization_container(model)
     @test IOM.has_container_key(
-        container, RequirementConstraint, ConstantReserveGroup{ReserveDown})
+        container, RequirementConstraint, GroupReserve{ReserveDown})
     con = IOM.get_constraint(
-        container, RequirementConstraint, ConstantReserveGroup{ReserveDown})
+        container, RequirementConstraint, GroupReserve{ReserveDown})
     @test "group_dn" in axes(con)[1]
     @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
 end
@@ -1391,8 +1387,8 @@ end
     # contributing services. Solve and confirm the sum meets the requirement at every step.
     req = 0.5
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    group = ConstantReserveGroup{ReserveUp}(;
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
+    group = GroupReserve{ReserveUp}(;
         name = "group_up",
         available = true,
         requirement = req,
@@ -1400,10 +1396,10 @@ end
     add_service!(sys, group, Service[r1])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveUp}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve),
     )
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
@@ -1411,7 +1407,7 @@ end
     @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
 
     container = get_optimization_container(model)
-    rv = IOM.get_variable(container, ActivePowerReserveVariable, VariableReserve{ReserveUp})
+    rv = IOM.get_variable(container, ActivePowerReserveVariable, OnlineReserve{ReserveUp})
     for t in IOM.get_time_steps(container)
         provided =
             sum(
@@ -1427,8 +1423,8 @@ end
     # to be modeled first. With no ServiceModel for the member reserve, its
     # ActivePowerReserveVariable is never created, so the build fails.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    group = ConstantReserveGroup{ReserveUp}(;
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
+    group = GroupReserve{ReserveUp}(;
         name = "group_up",
         available = true,
         requirement = 0.0,
@@ -1436,10 +1432,10 @@ end
     add_service!(sys, group, Service[r1])
 
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
-    # Deliberately omit `ServiceModel(VariableReserve{ReserveUp}, RangeReserve)`.
+    # Deliberately omit `ServiceModel(OnlineReserve{ReserveUp}, RangeReserve)`.
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveUp}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve),
     )
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
@@ -1450,8 +1446,8 @@ end
     # The group's ServiceModel is added before its member's; construction still defers the group
     # to last (so the member's ActivePowerReserveVariable exists when the group reads it).
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"; add_reserves = true))
-    r1 = PSY.get_component(VariableReserve{ReserveUp}, sys, "Reserve1")
-    group = ConstantReserveGroup{ReserveUp}(;
+    r1 = PSY.get_component(OnlineReserve{ReserveUp}, sys, "Reserve1")
+    group = GroupReserve{ReserveUp}(;
         name = "group_up",
         available = true,
         requirement = 0.0,
@@ -1461,9 +1457,9 @@ end
     template = get_thermal_dispatch_template_network(CopperPlateNetworkModel)
     set_service_model!(
         template,
-        ServiceModel(ConstantReserveGroup{ReserveUp}, GroupReserve),
+        ServiceModel(GroupReserve{ReserveUp}, GroupRangeReserve),
     )
-    set_service_model!(template, ServiceModel(VariableReserve{ReserveUp}, RangeReserve))
+    set_service_model!(template, ServiceModel(OnlineReserve{ReserveUp}, RangeReserve))
     model = DecisionModel(template, sys; optimizer = HiGHS_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
@@ -1476,25 +1472,26 @@ end
 #    (`LowerBoundFeedforward`, `FixValueFeedforward`, …) are not defined in POM or IOM —
 #    only the feedforward constraint types and the abstract construct hooks exist.
 # Also not ported (feature/framework not in POM): AGC (no `template_agc_reserve_deployment`),
-# Hydro reserves (`HydroTurbineEnergyDispatch` absent), the old bare-`TimeSeriesKey` ORDC
-# tests (the current PowerSystems model uses `ReserveDemandTimeSeriesCurve`; covered by the two ORDC testsets above),
-# and all Simulation-orchestration testsets (Simulation framework absent in the IOM/POM split).
+# Hydro reserves (`HydroTurbineEnergyDispatch` absent), the bare-`TimeSeriesKey` ORDC tests
+# (superseded by the two ORDC testsets above), and all Simulation-orchestration testsets
+# (Simulation framework absent in the IOM/POM split).
 
 # Time-varying ORDC support when the curve is attached as a `SingleTimeSeries` and materialized by
 # `transform_single_time_series!` (the ORDC testsets above attach a direct `Deterministic` with
 # thermal contributors, so neither path below is otherwise covered):
-#   (a) `StorageDispatchWithReserves` reserve bounds must accept `ReserveDemandTimeSeriesCurve`
-#       (only `ReserveDemandCurve` was specialized, so a storage contributor fell through to the
-#       generic method's `get_max_output_fraction`, which the demand curves lack).
+#   (a) `StorageDispatchWithReserves` reserve bounds must accept a time-series ORDC and give it
+#       the full-range bound.
 #   (b) `get_max_tranches` must handle the `DeterministicSingleTimeSeries` produced by transform
 #       (which has no `get_data`).
 
-@testset "StorageDispatchWithReserves reserve bound accepts ReserveDemandTimeSeriesCurve" begin
+@testset "StorageDispatchWithReserves reserve bound accepts a time-series ORDC" begin
     sys = PSB.build_system(PSITestSystems, "c_sys5_bat")
     storage = first(get_components(PSY.EnergyReservoirStorage, sys))
-    ordc_ts = ReserveDemandTimeSeriesCurve{ReserveUp}(
-        stub_ts_offer_curve(; power_units = PSY.SU), "ORDC_TS", true, 1.0)
-    # Full input/output range (no get_max_output_fraction), exactly as for a static ReserveDemandCurve.
+    ordc_ts = OnlineReserve{ReserveUp}(;
+        name = "ORDC_TS", available = true, time_frame = 1.0,
+        variable = stub_ts_offer_curve(; power_units = PSY.SU))
+    # Full input/output range, exactly as for a static ORDC (demand curves have no
+    # `get_max_output_fraction`).
     @test POM.get_variable_upper_bound(
         POM.AncillaryServiceVariableDischarge, ordc_ts, storage,
         POM.StorageDispatchWithReserves) ==
@@ -1517,8 +1514,9 @@ end
     three = IS.PiecewiseStepData([0.0, 100.0, 200.0, 300.0], [50.0, 30.0, 10.0])
     curves = [isodd(k) ? three : two for k in 1:n]
 
-    ordc_ts = ReserveDemandTimeSeriesCurve{ReserveUp}(
-        stub_ts_offer_curve(; power_units = IS.NaturalUnit()), "ORDC_TS", true, 1.0)
+    ordc_ts = OnlineReserve{ReserveUp}(;
+        name = "ORDC_TS", available = true, time_frame = 1.0,
+        variable = stub_ts_offer_curve(; power_units = IS.NaturalUnit()))
     add_service!(sys, ordc_ts, get_components(PSY.EnergyReservoirStorage, sys))
     add_time_series!(sys, ordc_ts,
         IS.SingleTimeSeries(;

--- a/test/test_storage_device_models.jl
+++ b/test/test_storage_device_models.jl
@@ -1,3 +1,14 @@
+# Deactivate demand-curve reserves (ORDC1 in `c_sys5_bat`) so a template registering
+# `ServiceModel(OnlineReserve{Dir}, RangeReserve)` models only the requirement reserves
+# (Reserve3 up, Reserve4 down); one `ServiceModel` covers every service of its type, so an
+# available ORDC would be swept into the same model and widen the tests' scope.
+function _deactivate_unmodeled_ordc!(sys)
+    for r in PSY.get_components(PSY.has_demand_curve, PSY.OnlineReserve, sys)
+        PSY.set_available!(r, false)
+    end
+    return sys
+end
+
 # TODO these all error due to add_event_model = true, which isn't supported in POM.
 #=
 @testset "Storage Basic Storage With DC - PF" begin
@@ -252,18 +263,43 @@ end =#
     set_device_model!(template, RenewableDispatch, FixedOutput)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
 
     c_sys5_bat = PSB.build_system(PSITestSystems, "c_sys5_bat"; add_reserves = true)
+    _deactivate_unmodeled_ordc!(c_sys5_bat)
     model = DecisionModel(template, c_sys5_bat)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           ModelBuildStatus.BUILT
-    moi_tests(model, 458, 0, 574, 286, 125, true)
+    # Complete-coverage constraints are built once per unique service type and side (each
+    # sums every same-direction service), so the battery's two up-reserves share a single
+    # 24-row container per coverage family.
+    moi_tests(model, 458, 0, 526, 286, 125, true)
+
+    # Silent-failure guard: each storage total-reserve balance row must hold exactly three
+    # terms (charge + discharge - award). If the service-device wiring is skipped, the award
+    # term vanishes while every constraint count still matches, letting storage "provide"
+    # reserves with no physical backing.
+    constraints = IOM.get_constraints(model)
+    for (service_type, s_name) in (
+        (OnlineReserve{ReserveUp}, "Reserve3"),
+        (OnlineReserve{ReserveDown}, "Reserve4"),
+    )
+        key = IOM.ConstraintKey(
+            StorageTotalReserveConstraint,
+            service_type,
+            "$(s_name)_$EnergyReservoirStorage",
+        )
+        con = constraints[key]
+        @test all(
+            length(JuMP.constraint_object(con[n, t]).func.terms) == 3
+            for n in axes(con)[1], t in axes(con)[2]
+        )
+    end
 
     device_model = DeviceModel(
         EnergyReservoirStorage,
@@ -280,7 +316,7 @@ end =#
     model = DecisionModel(template, c_sys5_bat)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           ModelBuildStatus.BUILT
-    moi_tests(model, 434, 0, 574, 286, 125, false)
+    moi_tests(model, 434, 0, 526, 286, 125, false)
 end
 
 @testset "Test Storage Energy Target Constraint" begin
@@ -371,14 +407,15 @@ end
     set_device_model!(template, RenewableDispatch, FixedOutput)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
 
     c_sys5_bat = PSB.build_system(PSITestSystems, "c_sys5_bat"; add_reserves = true)
+    _deactivate_unmodeled_ordc!(c_sys5_bat)
     model = DecisionModel(template, c_sys5_bat)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           ModelBuildStatus.BUILT
@@ -434,14 +471,15 @@ end
     set_device_model!(template, RenewableDispatch, FixedOutput)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
 
     c_sys5_bat = PSB.build_system(PSITestSystems, "c_sys5_bat"; add_reserves = true)
+    _deactivate_unmodeled_ordc!(c_sys5_bat)
     model = DecisionModel(template, c_sys5_bat; optimizer = ipopt_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           ModelBuildStatus.BUILT
@@ -464,14 +502,15 @@ end
     set_device_model!(template, RenewableDispatch, FixedOutput)
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveUp}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveUp}, RangeReserve),
     )
     set_service_model!(
         template,
-        ServiceModel(VariableReserve{ReserveDown}, RangeReserve),
+        ServiceModel(OnlineReserve{ReserveDown}, RangeReserve),
     )
 
     c_sys5_bat = PSB.build_system(PSITestSystems, "c_sys5_bat"; add_reserves = true)
+    _deactivate_unmodeled_ordc!(c_sys5_bat)
     model = DecisionModel(template, c_sys5_bat; optimizer = ipopt_optimizer)
     @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
           ModelBuildStatus.BUILT

--- a/test/test_utils/add_components_to_system.jl
+++ b/test/test_utils/add_components_to_system.jl
@@ -166,7 +166,7 @@ function add_reserve_product_without_requirement_time_series!(
         "Down" => ReserveDown,
     )
     as_direction = AS_DIRECTION_MAP[direction]
-    reserve_instance = VariableReserve{as_direction}(;
+    reserve_instance = OnlineReserve{as_direction}(;
         name = name,
         available = true,
         time_frame = 0.0,


### PR DESCRIPTION
Reserve dispatch re-expressed on the psy6 reserve tree, with distinctions recovered from state instead of struct types: direction and non-spin via `reserve_traits.jl`, ORDCs via the demand curve on `variable`, static vs time-varying requirements via the attached series. Includes the degenerate-demand supply-only skip (services can serve a `GroupReserve`), the `GroupRangeReserve` rename, instance-derived container metas, and two independent fixes in their own commits: the `Symbol(T)`-vs-`nameof` silent service-device wiring skip under parallel test workers, and the units-mandatory `get_max_shunt_current` read.

Full suite green locally against the local psy6 stack: 105891/105891.

**Scope note:** this PR is the refactor only. The elastic group ORDC (`GroupStepwiseCostReserve`) and load reserve provision (`PowerLoadDispatch` up/down reserves with the costless-load guard) are NEW features, not migrations of existing behavior, and will land in a follow-up PR together with the market integration test and their `formulation_library.md` entries.

Depends on the PSY reserve changes (`jd/schema_matching`), Sienna-Platform/PowerSystemsTestData#124, and Sienna-Platform/PowerSystemCaseBuilder.jl#212 - CI cannot pass until those merge and `[sources]` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)