### PR TITLE
Group-stepwise ORDC, load reserve provision, and OfflineReserve ORDC supply

### DIFF
--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -1957,11 +1957,7 @@ function add_to_expression!(
     model::DeviceModel{V, W},
     network_model::NetworkModel{X},
 ) where {
-    T <: Union{
-        ActivePowerRangeExpressionUB,
-        ActivePowerRangeExpressionLB,
-        ActivePowerRangeExpressionOnlineUB,
-    },
+    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
     U <: VariableType,
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
@@ -2001,27 +1997,10 @@ function add_to_expression!(
     end
     expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
-    # Online up-reserves also occupy the online-only band row when a device carries an
-    # OfflineReserve (the OnlineUB expression exists only in that case); offline awards
-    # live solely in the shared UB band, freed from the commitment gate by
-    # OfflineReserveBandConstraint.
-    online_ub =
-        if !(service isa PSY.OfflineReserve) &&
-           has_container_key(container, ActivePowerRangeExpressionOnlineUB, V)
-            get_expression(container, ActivePowerRangeExpressionOnlineUB, V)
-        else
-            nothing
-        end
     for d in devices, t in time_steps
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(
             expression[name, t],
-            variable[(service_name, name, t)],
-            1.0,
-        )
-        online_ub === nothing && continue
-        add_proportional_to_jump_expression!(
-            online_ub[name, t],
             variable[(service_name, name, t)],
             1.0,
         )
@@ -2507,11 +2486,7 @@ function add_to_expression!(
     devices::IS.FlattenIteratorWrapper{V},
     model::DeviceModel{V, W},
 ) where {
-    T <: Union{
-        ActivePowerRangeExpressionUB,
-        ActivePowerRangeExpressionLB,
-        ActivePowerRangeExpressionOnlineUB,
-    },
+    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
     U <: OnStatusParameter,
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
@@ -2544,11 +2519,7 @@ function add_to_expression!(
     devices::IS.FlattenIteratorWrapper{V},
     model::DeviceModel{V, W},
 ) where {
-    T <: Union{
-        ActivePowerRangeExpressionUB,
-        ActivePowerRangeExpressionLB,
-        ActivePowerRangeExpressionOnlineUB,
-    },
+    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
     U <: OnStatusParameter,
     V <: PSY.ThermalGen,
     W <: AbstractThermalDispatchFormulation,
@@ -2590,6 +2561,12 @@ function add_to_expression!(
         # silently skipping the whole service-device wiring on a key miss.
         device_model = get(devices_template, nameof(device_type), nothing)
         device_model === nothing && continue
+        # Offline awards stay out of the commitment-gated range expression for formulations
+        # providing offline capability through OfflineReserveBandConstraint.
+        if _is_offline_reserve(V) &&
+           !offline_reserve_in_range_ub(get_formulation(device_model))
+            continue
+        end
         expression_type = get_expression_type_for_reserve(U, device_type, V)
         add_to_expression!(container, expression_type, U, service, devices, model)
     end

--- a/src/common_models/add_to_expression.jl
+++ b/src/common_models/add_to_expression.jl
@@ -1957,7 +1957,11 @@ function add_to_expression!(
     model::DeviceModel{V, W},
     network_model::NetworkModel{X},
 ) where {
-    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
+    T <: Union{
+        ActivePowerRangeExpressionUB,
+        ActivePowerRangeExpressionLB,
+        ActivePowerRangeExpressionOnlineUB,
+    },
     U <: VariableType,
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
@@ -1997,10 +2001,27 @@ function add_to_expression!(
     end
     expression = get_expression(container, T, V)
     time_steps = get_time_steps(container)
+    # Online up-reserves also occupy the online-only band row when a device carries an
+    # OfflineReserve (the OnlineUB expression exists only in that case); offline awards
+    # live solely in the shared UB band, freed from the commitment gate by
+    # OfflineReserveBandConstraint.
+    online_ub =
+        if !(service isa PSY.OfflineReserve) &&
+           has_container_key(container, ActivePowerRangeExpressionOnlineUB, V)
+            get_expression(container, ActivePowerRangeExpressionOnlineUB, V)
+        else
+            nothing
+        end
     for d in devices, t in time_steps
         name = PSY.get_name(d)
         add_proportional_to_jump_expression!(
             expression[name, t],
+            variable[(service_name, name, t)],
+            1.0,
+        )
+        online_ub === nothing && continue
+        add_proportional_to_jump_expression!(
+            online_ub[name, t],
             variable[(service_name, name, t)],
             1.0,
         )
@@ -2486,7 +2507,11 @@ function add_to_expression!(
     devices::IS.FlattenIteratorWrapper{V},
     model::DeviceModel{V, W},
 ) where {
-    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
+    T <: Union{
+        ActivePowerRangeExpressionUB,
+        ActivePowerRangeExpressionLB,
+        ActivePowerRangeExpressionOnlineUB,
+    },
     U <: OnStatusParameter,
     V <: PSY.Device,
     W <: AbstractDeviceFormulation,
@@ -2519,7 +2544,11 @@ function add_to_expression!(
     devices::IS.FlattenIteratorWrapper{V},
     model::DeviceModel{V, W},
 ) where {
-    T <: Union{ActivePowerRangeExpressionUB, ActivePowerRangeExpressionLB},
+    T <: Union{
+        ActivePowerRangeExpressionUB,
+        ActivePowerRangeExpressionLB,
+        ActivePowerRangeExpressionOnlineUB,
+    },
     U <: OnStatusParameter,
     V <: PSY.ThermalGen,
     W <: AbstractThermalDispatchFormulation,

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -1197,3 +1197,19 @@ e^{st}_{T} - e^{st+} + e^{st-} = E^{st}_{T}.
 ```
 """
 struct HybridEnergyTargetConstraint <: ConstraintType end
+
+"""
+Band-plus-offline-capability row for unit-commitment devices contributing to an
+`OfflineReserve`, on the shared `ActivePowerRangeExpressionUB` (`p + online + offline`):
+
+`p + online + offline <= pmax * u + q_limit * (1 - u)`
+
+with `q_limit = pmax` (an hourly DAM lets most units reach `pmax` from OFF), so the row is
+the static range `<= pmax`. Committed: offline competes with the online products for the
+HSL band. Off: the paired semi-continuous row on
+`ActivePowerRangeExpressionOnlineUB` zeroes `p` and the online awards, leaving
+`offline <= q_limit`. Single award variable per (device, service): the device's merged
+offer curve prices both provision states (documented approximation - the online/offline
+non-spin offer prices are not differentiated).
+"""
+struct OfflineReserveBandConstraint <: ConstraintType end

--- a/src/core/constraints.jl
+++ b/src/core/constraints.jl
@@ -1199,17 +1199,16 @@ e^{st}_{T} - e^{st+} + e^{st-} = E^{st}_{T}.
 struct HybridEnergyTargetConstraint <: ConstraintType end
 
 """
-Band-plus-offline-capability row for unit-commitment devices contributing to an
-`OfflineReserve`, on the shared `ActivePowerRangeExpressionUB` (`p + online + offline`):
+Offline-capability band row for commitment formulations whose
+[`offline_reserve_in_range_ub`](@ref) trait is `false`: their commitment-gated range
+expression stays `p + online`, and this row adds the offline awards back against the
+static capability (`q_limit = pmax`):
 
-`p + online + offline <= pmax * u + q_limit * (1 - u)`
+`p + online + offline <= pmax * u + q_limit * (1 - u) = pmax`
 
-with `q_limit = pmax` (an hourly DAM lets most units reach `pmax` from OFF), so the row is
-the static range `<= pmax`. Committed: offline competes with the online products for the
-HSL band. Off: the paired semi-continuous row on
-`ActivePowerRangeExpressionOnlineUB` zeroes `p` and the online awards, leaving
-`offline <= q_limit`. Single award variable per (device, service): the device's merged
-offer curve prices both provision states (documented approximation - the online/offline
-non-spin offer prices are not differentiated).
+Committed: offline competes with the online products for the HSL band. Off: the
+semi-continuous range row zeroes `p` and the online awards, leaving `offline <= q_limit`.
+Single award variable per (device, service): the device's merged offer curve prices both
+provision states (documented approximation).
 """
 struct OfflineReserveBandConstraint <: ConstraintType end

--- a/src/core/expressions.jl
+++ b/src/core/expressions.jl
@@ -104,16 +104,6 @@ right-hand side of the system-level reserve balance.
 """
 struct TotalReserveOffering <: ExpressionType end
 
-"""
-Online-only upper range expression for unit-commitment devices that contribute to an
-`OfflineReserve`: `p + online_reserves`, bounded semi-continuously (`<= pmax * u`) so
-online products die with the commitment. Built ONLY when the device model carries an
-`OfflineReserve` service; the shared `ActivePowerRangeExpressionUB` then holds the full
-band (`p + online + offline`) bounded by the offline capability row instead. See
-[`OfflineReserveBandConstraint`](@ref).
-"""
-struct ActivePowerRangeExpressionOnlineUB <: RangeConstraintUBExpressions end
-
 abstract type ReserveAggregationExpression{
     D <: PSY.ReserveDirection,
     S <: ReserveScale,

--- a/src/core/expressions.jl
+++ b/src/core/expressions.jl
@@ -104,6 +104,16 @@ right-hand side of the system-level reserve balance.
 """
 struct TotalReserveOffering <: ExpressionType end
 
+"""
+Online-only upper range expression for unit-commitment devices that contribute to an
+`OfflineReserve`: `p + online_reserves`, bounded semi-continuously (`<= pmax * u`) so
+online products die with the commitment. Built ONLY when the device model carries an
+`OfflineReserve` service; the shared `ActivePowerRangeExpressionUB` then holds the full
+band (`p + online + offline`) bounded by the offline capability row instead. See
+[`OfflineReserveBandConstraint`](@ref).
+"""
+struct ActivePowerRangeExpressionOnlineUB <: RangeConstraintUBExpressions end
+
 abstract type ReserveAggregationExpression{
     D <: PSY.ReserveDirection,
     S <: ReserveScale,

--- a/src/core/reserve_traits.jl
+++ b/src/core/reserve_traits.jl
@@ -84,9 +84,25 @@ _service_container_meta(service::PSY.Service) =
     "$(typeof(service))_$(PSY.get_name(service))"
 
 """
-Whether a `DeviceModel` carries an `OfflineReserve` service. Gates the offline-capability
-machinery (`ActivePowerRangeExpressionOnlineUB` + `OfflineReserveBandConstraint`) so that
-models without offline reserves build exactly the classic single semi-continuous band row.
+Whether a reserve type is an offline (non-spinning) product. Trait form of the
+`OfflineReserve` check used by the offline-capability machinery.
+"""
+_is_offline_reserve(::Type{<:PSY.AbstractReserve}) = false
+_is_offline_reserve(::Type{<:PSY.OfflineReserve}) = true
+
+"""
+Whether a device formulation folds offline-reserve awards into the commitment-gated range
+expression (`ActivePowerRangeExpressionUB`). Defaults to `true` (the award consumes gated
+headroom, so an OFF unit cannot supply). Commitment formulations that provide offline
+capability through [`OfflineReserveBandConstraint`](@ref) return `false`.
+"""
+offline_reserve_in_range_ub(::Type{<:AbstractDeviceFormulation}) = true
+
+"""
+Whether a `DeviceModel` carries an `OfflineReserve` service. Gates the
+[`OfflineReserveBandConstraint`](@ref) so that models without offline reserves build
+exactly the classic single semi-continuous band row.
 """
 _has_offline_reserve_service(model::DeviceModel) =
-    any(sm -> get_component_type(sm) <: PSY.OfflineReserve, values(get_services(model)))
+    has_service_model(model) &&
+    any(sm -> _is_offline_reserve(get_component_type(sm)), get_services(model))

--- a/src/core/reserve_traits.jl
+++ b/src/core/reserve_traits.jl
@@ -82,3 +82,11 @@ written with the fully concrete instance type, and the two spellings do not matc
 """
 _service_container_meta(service::PSY.Service) =
     "$(typeof(service))_$(PSY.get_name(service))"
+
+"""
+Whether a `DeviceModel` carries an `OfflineReserve` service. Gates the offline-capability
+machinery (`ActivePowerRangeExpressionOnlineUB` + `OfflineReserveBandConstraint`) so that
+models without offline reserves build exactly the classic single semi-continuous band row.
+"""
+_has_offline_reserve_service(model::DeviceModel) =
+    any(sm -> get_component_type(sm) <: PSY.OfflineReserve, values(get_services(model)))

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -37,6 +37,9 @@ get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.Reserve{PSY.ReserveDown}}) = ActivePowerRangeExpressionLB
 # OfflineReserve (non-spin) is upward-only, so it reduces upward headroom like a ReserveUp product.
 get_expression_type_for_reserve(::Type{ActivePowerReserveVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:PSY.OfflineReserve}) = ActivePowerRangeExpressionUB
+# Standard-UC keeps its UB expression p + online: offline awards enter through the static
+# OfflineReserveBandConstraint instead of consuming commitment-gated headroom.
+offline_reserve_in_range_ub(::Type{<:AbstractStandardUnitCommitment}) = false
 
 ############## ActivePowerVariable, ThermalGen ####################
 get_variable_binary(::Type{ActivePowerVariable}, ::Type{<:PSY.ThermalGen}, ::Type{<:AbstractThermalFormulation}) = false
@@ -90,7 +93,6 @@ get_multiplier_value(::Type{FuelCostParameter}, d::PSY.ThermalGen, ::Type{<:Abst
 get_parameter_multiplier(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 get_initial_parameter_value(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
-get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionOnlineUB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).min
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = PSY.get_active_power_limits(d, PSY.SU).max - PSY.get_active_power_limits(d, PSY.SU).min
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = 0.0
@@ -1699,10 +1701,16 @@ function IOM._add_semicontinuous_bound_range_constraints_impl!(
 end
 
 """
-Offline-capability band row for standard-UC devices contributing to an `OfflineReserve`:
-the shared UB expression (`p + online + offline`) bounded by the STATIC `pmax`
-(`q_limit = pmax`; the paired semi-continuous row on the online-only expression keeps
-`p` and the online awards commitment-gated). See [`OfflineReserveBandConstraint`](@ref).
+Offline-capability band row for standard-UC devices contributing to an `OfflineReserve`.
+The commitment-gated UB expression stays `p + online`
+([`offline_reserve_in_range_ub`](@ref) excludes the offline awards); this row adds them
+back against the STATIC capability (`q_limit = pmax`):
+
+`p + online + offline <= pmax`
+
+Committed: offline competes with the online products for the HSL band. Off: the
+semi-continuous UB row zeroes `p` and the online awards, leaving `offline <= pmax`.
+Devices contributing to no offline service get no row.
 """
 function add_constraints!(
     container::OptimizationContainer,
@@ -1716,17 +1724,38 @@ function add_constraints!(
     X <: AbstractNetworkModel,
 }
     time_steps = get_time_steps(container)
-    names = [PSY.get_name(d) for d in devices]
     expression = get_expression(container, ActivePowerRangeExpressionUB, V)
     jump_model = get_jump_model(container)
-    constraint = add_constraints_container!(container, T, V, names, time_steps)
+    # (service name, sparse award variable, contributing member names) per offline service
+    # attached to the device model; the ServiceModel's contributing map carries both the
+    # service names and the membership.
+    offline = Tuple{String, Any, Set{String}}[]
+    for sm in get_services(model)
+        _is_offline_reserve(get_component_type(sm)) || continue
+        variable =
+            get_variable(container, ActivePowerReserveVariable, get_component_type(sm))
+        for (service_name, dev_map) in get_contributing_devices_map(sm)
+            members = get(dev_map, V, nothing)
+            members === nothing && continue
+            push!(offline, (service_name, variable, Set(PSY.get_name.(members))))
+        end
+    end
+    isempty(offline) && return
+    names = [PSY.get_name(d) for d in devices]
+    constraint =
+        add_constraints_container!(container, T, V, names, time_steps; sparse = true)
     for d in devices
         name = PSY.get_name(d)
         q_limit = PSY.get_active_power_limits(d, PSY.SU).max
+        any(((_, _, members),) -> name in members, offline) || continue
         for t in time_steps
-            constraint[name, t] = JuMP.@constraint(
+            constraint[(name, t)] = JuMP.@constraint(
                 jump_model,
-                expression[name, t] <= q_limit
+                expression[name, t] + sum(
+                    v[(sname, name, t)] for
+                    (sname, v, members) in offline if name in members;
+                    init = 0.0,
+                ) <= q_limit
             )
         end
     end

--- a/src/static_injector_models/thermal_generation.jl
+++ b/src/static_injector_models/thermal_generation.jl
@@ -90,6 +90,7 @@ get_multiplier_value(::Type{FuelCostParameter}, d::PSY.ThermalGen, ::Type{<:Abst
 get_parameter_multiplier(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 get_initial_parameter_value(::Type{<:VariableValueParameter}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = 1.0
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
+get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionOnlineUB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).max
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractThermalFormulation}) = PSY.get_active_power_limits(d, PSY.SU).min
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionUB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = PSY.get_active_power_limits(d, PSY.SU).max - PSY.get_active_power_limits(d, PSY.SU).min
 get_expression_multiplier(::Type{OnStatusParameter}, ::Type{ActivePowerRangeExpressionLB}, d::PSY.ThermalGen, ::Type{<:AbstractCompactUnitCommitment}) = 0.0
@@ -1692,6 +1693,41 @@ function IOM._add_semicontinuous_bound_range_constraints_impl!(
             IOM.add_range_bound_constraint!(
                 dir, jump_model, con, ci_name, t,
                 array[ci_name, t], IOM.get_bound(dir, limits), bin)
+        end
+    end
+    return
+end
+
+"""
+Offline-capability band row for standard-UC devices contributing to an `OfflineReserve`:
+the shared UB expression (`p + online + offline`) bounded by the STATIC `pmax`
+(`q_limit = pmax`; the paired semi-continuous row on the online-only expression keeps
+`p` and the online awards commitment-gated). See [`OfflineReserveBandConstraint`](@ref).
+"""
+function add_constraints!(
+    container::OptimizationContainer,
+    T::Type{OfflineReserveBandConstraint},
+    devices::IS.FlattenIteratorWrapper{V},
+    model::DeviceModel{V, W},
+    ::NetworkModel{X},
+) where {
+    V <: PSY.ThermalGen,
+    W <: AbstractStandardUnitCommitment,
+    X <: AbstractNetworkModel,
+}
+    time_steps = get_time_steps(container)
+    names = [PSY.get_name(d) for d in devices]
+    expression = get_expression(container, ActivePowerRangeExpressionUB, V)
+    jump_model = get_jump_model(container)
+    constraint = add_constraints_container!(container, T, V, names, time_steps)
+    for d in devices
+        name = PSY.get_name(d)
+        q_limit = PSY.get_active_power_limits(d, PSY.SU).max
+        for t in time_steps
+            constraint[name, t] = JuMP.@constraint(
+                jump_model,
+                expression[name, t] <= q_limit
+            )
         end
     end
     return

--- a/src/static_injector_models/thermalgeneration_constructor.jl
+++ b/src/static_injector_models/thermalgeneration_constructor.jl
@@ -150,17 +150,6 @@ function construct_device!(
         device_model,
         network_model,
     )
-    if _has_offline_reserve_service(device_model)
-        # Online-only band expression; the shared UB keeps p + online + offline.
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionOnlineUB,
-            ActivePowerVariable,
-            devices,
-            device_model,
-            network_model,
-        )
-    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -200,29 +189,19 @@ function construct_device!(
         device_model,
         network_model,
     )
+    add_constraints!(
+        container,
+        ActivePowerVariableLimitsConstraint,
+        ActivePowerRangeExpressionUB,
+        devices,
+        device_model,
+        network_model,
+    )
     if _has_offline_reserve_service(device_model)
-        # Row A: p + online reserves stay commitment-gated on the online-only expression.
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionOnlineUB,
-            devices,
-            device_model,
-            network_model,
-        )
-        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        # p + online + offline <= pmax preserves an OFF unit's offline capability.
         add_constraints!(
             container,
             OfflineReserveBandConstraint,
-            devices,
-            device_model,
-            network_model,
-        )
-    else
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionUB,
             devices,
             device_model,
             network_model,
@@ -331,17 +310,6 @@ function construct_device!(
         device_model,
         network_model,
     )
-    if _has_offline_reserve_service(device_model)
-        # Online-only band expression; the shared UB keeps p + online + offline.
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionOnlineUB,
-            ActivePowerVariable,
-            devices,
-            device_model,
-            network_model,
-        )
-    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -378,29 +346,19 @@ function construct_device!(
         device_model,
         network_model,
     )
+    add_constraints!(
+        container,
+        ActivePowerVariableLimitsConstraint,
+        ActivePowerRangeExpressionUB,
+        devices,
+        device_model,
+        network_model,
+    )
     if _has_offline_reserve_service(device_model)
-        # Row A: p + online reserves stay commitment-gated on the online-only expression.
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionOnlineUB,
-            devices,
-            device_model,
-            network_model,
-        )
-        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        # p + online + offline <= pmax preserves an OFF unit's offline capability.
         add_constraints!(
             container,
             OfflineReserveBandConstraint,
-            devices,
-            device_model,
-            network_model,
-        )
-    else
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionUB,
             devices,
             device_model,
             network_model,
@@ -497,17 +455,6 @@ function construct_device!(
         device_model,
         network_model,
     )
-    if _has_offline_reserve_service(device_model)
-        # Online-only band expression; the shared UB keeps p + online + offline.
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionOnlineUB,
-            ActivePowerVariable,
-            devices,
-            device_model,
-            network_model,
-        )
-    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -555,29 +502,19 @@ function construct_device!(
         device_model,
         network_model,
     )
+    add_constraints!(
+        container,
+        ActivePowerVariableLimitsConstraint,
+        ActivePowerRangeExpressionUB,
+        devices,
+        device_model,
+        network_model,
+    )
     if _has_offline_reserve_service(device_model)
-        # Row A: p + online reserves stay commitment-gated on the online-only expression.
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionOnlineUB,
-            devices,
-            device_model,
-            network_model,
-        )
-        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        # p + online + offline <= pmax preserves an OFF unit's offline capability.
         add_constraints!(
             container,
             OfflineReserveBandConstraint,
-            devices,
-            device_model,
-            network_model,
-        )
-    else
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionUB,
             devices,
             device_model,
             network_model,
@@ -672,17 +609,6 @@ function construct_device!(
         device_model,
         network_model,
     )
-    if _has_offline_reserve_service(device_model)
-        # Online-only band expression; the shared UB keeps p + online + offline.
-        add_to_expression!(
-            container,
-            ActivePowerRangeExpressionOnlineUB,
-            ActivePowerVariable,
-            devices,
-            device_model,
-            network_model,
-        )
-    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -730,29 +656,19 @@ function construct_device!(
         device_model,
         network_model,
     )
+    add_constraints!(
+        container,
+        ActivePowerVariableLimitsConstraint,
+        ActivePowerRangeExpressionUB,
+        devices,
+        device_model,
+        network_model,
+    )
     if _has_offline_reserve_service(device_model)
-        # Row A: p + online reserves stay commitment-gated on the online-only expression.
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionOnlineUB,
-            devices,
-            device_model,
-            network_model,
-        )
-        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        # p + online + offline <= pmax preserves an OFF unit's offline capability.
         add_constraints!(
             container,
             OfflineReserveBandConstraint,
-            devices,
-            device_model,
-            network_model,
-        )
-    else
-        add_constraints!(
-            container,
-            ActivePowerVariableLimitsConstraint,
-            ActivePowerRangeExpressionUB,
             devices,
             device_model,
             network_model,

--- a/src/static_injector_models/thermalgeneration_constructor.jl
+++ b/src/static_injector_models/thermalgeneration_constructor.jl
@@ -150,6 +150,17 @@ function construct_device!(
         device_model,
         network_model,
     )
+    if _has_offline_reserve_service(device_model)
+        # Online-only band expression; the shared UB keeps p + online + offline.
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionOnlineUB,
+            ActivePowerVariable,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -189,14 +200,34 @@ function construct_device!(
         device_model,
         network_model,
     )
-    add_constraints!(
-        container,
-        ActivePowerVariableLimitsConstraint,
-        ActivePowerRangeExpressionUB,
-        devices,
-        device_model,
-        network_model,
-    )
+    if _has_offline_reserve_service(device_model)
+        # Row A: p + online reserves stay commitment-gated on the online-only expression.
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionOnlineUB,
+            devices,
+            device_model,
+            network_model,
+        )
+        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        add_constraints!(
+            container,
+            OfflineReserveBandConstraint,
+            devices,
+            device_model,
+            network_model,
+        )
+    else
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionUB,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
     add_constraints!(
         container,
         ReactivePowerVariableLimitsConstraint,
@@ -300,6 +331,17 @@ function construct_device!(
         device_model,
         network_model,
     )
+    if _has_offline_reserve_service(device_model)
+        # Online-only band expression; the shared UB keeps p + online + offline.
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionOnlineUB,
+            ActivePowerVariable,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -336,14 +378,34 @@ function construct_device!(
         device_model,
         network_model,
     )
-    add_constraints!(
-        container,
-        ActivePowerVariableLimitsConstraint,
-        ActivePowerRangeExpressionUB,
-        devices,
-        device_model,
-        network_model,
-    )
+    if _has_offline_reserve_service(device_model)
+        # Row A: p + online reserves stay commitment-gated on the online-only expression.
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionOnlineUB,
+            devices,
+            device_model,
+            network_model,
+        )
+        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        add_constraints!(
+            container,
+            OfflineReserveBandConstraint,
+            devices,
+            device_model,
+            network_model,
+        )
+    else
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionUB,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
 
     add_constraints!(container, CommitmentConstraint, devices, device_model, network_model)
     add_constraints!(container, RampConstraint, devices, device_model, network_model)
@@ -435,6 +497,17 @@ function construct_device!(
         device_model,
         network_model,
     )
+    if _has_offline_reserve_service(device_model)
+        # Online-only band expression; the shared UB keeps p + online + offline.
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionOnlineUB,
+            ActivePowerVariable,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -482,14 +555,34 @@ function construct_device!(
         device_model,
         network_model,
     )
-    add_constraints!(
-        container,
-        ActivePowerVariableLimitsConstraint,
-        ActivePowerRangeExpressionUB,
-        devices,
-        device_model,
-        network_model,
-    )
+    if _has_offline_reserve_service(device_model)
+        # Row A: p + online reserves stay commitment-gated on the online-only expression.
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionOnlineUB,
+            devices,
+            device_model,
+            network_model,
+        )
+        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        add_constraints!(
+            container,
+            OfflineReserveBandConstraint,
+            devices,
+            device_model,
+            network_model,
+        )
+    else
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionUB,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
 
     add_constraints!(
         container,
@@ -579,6 +672,17 @@ function construct_device!(
         device_model,
         network_model,
     )
+    if _has_offline_reserve_service(device_model)
+        # Online-only band expression; the shared UB keeps p + online + offline.
+        add_to_expression!(
+            container,
+            ActivePowerRangeExpressionOnlineUB,
+            ActivePowerVariable,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
     add_to_expression!(
         container,
         FuelConsumptionExpression,
@@ -626,14 +730,34 @@ function construct_device!(
         device_model,
         network_model,
     )
-    add_constraints!(
-        container,
-        ActivePowerVariableLimitsConstraint,
-        ActivePowerRangeExpressionUB,
-        devices,
-        device_model,
-        network_model,
-    )
+    if _has_offline_reserve_service(device_model)
+        # Row A: p + online reserves stay commitment-gated on the online-only expression.
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionOnlineUB,
+            devices,
+            device_model,
+            network_model,
+        )
+        # Row B: p + online + offline <= pmax preserves an OFF unit's offline capability.
+        add_constraints!(
+            container,
+            OfflineReserveBandConstraint,
+            devices,
+            device_model,
+            network_model,
+        )
+    else
+        add_constraints!(
+            container,
+            ActivePowerVariableLimitsConstraint,
+            ActivePowerRangeExpressionUB,
+            devices,
+            device_model,
+            network_model,
+        )
+    end
 
     add_constraints!(container, CommitmentConstraint, devices, device_model, network_model)
     if haskey(get_time_series_names(device_model), ActivePowerTimeSeriesParameter)
@@ -1132,6 +1256,11 @@ function construct_device!(
     network_model::NetworkModel{<:AbstractNetworkModel},
 )
     devices = get_available_components(device_model, sys)
+    _has_offline_reserve_service(device_model) && error(
+        "OfflineReserve services on ThermalMultiStartUnitCommitment (compact UC) are not " *
+        "supported: the offline-capability band anchors to total pmax while compact " *
+        "power is a delta above pmin. Use a standard UC formulation.",
+    )
 
     add_variables!(
         container,

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -542,9 +542,10 @@ end
 end
 
 @testset "OfflineReserve as ORDC: OFF unit provides offline capability (UC)" begin
-    # Single-award-variable offline design: row A keeps p + online commitment-gated on the
-    # online-only expression; row B bounds the shared band p + online + offline by the
-    # static q_limit = pmax, so an OFF unit's offline capability survives.
+    # Single-award-variable offline design: the UB expression keeps p + online
+    # commitment-gated (offline_reserve_in_range_ub = false for standard UC); the band row
+    # adds the offline awards against the static q_limit = pmax, so an OFF unit's offline
+    # capability survives.
     sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"))
     thermals = collect(get_components(ThermalStandard, sys))
     # Make one unit uneconomical for energy so the UC leaves it OFF; its cheap offline
@@ -658,9 +659,6 @@ end
     @test build!(model2; output_dir = mktempdir(; cleanup = true)) ==
           IOM.ModelBuildStatus.BUILT
     container2 = IOM.get_optimization_container(model2)
-    @test !IOM.has_container_key(
-        container2, POM.ActivePowerRangeExpressionOnlineUB, ThermalStandard,
-    )
     @test all(
         k -> IOM.get_entry_type(k) != POM.OfflineReserveBandConstraint,
         keys(IOM.get_constraints(container2)),

--- a/test/test_device_reserve_offers.jl
+++ b/test/test_device_reserve_offers.jl
@@ -541,6 +541,132 @@ end
     end
 end
 
+@testset "OfflineReserve as ORDC: OFF unit provides offline capability (UC)" begin
+    # Single-award-variable offline design: row A keeps p + online commitment-gated on the
+    # online-only expression; row B bounds the shared band p + online + offline by the
+    # static q_limit = pmax, so an OFF unit's offline capability survives.
+    sys = deepcopy(PSB.build_system(PSITestSystems, "c_sys5_uc"))
+    thermals = collect(get_components(ThermalStandard, sys))
+    # Make one unit uneconomical for energy so the UC leaves it OFF; its cheap offline
+    # offer must clear regardless.
+    offunit = first(sort(thermals; by = PSY.get_name))
+    # Service bids require an OfferCurveCost: convert every thermal to a MarketBidCost that
+    # keeps its energy slope; the off-unit gets a prohibitive slope + startup so the UC
+    # never commits it for energy.
+    for g in thermals
+        pmax_g = PSY.get_max_active_power(g, PSY.NU)
+        slope = if g === offunit
+            1.0e4
+        else
+            PSY.get_proportional_term(
+                PSY.get_value_curve(PSY.get_variable(get_operation_cost(g))),
+            )
+        end
+        PSY.set_operation_cost!(
+            g,
+            MarketBidCost(;
+                no_load_cost = LinearCurve(0.0),
+                start_up = (
+                    hot = g === offunit ? 1.0e5 : 0.0,
+                    warm = g === offunit ? 1.0e5 : 0.0,
+                    cold = g === offunit ? 1.0e5 : 0.0,
+                ),
+                shut_down = LinearCurve(0.0),
+                incremental_offer_curves = make_market_bid_curve(
+                    [0.0, pmax_g], [slope], 0.0; power_units = IS.NaturalUnit(),
+                ),
+            ),
+        )
+    end
+    nspin = OfflineReserve(;
+        name = "NSPIN",
+        available = true,
+        time_frame = 30.0,
+        variable = _mkt_curve([0.0, 100.0, 200.0], [65.0, 11.0]),
+    )
+    spin = OnlineReserve{ReserveUp}(;
+        name = "SPIN", available = true, time_frame = 10.0, requirement = 0.0,
+        variable = _mkt_curve([0.0, 50.0], [40.0]),
+    )
+    add_service!(sys, nspin, PSY.Device[thermals...])
+    add_service!(sys, spin, PSY.Device[thermals...])
+    for (i, g) in enumerate(thermals)
+        price = g === offunit ? 0.01 : 6.0 + i
+        PSY.set_service_bid!(
+            sys,
+            g,
+            nspin,
+            _mkt_offer_ts(nspin, 80.0, price),
+            IS.NaturalUnit(),
+        )
+        PSY.set_service_bid!(
+            sys,
+            g,
+            spin,
+            _mkt_offer_ts(spin, 30.0, price),
+            IS.NaturalUnit(),
+        )
+    end
+
+    template = get_thermal_standard_uc_template()
+    set_service_model!(template, ServiceModel(OfflineReserve, StepwiseCostReserve))
+    set_service_model!(
+        template,
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
+    )
+    model = DecisionModel(
+        template, sys;
+        optimizer = HiGHS_optimizer, store_variable_names = true,
+    )
+    @test build!(model; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    @test solve!(model) == IOM.RunStatus.SUCCESSFULLY_FINALIZED
+
+    res = IOM.OptimizationProblemOutputs(model)
+    on = read_variable(res, OnVariable, ThermalStandard; table_format = TableFormat.WIDE)
+    nspin_awards = read_variable(
+        res, "ActivePowerReserveVariable__OfflineReserve";
+        table_format = TableFormat.WIDE,
+    )
+    spin_awards = read_variable(
+        res, "ActivePowerReserveVariable__OnlineReserve__ReserveUp";
+        table_format = TableFormat.WIDE,
+    )
+    off_name = PSY.get_name(offunit)
+    pmax = PSY.get_active_power_limits(offunit, PSY.NU).max
+    total_off_award = 0.0
+    for t in 1:24
+        @test on[t, off_name] < 0.5                       # stays uncommitted
+        @test spin_awards[t, "SPIN__$(off_name)"] <= 1e-3  # row A: online dead when OFF
+        @test nspin_awards[t, "NSPIN__$(off_name)"] <= pmax + 1e-3  # row B capability
+        total_off_award += nspin_awards[t, "NSPIN__$(off_name)"]
+    end
+    # The cheapest offline offer in the stack clears from the OFF unit.
+    @test total_off_award > 1.0
+
+    # Zero-footprint: without an OfflineReserve service model, none of the offline
+    # machinery exists - no online-only expression, no band constraint.
+    template2 = get_thermal_standard_uc_template()
+    set_service_model!(
+        template2,
+        ServiceModel(OnlineReserve{ReserveUp}, StepwiseCostReserve),
+    )
+    model2 = DecisionModel(
+        template2, sys;
+        optimizer = HiGHS_optimizer, store_variable_names = true,
+    )
+    @test build!(model2; output_dir = mktempdir(; cleanup = true)) ==
+          IOM.ModelBuildStatus.BUILT
+    container2 = IOM.get_optimization_container(model2)
+    @test !IOM.has_container_key(
+        container2, POM.ActivePowerRangeExpressionOnlineUB, ThermalStandard,
+    )
+    @test all(
+        k -> IOM.get_entry_type(k) != POM.OfflineReserveBandConstraint,
+        keys(IOM.get_constraints(container2)),
+    )
+end
+
 #################################################################################
 # Load reserve provision (PowerLoadDispatch)
 #################################################################################

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1780,7 +1780,8 @@ end
     sys, group = build_group_reserve_system(; group_curve = false)
     init_times = [DateTime("2024-01-01T00:00:00"), DateTime("2024-01-02T00:00:00")]
     horizon = 24
-    curves = [IS.PiecewiseStepData([0.0, isodd(h) ? 40.0 : 80.0], [9.0e4]) for h in 1:horizon]
+    curves =
+        [IS.PiecewiseStepData([0.0, isodd(h) ? 40.0 : 80.0], [9.0e4]) for h in 1:horizon]
     data = Dict(it => copy(curves) for it in init_times)
     PSY.add_time_series!(
         sys,

--- a/test/test_services_constructor.jl
+++ b/test/test_services_constructor.jl
@@ -1769,6 +1769,46 @@ end
     @test sub_a_total > sub_b_total
 end
 
+@testset "GroupStepwiseCostReserve: time-series group demand curve clears per hour" begin
+    # The group ORDC can be time-series-backed (`CostCurve{TimeSeriesPiecewiseIncrementalCurve}`,
+    # same Union as the single reserves); the parameter machinery
+    # (`process_stepwise_cost_reserve_parameters!`) must feed hour-varying blocks into the
+    # clearing. Demand cap alternates 40/80 MW by hour at a price far above both the member
+    # offer and any commitment cost, so the cleared group demand must track the alternation
+    # exactly - a static curve cannot. (A moderate price lets commitment economics under-buy;
+    # the point here is the hourly caps, so make the value decisive.)
+    sys, group = build_group_reserve_system(; group_curve = false)
+    init_times = [DateTime("2024-01-01T00:00:00"), DateTime("2024-01-02T00:00:00")]
+    horizon = 24
+    curves = [IS.PiecewiseStepData([0.0, isodd(h) ? 40.0 : 80.0], [9.0e4]) for h in 1:horizon]
+    data = Dict(it => copy(curves) for it in init_times)
+    PSY.add_time_series!(
+        sys,
+        group,
+        Deterministic("variable_cost", data, Hour(1)),
+    )
+    key = IS.ForecastKey(;
+        time_series_type = IS.Deterministic,
+        name = "variable_cost",
+        initial_timestamp = first(init_times),
+        resolution = Hour(1),
+        horizon = Hour(horizon),
+        interval = Hour(24),
+        count = 2,
+        features = Dict{String, Any}(),
+    )
+    PSY.set_variable!(group, PSY.make_market_bid_ts_curve(key, nothing, IS.NaturalUnit()))
+    @test PSY.has_demand_curve(group)
+
+    model = _solve_group_model(sys)
+    res = IOM.OptimizationProblemOutputs(model)
+    demand = read_variable(res, "ServiceRequirementVariable__GroupReserve__ReserveUp";
+        table_format = TableFormat.WIDE)
+    for t in 1:horizon
+        @test demand[t, "UP_GROUP"] ≈ (isodd(t) ? 40.0 : 80.0) atol = 1e-4
+    end
+end
+
 @testset "GroupStepwiseCostReserve: no group model -> no procurement" begin
     sys, _ = build_group_reserve_system()
     model = _solve_group_model(sys; include_group = false)


### PR DESCRIPTION
Stacked on #235 (base branch `rh/reserve_refactor`); the diff shows only this feature's commits.

New features (not refactor items) re-expressed on the psy6 reserve tree:

- **`GroupStepwiseCostReserve`**: elastic group ORDC. One dense `ServiceRequirementVariable` per group, a clearing constraint `sum(member awards) >= requirement variable`, and the group's demand curve (static or time series) priced through the existing delta-PWL path. Mis-paired `ServiceModel`s (`GroupReserve` with a non-group formulation and vice versa) fail at declaration.
- **Load reserve provision under `PowerLoadDispatch`**: the inverse of a generator. Up reserve is committed shed (`P - r_up >= 0`), down reserve is committed extra consumption (`P + r_down <= forecast`), gated on an attached service model. A costless load selling reserves errors since nothing pins its consumption.
- **`OfflineReserve` (non-spin) as ORDC supply from storage and loads**: non-spinning is upward-only, so it routes like an up reserve everywhere a device supplies it (new `UP_RESERVE` union). Previously only thermal was wired: the storage reserve-balance multipliers MethodError'd, two storage coverage branches silently skipped the service, complete coverage hit an `@assert false`, and `_modify_device_model!` no-opped every `OfflineReserve` model. The no-op is now scoped to `NonSpinningReserve`, whose awards ride `ReservePowerConstraint` instead of the device range expressions.
- **Integration test**: energy + reserve co-clearing with an elastic service, a stepwise group, and per-resource offers from thermal, storage, and load participants.

Tests live in existing files: group-stepwise testsets in `test_services_constructor.jl`; market integration, load provision, and the `OfflineReserve` ORDC scenarios in `test_device_reserve_offers.jl`; the storage non-spin coverage testset in `test_storage_device_models.jl`.

Full suite green: 106708/106708. Docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)