### PR TITLE
Move `get_hinted_aff_expr` from IOM into POM

### DIFF
--- a/src/PowerOperationsModels.jl
+++ b/src/PowerOperationsModels.jl
@@ -232,6 +232,7 @@ import InfrastructureOptimizationModels:
 # These define concrete Variable, Expression, Constraint, and Parameter types
 # and extend should_write_resulting_value/convert_output_to_natural_units
 #################################################################################
+include("utils/jump_utils.jl")
 include("core/definitions.jl")
 include("core/problem_types.jl")
 include("core/interfaces.jl")

--- a/src/ac_transmission_models/AC_branches.jl
+++ b/src/ac_transmission_models/AC_branches.jl
@@ -774,7 +774,7 @@ function _make_flow_expressions!(
     hint = length(nz_idx)
     expressions = Vector{JuMP.AffExpr}(undef, length(time_steps))
     for t in time_steps
-        acc = IOM.get_hinted_aff_expr(hint)
+        acc = get_hinted_aff_expr(hint)
         @inbounds for i in nz_idx
             JuMP.add_to_expression!(acc, ptdf_col[i], nodal_balance_expressions[i, t])
         end
@@ -798,7 +798,7 @@ function _make_flow_expressions!(
     hint = length(nz_idx)
     expressions = Vector{JuMP.AffExpr}(undef, length(time_steps))
     for t in time_steps
-        acc = IOM.get_hinted_aff_expr(hint)
+        acc = get_hinted_aff_expr(hint)
         @inbounds for k in eachindex(nz_idx)
             JuMP.add_to_expression!(
                 acc,

--- a/src/services_models/reserve_group.jl
+++ b/src/services_models/reserve_group.jl
@@ -129,7 +129,7 @@ function add_constraints!(
 
     for t in time_steps
         vars = member_vars[t]
-        resource_expression = IOM.get_hinted_aff_expr(length(vars))
+        resource_expression = get_hinted_aff_expr(length(vars))
         for var in vars
             JuMP.add_to_expression!(resource_expression, var)
         end

--- a/src/services_models/reserves.jl
+++ b/src/services_models/reserves.jl
@@ -184,7 +184,7 @@ function _sum_service_reserves(
 ) where {
     U <: Union{Vector{D}, IS.FlattenIteratorWrapper{D}},
 } where {D <: PSY.Component}
-    acc = IOM.get_hinted_aff_expr(length(contributing_devices) + extra)
+    acc = get_hinted_aff_expr(length(contributing_devices) + extra)
     for d in contributing_devices
         JuMP.add_to_expression!(acc, reserve_variable[(service_name, PSY.get_name(d), t)])
     end

--- a/src/utils/jump_utils.jl
+++ b/src/utils/jump_utils.jl
@@ -1,0 +1,8 @@
+"""
+Return an empty `JuMP.AffExpr` whose term dictionary is pre-sized for `size` terms.
+"""
+function get_hinted_aff_expr(size::Int)
+    expr = JuMP.AffExpr(0.0)
+    sizehint!(expr.terms, size)
+    return expr
+end

--- a/test/test_ac_transmission_security_constrained_models.jl
+++ b/test/test_ac_transmission_security_constrained_models.jl
@@ -121,7 +121,7 @@ end
                 i for i in eachindex(modf_col) if
                 abs(modf_col[i]) > POM.PTDF_ZERO_TOL
             ]
-            expected = IOM.get_hinted_aff_expr(length(nz_idx))
+            expected = POM.get_hinted_aff_expr(length(nz_idx))
             for i in nz_idx
                 JuMP.add_to_expression!(expected, modf_col[i], nodal_balance[i, t])
             end
@@ -249,7 +249,7 @@ end
                 i for i in eachindex(ptdf_col) if abs(ptdf_col[i]) > POM.PTDF_ZERO_TOL
             ]
             for t in time_steps
-                expected = IOM.get_hinted_aff_expr(length(nz_idx))
+                expected = POM.get_hinted_aff_expr(length(nz_idx))
                 for i in nz_idx
                     JuMP.add_to_expression!(expected, ptdf_col[i], nodal_balance[i, t])
                 end
@@ -356,7 +356,7 @@ end
             nz_idx = [
                 i for i in eachindex(modf_col) if abs(modf_col[i]) > POM.PTDF_ZERO_TOL
             ]
-            expected = IOM.get_hinted_aff_expr(length(nz_idx))
+            expected = POM.get_hinted_aff_expr(length(nz_idx))
             for i in nz_idx
                 JuMP.add_to_expression!(expected, modf_col[i], nodal_balance[i, t])
             end


### PR DESCRIPTION
Fixes #224 (POM half).

`IOM.get_hinted_aff_expr` is unexported and has no caller inside IOM — every call site is in POM. This moves the three-line helper into POM at `src/utils/jump_utils.jl` and drops the `IOM.` qualifier at all seven call sites (four in `src`, three in `test`; the test sites take a `POM.` qualifier since the helper stays unexported).

A companion PR on InfrastructureOptimizationModels.jl deletes the original definition. Merging this one first keeps IOM from ever being the broken side.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)