### PR TITLE
Identify the system by its UUID and the outages by their ids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,12 +28,12 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 PowerFlows = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
 
 [sources]
-InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-InfrastructureOptimizationModels = {rev = "feat/rust-time-series-store", url = "https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl"}
-PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfrastructureOptimizationModels = {rev = "main", url = "https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl"}
+PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
 PowerNetworkMatrices = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
 
 [extensions]
 PowerFlowsExt = "PowerFlows"

--- a/src/core/reserve_traits.jl
+++ b/src/core/reserve_traits.jl
@@ -58,7 +58,7 @@ model declares no requirement series name (the formulation carries no requiremen
 function _has_ts_requirement(model::ServiceModel, s::PSY.AbstractReserve)
     ts_names = get_time_series_names(model)
     haskey(ts_names, RequirementTimeSeriesParameter) || return false
-    return PSY.has_time_series(s; name = ts_names[RequirementTimeSeriesParameter])
+    return PSY.has_time_series(s, ts_names[RequirementTimeSeriesParameter])
 end
 
 # ── ORDC (operating-reserve-demand-curve) predicates ─────────────────────────────────

--- a/src/network_models/instantiate_network_model.jl
+++ b/src/network_models/instantiate_network_model.jl
@@ -220,7 +220,7 @@ end
 
 # Every PTDF-family matrix wraps one of these, so the tolerance and uuid are set once.
 _factor_core(ybus::PNM.Ybus, sys::PSY.System) =
-    PNM.VirtualFactorCore(ybus; tol = PTDF_ZERO_TOL, system_uuid = IS.get_id(sys))
+    PNM.VirtualFactorCore(ybus; tol = PTDF_ZERO_TOL, system_uuid = PSY.get_system_uuid(sys))
 
 #=
 The one source-aware Ybus resolution, dispatched on the source so every formulation

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,14 +19,18 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PowerCoreOpenAPIModels = "b7b40286-e793-417d-a9a0-b1583e4da1cb"
+PowerDynamicsOpenAPIModels = "044a0b22-31f8-4ef6-8282-c9a61b3013f6"
 PowerFlowFileParser = "bed98974-b02e-5e2f-9ee0-a103f5c450dd"
 PowerFlows = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
+PowerInvestmentsOpenAPIModels = "33cb4396-f4d9-4f59-8585-787ebb56cb1b"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
+PowerOpenAPIModels = "0730f07c-cff6-4c3b-a9df-c546153be50a"
 PowerOperationsModels = "c9281074-0ec2-4761-850d-1a24107ea5e8"
 PowerOperationsOpenAPIModels = "a372b6d7-45a2-44c2-8199-6a724b72e8ff"
 PowerSystemCaseBuilder = "f00506e0-b84f-492a-93c2-c0a9afc4364e"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 PowerTableDataParser = "2b750c0e-0bff-11f1-9200-1befd75df6be"
+PowerTimeSeriesOpenAPIModels = "8c2f6a0d-6b0e-4d0a-9d8f-2b5e6a4f9c31"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
@@ -43,16 +47,20 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 # to apply). Drop the dep + entry once InfraStore is registered.
 [sources]
 PowerOperationsModels = {path = ".."}
-InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
-InfrastructureOptimizationModels = {rev = "feat/rust-time-series-store", url = "https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl"}
-PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl"}
+InfrastructureOptimizationModels = {rev = "main", url = "https://github.com/Sienna-Platform/InfrastructureOptimizationModels.jl"}
+PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl"}
 PowerSystemCaseBuilder = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl"}
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerDynamicsOpenAPIModels.jl"}
 PowerFlowFileParser = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl"}
 PowerFlows = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerFlows.jl"}
+PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
 PowerNetworkMatrices = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
 PowerTableDataParser = {rev = "psy6", url = "https://github.com/NREL-Sienna/PowerTableDataParser.jl"}
+PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
 HiGHS = "1"

--- a/test/test_ac_transmission_security_constrained_models.jl
+++ b/test/test_ac_transmission_security_constrained_models.jl
@@ -97,8 +97,8 @@ end
         )]
 
         for (outage_id_str, name, t) in keys(pcbf.data)
-            uuid = Base.UUID(outage_id_str)
-            ctg = ground_truth_registered[uuid]
+            outage_id = parse(Int, outage_id_str)
+            ctg = ground_truth_registered[outage_id]
 
             # Resolve the monitored name to its arc and reduction kind.
             arc = nothing
@@ -341,8 +341,8 @@ end
         pcbf = IOM.get_expression(container, POM.PostContingencyBranchFlow, V)
         n_checked += 1
         for (outage_id_str, name, t) in keys(pcbf.data)
-            uuid = Base.UUID(outage_id_str)
-            ctg = ground_truth_registered[uuid]
+            outage_id = parse(Int, outage_id_str)
+            ctg = ground_truth_registered[outage_id]
             arc = nothing
             for n2a in values(name_to_arc_maps)
                 if haskey(n2a, name)
@@ -381,7 +381,7 @@ end
     c_sys5 = PSB.build_system(PSITestSystems, "c_sys5")
     all_branches = collect(get_components(PSY.ACTransmission, c_sys5))
     outage_components = ["1", "2", "3"]
-    outage_uuids = Base.UUID[]
+    outage_ids = Int[]
     for line_name in outage_components
         component = get_component(PSY.ACTransmission, c_sys5, line_name)
         transition_data = PSY.GeometricDistributionForcedOutage(;
@@ -390,7 +390,7 @@ end
             monitored_components = all_branches,
         )
         PSY.add_supplemental_attribute!(c_sys5, component, transition_data)
-        push!(outage_uuids, IS.get_id(transition_data))
+        push!(outage_ids, IS.get_id(transition_data))
     end
 
     auto_template = get_thermal_dispatch_template_network(
@@ -412,7 +412,7 @@ end
           IOM.ModelBuildStatus.BUILT
     auto_line_outages =
         IOM.get_outages(IOM.get_model(IOM.get_template(auto_model), PSY.Line))
-    @test Set(keys(auto_line_outages)) == Set(outage_uuids)
+    @test Set(keys(auto_line_outages)) == Set(outage_ids)
 
     container = IOM.get_optimization_container(auto_model)
     con_ub = IOM.get_constraint(
@@ -420,7 +420,7 @@ end
         IOM.ConstraintKey(POM.PostContingencyFlowRateConstraint, PSY.Line, "ub"),
     )
     ub_outages = Set(k[1] for k in keys(con_ub.data))
-    @test ub_outages == Set(string(u) for u in outage_uuids)
+    @test ub_outages == Set(string(u) for u in outage_ids)
 end
 
 @testset "DeviceModel.outages kwarg is dropped with a warning for non-SC formulations" begin
@@ -778,8 +778,8 @@ end
 
     n_checked = 0
     for (outage_id_str, name, t) in keys(pcbf.data)
-        uuid = Base.UUID(outage_id_str)
-        ctg = ground_truth_registered[uuid]
+        outage_id = parse(Int, outage_id_str)
+        ctg = ground_truth_registered[outage_id]
         arc, reduction_kind = name_to_arc_map[name]
 
         modf_col = ground_truth_modf[arc, ctg]

--- a/test/test_utils/add_market_bid_cost.jl
+++ b/test/test_utils/add_market_bid_cost.jl
@@ -117,9 +117,7 @@ function extend_mbc!(
         op_cost = get_operation_cost(comp)
         @assert op_cost isa MarketBidCost
         if do_override_min_x && :active_power_limits in fieldnames(typeof(comp))
-            min_power = with_units_base(sys, UnitSystem.NATURAL_UNITS) do
-                get_active_power_limits(comp, PSY.SU).min
-            end
+            min_power = get_active_power_limits(comp, PSY.SU).min
         else
             min_power = nothing
         end

--- a/test/test_utils/mbc_system_utils.jl
+++ b/test/test_utils/mbc_system_utils.jl
@@ -106,14 +106,12 @@ function tweak_system!(sys::System, load_pow_mult, therm_pow_mult, therm_price_m
     for therm in get_components(ThermalStandard, sys)
         op_cost = get_operation_cost(therm)
         op_cost isa MarketBidCost && continue
-        with_units_base(sys, UnitSystem.DEVICE_BASE) do
-            old_limits = get_active_power_limits(therm, PSY.SU)
-            new_limits = (
-                min = old_limits.min * PSY.SU,
-                max = old_limits.max * therm_pow_mult * PSY.SU,
-            )
-            set_active_power_limits!(therm, new_limits)
-        end
+        old_limits = get_active_power_limits(therm, PSY.SU)
+        new_limits = (
+            min = old_limits.min * PSY.SU,
+            max = old_limits.max * therm_pow_mult * PSY.SU,
+        )
+        set_active_power_limits!(therm, new_limits)
         if get_variable(op_cost) isa CostCurve{LinearCurve} ||
            get_variable(op_cost) isa CostCurve{QuadraticCurve}
             prop = get_proportional_term(get_value_curve(get_variable(op_cost)))
@@ -198,12 +196,10 @@ function adjust_min_power!(sys)
         cost_curve = get_incremental_offer_curves(op_cost)::CostCurve
         baseline = get_value_curve(cost_curve)::PiecewiseIncrementalCurve
         x_coords = get_x_coords(get_function_data(baseline))
-        with_units_base(sys, UnitSystem.NATURAL_UNITS) do
-            set_active_power_limits!(
-                comp,
-                (min = first(x_coords) * PSY.SU, max = last(x_coords) * PSY.SU),
-            )
-        end
+        set_active_power_limits!(
+            comp,
+            (min = first(x_coords) * PSY.SU, max = last(x_coords) * PSY.SU),
+        )
     end
 end
 


### PR DESCRIPTION
The System kept a UUID when components moved to integer ids, so the factorization cache is keyed by get_system_uuid rather than the component id accessor, which returned an Int the cache could not hold. The outage tests parse the registered contingency keys as ids for the same reason. Reserve time series read positionally, the retired units-base wrappers are gone, and the test environment pins the OpenAPI packages it needs to resolve at all.

Thanks for opening a PR to PowerOperationsModels.jl, please take note of the following when making a PR:

Check the [contributor guidelines](https://sienna-platform.github.io/PowerOperationsModels.jl/stable/api/developer_guidelines/)
